### PR TITLE
fusor server: update content management actions to use deployment model

### DIFF
--- a/server/app/lib/actions/fusor/deploy.rb
+++ b/server/app/lib/actions/fusor/deploy.rb
@@ -27,7 +27,7 @@ module Actions
 
           # As part of enabling repositories, zero or more repos will be created.  Let's
           # retrieve the repos needed for the deployment and use them in actions that follow
-          repositories = retrieve_deployment_repositories
+          repositories = retrieve_deployment_repositories(deployment)
 
           plan_action(::Actions::Fusor::Content::SyncRepositories, repositories)
           plan_action(::Actions::Fusor::Content::PublishContentView, deployment, repositories)
@@ -36,18 +36,26 @@ module Actions
 
       private
 
-      def retrieve_deployment_repositories
+      def retrieve_deployment_repositories(deployment)
         repos = []
         if content = SETTINGS[:fusor][:content]
-          [content[:rhev], content[:cloudforms], content[:openstack]].compact.flatten(1).each do |details|
-            repos << find_repository(details)
+          products_enabled = [deployment.deploy_rhev, deployment.deploy_cfme, deployment.deploy_openstack]
+          products_content = [content[:rhev], content[:cloudforms], content[:openstack]]
+
+          products_enabled.each_with_index do |product_enabled, index|
+            if product_enabled && products_content[index]
+              products_content[index].each { |details| repos << find_repository(deployment.organization, details) }
+            end
           end
         end
         repos
       end
 
-      def find_repository(repo_details)
-        if product = ::Katello::Product.find_by_name(repo_details[:product_name])
+      def find_repository(organization, repo_details)
+        product = ::Katello::Product.where(:organization_id => organization.id,
+                                           :name => repo_details[:product_name]).first
+
+        if product
           product_content = product.productContent.find do |content|
             content.content.name == repo_details[:repository_set_name]
           end


### PR DESCRIPTION
This commit contains modifications so that the content management actions will use the data in the deployment model/object versus hard-coding behavior for organization, lifecycle environment and products.

NOTE: this PR is dependent https://github.com/fusor/fusor/pull/16 .  It will require that the deployment model has the belongs_to associations for organization and lifecycle environment mentioned in one of the PR comments.