### PR TITLE
fusor server: initial content management actions

### DIFF
--- a/server/app/controllers/fusor/api/v2/deployments_controller.rb
+++ b/server/app/controllers/fusor/api/v2/deployments_controller.rb
@@ -13,7 +13,7 @@
 module Fusor
   class Api::V2::DeploymentsController < Api::V2::BaseController
 
-   before_filter :find_deployment, :only => [:destroy, :show, :update]
+   before_filter :find_deployment, :only => [:destroy, :show, :update, :deploy]
 
     def index
       respond :collection => Deployment.all
@@ -36,6 +36,11 @@ module Fusor
     def destroy
       @deployment.destroy
       respond_for_show :resource => @deployment
+    end
+
+    def deploy
+      task = async_task(::Actions::Fusor::Deploy, @deployment)
+      respond_for_async :resource => task
     end
 
     def find_deployment

--- a/server/app/controllers/fusor/concerns/api/api_controller.rb
+++ b/server/app/controllers/fusor/concerns/api/api_controller.rb
@@ -16,6 +16,8 @@ module Fusor
       extend ActiveSupport::Concern
 
       included do
+        include ForemanTasks::Triggers
+
         respond_to :json
         before_filter :set_gettext_locale
       end

--- a/server/app/lib/actions/fusor/content/enable_repositories.rb
+++ b/server/app/lib/actions/fusor/content/enable_repositories.rb
@@ -1,0 +1,63 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Fusor
+    module Content
+      class EnableRepositories < Actions::Base
+        def humanized_name
+          _("Enable Repositories")
+        end
+
+        def plan(deployment)
+          # TODO: update the enabling of repos based upon products that are associated with the deployment object
+
+          sequence do
+            content = SETTINGS[:fusor][:content]
+            if content
+              [content[:rhev], content[:cloudforms], content[:openstack]].compact.flatten(1).each do |details|
+                enable_repo(details)
+              end
+            end
+          end
+        end
+
+        private
+
+        def enable_repo(repo_details)
+          # TODO: update the find to also include deployment.organization_id, once we have the model in place
+          if product = ::Katello::Product.find_by_name(repo_details[:product_name])
+            product_content = product.productContent.find do |content|
+              content.content.name == repo_details[:repository_set_name]
+            end
+
+            substitutions = { basearch: repo_details[:basearch], releasever: repo_details[:releasever] }
+            if repo_mapper(product, product_content.content, substitutions).find_repository
+              Rails.logger.info("Repository already enabled for: Product: #{product.name},"\
+                                " Repository Set: #{product_content.content.name}")
+            else
+              plan_action(::Actions::Katello::RepositorySet::EnableRepository, product,
+                          product_content.content, substitutions)
+            end
+          else
+            fail _("Product '%{product_name}' does not exist. Confirm that a manifest"\
+                   " containing it has been imported.") % { :product_name => repo_details[:product_name] }
+          end
+        end
+
+        def repo_mapper(product, content, substitutions)
+          ::Katello::Candlepin::Content::RepositoryMapper.new(product, content, substitutions)
+        end
+      end
+    end
+  end
+end

--- a/server/app/lib/actions/fusor/content/publish_content_view.rb
+++ b/server/app/lib/actions/fusor/content/publish_content_view.rb
@@ -1,0 +1,77 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Fusor
+    module Content
+      class PublishContentView < Actions::Base
+        def humanized_name
+          _("Publish Content View")
+        end
+
+        def plan(deployment, repositories)
+          # TODO: Update the organization & environment to use the deployment object
+          organization = ::Organization.all.first
+          lifecycle_environment = ::Katello::KTEnvironment.where(:name => "dev").first
+
+          sequence do
+            composite_view = find_or_create_content_view(organization,
+                                                         SETTINGS[:fusor][:content][:content_view][:composite_view_name],
+                                                         true)
+
+            rpm_view = find_or_create_content_view(organization,
+                                                   SETTINGS[:fusor][:content][:content_view][:rpm_component_view_name])
+            repo_ids = repositories.map(&:id)
+            unless rpm_view.repository_ids == repo_ids
+              plan_action(::Actions::Katello::ContentView::Update, rpm_view, :repository_ids => repo_ids)
+              plan_action(::Actions::Katello::ContentView::Publish, rpm_view)
+            end
+            rpm_view_version = rpm_view.version(organization.library)
+
+            #The puppet view is created during the seeding of the plugin; therefore, we should not need to create it
+            puppet_view = find_content_view(organization,
+                                            SETTINGS[:fusor][:content][:content_view][:puppet_component_view_name])
+            puppet_view_version = puppet_view.version(organization.library)
+
+            component_version_ids = [rpm_view_version.id, puppet_view_version.id]
+            unless composite_view.component_ids == component_version_ids
+              plan_action(::Actions::Katello::ContentView::Update, composite_view, :component_ids => component_version_ids)
+              plan_action(::Actions::Katello::ContentView::Publish, composite_view)
+            end
+
+            # Promote content view to target lifecycle environment (Note: if the target env is library, no need to promote...)
+            unless lifecycle_environment.library?
+              plan_action(::Actions::Katello::ContentView::Promote, composite_view.version(organization.library), lifecycle_environment)
+            end
+          end
+        end
+
+        private
+
+        def find_or_create_content_view(organization, view_name, composite = false)
+          if view_name
+            unless view = find_content_view(organization, view_name)
+              view = ::Katello::ContentView.create!(:organization_id => organization.id,
+                                                    :name => view_name,
+                                                    :composite => composite)
+            end
+          end
+          view
+        end
+
+        def find_content_view(organization, view_name)
+          ::Katello::ContentView.where(:organization_id => organization.id, :name => view_name).first
+        end
+      end
+    end
+  end
+end

