### PR TITLE
remove hypervisor columns, add self_hosted column.

### DIFF
--- a/server/db/migrate/20150310161747_remove_hypervisor_from_deployments.rb
+++ b/server/db/migrate/20150310161747_remove_hypervisor_from_deployments.rb
@@ -1,0 +1,13 @@
+class RemoveHypervisorFromDeployments < ActiveRecord::Migration
+  def up
+    remove_column :fusor_deployments, :rhev_hypervisor_hostname
+    remove_column :fusor_deployments, :rhev_hypervisor_host_id
+    add_column :fusor_deployments, :rhev_is_self_hosted, :boolean, :default => false
+  end
+
+  def down
+    add_column :fusor_deployments, :rhev_hypervisor_hostname, :string
+    add_column :fusor_deployments, :rhev_hypervisor_host_id, :string
+    remove_column :fusor_deployments, :rhev_is_self_hosted
+  end
+end


### PR DESCRIPTION
The plan is to create a mapping table to allow deployments to have multiple hosts.
Something along the lines of deployment_id, host_id and many to many.

The rhev_is_self_hosted column defaults to false.