### PR TITLE
add description column to the deployment

### DIFF
--- a/server/db/migrate/20150303132827_add_description_to_deployments.rb
+++ b/server/db/migrate/20150303132827_add_description_to_deployments.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToDeployments < ActiveRecord::Migration
+  def change
+    add_column :fusor_deployments, :description, :string
+  end
+end


### PR DESCRIPTION
I added a description field for @isratrade. 

Run ```rake db:migrate``` to get the updated table, ```fusor_deployments``` table now has new column:

```
katello=# \d fusor_deployments
                                            Table "public.fusor_deployments"
          Column          |            Type             |                           Modifiers                            
--------------------------+-----------------------------+----------------------------------------------------------------
 id                       | integer                     | not null default nextval('fusor_deployments_id_seq'::regclass)
 name                     | character varying(255)      | not null
 lifecycle_environment_id | integer                     | not null
 organization_id          | integer                     | not null
 deploy_rhev              | boolean                     | default false
 deploy_cfme              | boolean                     | default false
 deploy_openstack         | boolean                     | default false
 rhev_hypervisor_host_id  | integer                     | 
 rhev_engine_host_id      | integer                     | 
 rhev_hypervisor_hostname | character varying(255)      | 
 rhev_engine_hostname     | character varying(255)      | 
 rhev_database_name       | character varying(255)      | 
 rhev_cluster_name        | character varying(255)      | 
 rhev_storage_name        | character varying(255)      | 
 rhev_storage_type        | character varying(255)      | 
 rhev_storage_address     | character varying(255)      | 
 rhev_cpu_type            | character varying(255)      | 
 rhev_share_path          | character varying(255)      | 
 cfme_install_loc         | character varying(255)      | 
 created_at               | timestamp without time zone | not null
 updated_at               | timestamp without time zone | not null
 description              | character varying(255)      | 
Indexes:
    "fusor_deployments_pkey" PRIMARY KEY, btree (id)
```