### PR TITLE
fusor server: update content mgmt to execute one product at a time

### DIFF
--- a/server/app/lib/actions/fusor/content/enable_repositories.rb
+++ b/server/app/lib/actions/fusor/content/enable_repositories.rb
@@ -18,20 +18,10 @@ module Actions
           _("Enable Repositories")
         end
 
-        def plan(deployment)
+        def plan(organization, product_content_settings)
           sequence do
-            unless content = SETTINGS[:fusor][:content]
-              fail _("fusor.yaml is missing definition for fusor content.")
-            end
-
-            products_enabled = [deployment.deploy_rhev, deployment.deploy_cfme, deployment.deploy_openstack]
-            products_content = [content[:rhev], content[:cloudforms], content[:openstack]]
-
-            products_enabled.each_with_index do |product_enabled, index|
-              if product_enabled && products_content[index]
-                products_content[index].each { |details| enable_repo(deployment.organization, details) }
-              end
-            end
+            fail _("fusor.yaml is missing definition for fusor content.") unless product_content_settings
+            product_content_settings.each { |details| enable_repo(organization, details) }
           end
         end
 

--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -1,5 +1,10 @@
 :fusor:
   :content:
+    :content_view:
+      :composite_view_name: "Fusor Deployment Content"
+      :rpm_component_view_name: "Fusor RPM Content"
+      :puppet_component_view_name: "Fusor Puppet Content"
+
     :rhev:
       - :product_name: "Red Hat Enterprise Linux Server"
         :repository_set_name: "Red Hat Enterprise Linux 6 Server (RPMs)"


### PR DESCRIPTION
This commit alters the behavior of the content management to
operate on one product at a time.  This is a step towards
being able to show deployment status on an individual product
versus showing them all at once.