### PR TITLE
fusor server: update to use sub action for repo sync

### DIFF
--- a/server/app/lib/actions/fusor/content/sync_repository_as_sub_plan.rb
+++ b/server/app/lib/actions/fusor/content/sync_repository_as_sub_plan.rb
@@ -13,17 +13,17 @@
 module Actions
   module Fusor
     module Content
-      class SyncRepositories < Actions::Base
-        def humanized_name
-          _("Synchronize Repositories")
+      class SyncRepositoryAsSubPlan < Actions::ActionWithSubPlans
+        input_format do
+          param :id, Integer
         end
 
-        def plan(repositories)
-          concurrence do
-            repositories.each do |repository|
-              plan_action(::Actions::Fusor::Content::SyncRepositoryAsSubPlan, repository)
-            end
-          end
+        def plan(repository)
+          plan_self(:id => repository.id)
+        end
+
+        def create_sub_plans
+          trigger(::Actions::Katello::Repository::Sync, ::Katello::Repository.find(input[:id]))
         end
       end
     end


### PR DESCRIPTION
The changes provide by this PR will allow repository syncs that are performed as part of a fusor deployment to correctly show their 'sync status' within Katello.  For example, status shown in Sync Status page, Products page, Repository page...etc.

This PR is dependent on https://github.com/theforeman/foreman-tasks/pull/99  which provides support for sub-actions.