--- a/server/app/lib/actions/fusor/content/sync_repositories.rb
+++ b/server/app/lib/actions/fusor/content/sync_repositories.rb
@@ -1,0 +1,31 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Fusor
+    module Content
+      class SyncRepositories < Actions::Base
+        def humanized_name
+          _("Synchronize Repositories")
+        end
+
+        def plan(repositories)
+          concurrence do
+            repositories.each do |repository|
+              plan_action(::Actions::Katello::Repository::Sync, repository)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/app/lib/actions/fusor/deploy.rb
+++ b/server/app/lib/actions/fusor/deploy.rb
@@ -1,0 +1,73 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Fusor
+    class Deploy < Actions::EntryAction
+      def humanized_name
+        _("Deploy")
+      end
+
+      def plan(deployment)
+        fail _("Unable to locate fusor.yaml settings in config/settings.plugins.d") unless SETTINGS[:fusor]
+
+        sequence do
+          # TODO: add an action to support importing a manifest created as part of the deployment
+
+          plan_action(::Actions::Fusor::Content::EnableRepositories, deployment)
+
+          # As part of enabling repositories, zero or more repos will be created.  Let's
+          # retrieve the repos needed for the deployment and use them in actions that follow
+          repositories = retrieve_deployment_repositories
+
+          plan_action(::Actions::Fusor::Content::SyncRepositories, repositories)
+          plan_action(::Actions::Fusor::Content::PublishContentView, deployment, repositories)
+        end
+      end
+
+      private
+
+      def retrieve_deployment_repositories
+        repos = []
+        if content = SETTINGS[:fusor][:content]
+          [content[:rhev], content[:cloudforms], content[:openstack]].compact.flatten(1).each do |details|
+            repos << find_repository(details)
+          end
+        end
+        repos
+      end
+
+      def find_repository(repo_details)
+        if product = ::Katello::Product.find_by_name(repo_details[:product_name])
+          product_content = product.productContent.find do |content|
+            content.content.name == repo_details[:repository_set_name]
+          end
+
+          substitutions = { basearch: repo_details[:basearch], releasever: repo_details[:releasever] }
+          unless repository = repository_mapper(product, product_content.content, substitutions).find_repository
+            fail _("Unable to locate repository for: Product '%{product_name}',"\
+                   " Repository Set '%{repo_set_name}'") %
+                   { :product_name => product.name, :repo_set_name => product_content.content.name }
+          end
+        else
+          fail _("Product '%{product_name}' does not exist. Confirm that a manifest"\
+                 " containing it has been imported.") % { :product_name => repo_details[:product_name] }
+        end
+        repository
+      end
+
+      def repository_mapper(product, content, substitutions)
+        ::Katello::Candlepin::Content::RepositoryMapper.new(product, content, substitutions)
+      end
+    end
+  end
+end

--- a/server/app/views/fusor/api/v2/common/async.json.rabl
+++ b/server/app/views/fusor/api/v2/common/async.json.rabl
@@ -1,0 +1,3 @@
+object @resource
+
+extends 'katello/api/v2/tasks/show'

--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -1,0 +1,27 @@
+:fusor:
+  :content:
+    :rhev:
+      - :product_name: "Red Hat Enterprise Linux Server"
+        :repository_set_name: "Red Hat Enterprise Linux 6 Server (RPMs)"
+        :basearch: "x86_64"
+        :releasever: "6Server"
+
+      - :product_name: "Red Hat Enterprise Linux Server"
+        :repository_set_name: "Red Hat Enterprise Linux 6 Server - Supplementary (RPMs)"
+        :basearch: "x86_64"
+        :releasever: "6Server"
+
+      - :product_name: "Red Hat Enterprise Virtualization"
+        :repository_set_name: "Red Hat Enterprise Virtualization Hypervisor (RPMs)"
+        :basearch: "x86_64"
+        :releasever: "6Server"
+
+      - :product_name: "Red Hat Enterprise Virtualization"
+        :repository_set_name: "Red Hat Enterprise Virtualization Manager 3.5 (RPMs)"
+        :basearch: "x86_64"
+        :releasever: "6Server"
+
+      - :product_name: "JBoss Enterprise Application Platform"
+        :repository_set_name: "JBoss Enterprise Application Platform 6 (RHEL 6 Server) (RPMs)"
+        :basearch: "x86_64"
+        :releasever: "6Server"

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -8,7 +8,11 @@ Rails.application.routes.draw do
             :apiv        => /v1|v2/,
             :constraints => ApiConstraints.new(:version => 2) do
 
-       resources :deployments
+       resources :deployments do
+         member do
+           put :deploy
+         end
+       end
       end
     end
   end


### PR DESCRIPTION
This commit does a few things:

- Adds a config file (fusor.yaml) that will need to be placed in
  foreman/config/settings.config.d to specify properties that
  are needed to support the content managment actions.  These
  are settings that a user should not need to touch; however,
  using settings is much better than hard-coding within the plugin
  logic.

- Adds a 'deploy' action & route on the deployments controller.

- Adds a dynflow action 'deploy' to trigger the other dynflow actions
  that we need to support creating the deployment.  The actions added
  so far support only following needed for content management:
  - enable repositories (based upon fusor.yaml)
  - sync repositories
  - create composite content view (e.g. "fusor")
  - create rpm component content view (e.g. "fusor rpm content")
  - publish rpm component content view
  - add the rpm and puppet (e.g. "fusor puppet content") component
    content views to the composite view
  - publish and promote the composite content view

Note: This commit does not currently support importing manifest.
It also has several "TODO" items to update it to use the information
in the deployment object, once available.