### PR TITLE
fusor server: create hostgroups and activation key for rhev deployment

### DIFF
--- a/server/app/lib/actions/fusor/activation_key/add_subscriptions.rb
+++ b/server/app/lib/actions/fusor/activation_key/add_subscriptions.rb
@@ -1,0 +1,58 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Fusor
+    module ActivationKey
+      class AddSubscriptions < Actions::Base
+        def humanized_name
+          _("Activation Key - Add Subscriptions")
+        end
+
+        def plan(organization)
+          unless activation_key_name && subscription_descriptions
+            fail _("Unable to locate activation key settings in config/settings.plugins.d/fusor.yaml")
+          end
+
+          plan_self(:organization_id => organization.id, :user_id => ::User.current.id)
+        end
+
+        def finalize
+          ::User.current = ::User.find(input[:user_id])
+
+          key = ::Katello::ActivationKey.where(:organization_id => input[:organization_id],
+                                               :name => activation_key_name).first
+          associate_subscriptions(key)
+        ensure
+          ::User.current = nil
+        end
+
+        private
+
+        def associate_subscriptions(key)
+          subscription_descriptions.each do |description|
+            subscription = key.available_subscriptions.find{ |key| key.description == description }
+            key.subscribe(subscription.cp_id) if subscription
+          end
+        end
+
+        def activation_key_name
+          SETTINGS[:fusor][:activation_key][:name]
+        end
+
+        def subscription_descriptions
+          SETTINGS[:fusor][:activation_key][:subscription_descriptions]
+        end
+      end
+    end
+  end
+end

--- a/server/app/lib/actions/fusor/activation_key/configure_activation_key.rb
+++ b/server/app/lib/actions/fusor/activation_key/configure_activation_key.rb
@@ -1,0 +1,83 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Fusor
+    module ActivationKey
+      class ConfigureActivationKey < Actions::Base
+        def humanized_name
+          _("Configure Activation Key")
+        end
+
+        def plan(organization, lifecycle_environment)
+          unless activation_key_name
+            fail _("Unable to locate activation key settings in config/settings.plugins.d/fusor.yaml")
+          end
+
+          unless content_view_name
+            fail _("Unable to locate content settings in config/settings.plugins.d/fusor.yaml")
+          end
+
+          unless content_view = find_content_view(organization)
+            fail _("Unable to locate content view '%s'.") % content_view_name
+          end
+
+          sequence do
+            find_or_ensure_key(organization, lifecycle_environment, content_view)
+            # TODO: update to support UpdateSubscriptions, which could add or remove based
+            # on changes in configuration... not urgent, since currently there is only a single
+            # subscription in the configuration
+            plan_action(::Actions::Fusor::ActivationKey::AddSubscriptions, organization)
+          end
+        end
+
+        private
+
+        def find_or_ensure_key(organization, lifecycle_environment, content_view)
+          key = ::Katello::ActivationKey.where(:organization_id => organization.id,
+                                               :name => activation_key_name).first
+          if key
+            attributes = { :name => activation_key_name,
+                           :organization_id => organization.id,
+                           :environment_id => lifecycle_environment.id,
+                           :content_view_id => content_view.id,
+                           :auto_attach => true,
+                           :user_id => ::User.current.id }
+
+            plan_action(::Actions::Katello::ActivationKey::Update, key, attributes)
+          else
+            key = ::Katello::ActivationKey.new(:name => activation_key_name,
+                                               :organization_id => organization.id,
+                                               :environment_id => lifecycle_environment.id,
+                                               :content_view_id => content_view.id,
+                                               :auto_attach => true,
+                                               :user_id => ::User.current.id)
+
+            plan_action(::Actions::Katello::ActivationKey::Create, key)
+          end
+        end
+
+        def find_content_view(organization)
+          ::Katello::ContentView.where(:organization_id => organization.id, :name => content_view_name).first
+        end
+
+        def content_view_name
+          SETTINGS[:fusor][:content][:content_view][:composite_view_name]
+        end
+
+        def activation_key_name
+          SETTINGS[:fusor][:activation_key][:name]
+        end
+      end
+    end
+  end
+end

--- a/server/app/lib/actions/fusor/configure_host_groups.rb
+++ b/server/app/lib/actions/fusor/configure_host_groups.rb
@@ -17,13 +17,14 @@ module Actions
         _("Configure Host Groups")
       end
 
-      def plan(organization, lifecycle_environment, hostgroup_settings)
+      def plan(deployment, hostgroup_settings)
         unless hostgroup_settings && hostgroup_settings[:host_groups]
           fail _("Unable to locate host group settings in config/settings.plugins.d/fusor.yaml")
         end
 
-        plan_self(:organization_id => organization.id,
-                  :lifecycle_environment_id => lifecycle_environment.id,
+        plan_self(:deployment_name => deployment.name,
+                  :organization_id => deployment.organization.id,
+                  :lifecycle_environment_id => deployment.lifecycle_environment.id,
                   :hostgroup_settings => hostgroup_settings,
                   :user_id => ::User.current.id)
       end
@@ -35,7 +36,8 @@ module Actions
         ::User.current = ::User.find(input[:user_id])
 
         input[:hostgroup_settings][:host_groups].each do |hostgroup|
-          find_or_ensure_hostgroup(input[:organization_id], input[:lifecycle_environment_id], hostgroup)
+          find_or_ensure_hostgroup(input[:deployment_name], input[:organization_id],
+                                   input[:lifecycle_environment_id], hostgroup)
         end
       ensure
         ::User.current = nil
@@ -43,13 +45,20 @@ module Actions
 
       private
 
-      def find_or_ensure_hostgroup(organization_id, lifecycle_environment_id, hostgroup_settings)
-        if content_view = find_content_view(organization_id)
-          if parent_name = hostgroup_settings[:parent_name]
+      def find_or_ensure_hostgroup(deployment_name, organization_id, lifecycle_environment_id, hostgroup_settings)
+        if content_view = find_content_view(organization_id, content_view_name(deployment_name))
+
+          if parent_setting = hostgroup_settings[:parent]
+            if parent_setting == "root_deployment"
+              parent_name = deployment_name
+            else
+              parent_name = parent_setting
+            end
             parent = ::Hostgroup.where(:name => parent_name).
                 joins(:organizations).
                 where("taxonomies.id in (?)", [organization_id]).first
           end
+
           lifecycle_environment = ::Katello::KTEnvironment.find(lifecycle_environment_id)
           content_view_puppet_environment = content_view.puppet_env(lifecycle_environment)
 
@@ -61,65 +70,69 @@ module Actions
             puppet_class_ids = puppet_classes.map(&:id)
           end
 
-          operating_system = find_operating_system(lifecycle_environment, content_view)
-          default_capsule_id = ::Katello::CapsuleContent.default_capsule.try(:capsule).try(:id)
+          if name_setting = hostgroup_settings[:name]
+            # this host group is a child of the deployment group; therefore, some attributes
+            # do not need to be set
+            hostgroup_name = name_setting
+            lifecycle_environment_id = nil
+            content_view_puppet_environment = nil
+            content_view = nil
+            default_capsule_id = nil
+            operating_system = nil
+          else
+            # this host group is the deployment group
+            hostgroup_name = deployment_name
+            operating_system = find_operating_system(lifecycle_environment, content_view)
+            default_capsule_id = ::Katello::CapsuleContent.default_capsule.try(:capsule).try(:id)
+          end
         else
-          fail _("Unable to locate content view '%s'.") % content_view_name
+          fail _("Unable to locate content view '%s'.") % content_view_name(deployment_name)
         end
 
-        if hostgroup = find_hostgroup(organization_id, hostgroup_settings[:name])
-          hostgroup.update_attributes!(:parent_id => parent.id,
-                                       :name => hostgroup_settings[:name],
-                                       :organization_ids => [organization_id],
-                                       :lifecycle_environment_id => lifecycle_environment_id,
-                                       :environment_id => content_view_puppet_environment.puppet_environment.id,
-                                       :content_view_id => content_view.id,
-                                       :content_source_id => default_capsule_id,
-                                       :puppet_ca_proxy_id => default_capsule_id,
-                                       :puppet_proxy_id => default_capsule_id,
-                                       :puppetclass_ids => puppet_class_ids,
-                                       :operatingsystem_id => operating_system.id,
-                                       :medium_id => operating_system.try(:media).try(:first).try(:id),
-                                       :ptable_id => operating_system.try(:ptables).try(:first).try(:id))
+        hostgroup_params = { :parent_id => parent.id,
+                             :name => hostgroup_name,
+                             :organization_ids => [organization_id],
+                             :lifecycle_environment_id => lifecycle_environment_id,
+                             :environment_id => content_view_puppet_environment.try(:puppet_environment).try(:id),
+                             :content_view_id => content_view.try(:id),
+                             :content_source_id => default_capsule_id,
+                             :puppet_ca_proxy_id => default_capsule_id,
+                             :puppet_proxy_id => default_capsule_id,
+                             :puppetclass_ids => puppet_class_ids,
+                             :operatingsystem_id => operating_system.try(:id),
+                             :medium_id => operating_system.try(:media).try(:first).try(:id),
+                             :ptable_id => operating_system.try(:ptables).try(:first).try(:id) }
+
+        if hostgroup = find_hostgroup(organization_id, hostgroup_name, parent)
+          hostgroup.update_attributes!(hostgroup_params)
 
           parameter = ::GroupParameter.where(:type => "GroupParameter",
                                              :reference_id => hostgroup.id,
                                              :name => "kt_activation_keys").first
           parameter.update_attributes!(:reference_id => hostgroup.id,
                                        :name => "kt_activation_keys",
-                                       :value => activation_key_name)
+                                       :value => activation_key_name(deployment_name))
         else
           # Note: when setting the arch, medium and ptable, we assume that there will only be 1
           # associated with the operating system.  If we need to support multiple in the future,
           # we'll need to update this behavior.
-          hostgroup = ::Hostgroup.create!(:parent_id => parent.id,
-                                          :name => hostgroup_settings[:name],
-                                          :organization_ids => [organization_id],
-                                          :lifecycle_environment_id => lifecycle_environment_id,
-                                          :environment_id => content_view_puppet_environment.puppet_environment.id,
-                                          :content_view_id => content_view.id,
-                                          :content_source_id => default_capsule_id,
-                                          :puppet_ca_proxy_id => default_capsule_id,
-                                          :puppet_proxy_id => default_capsule_id,
-                                          :puppetclass_ids => puppet_class_ids,
-                                          :operatingsystem_id => operating_system.id,
-                                          :medium_id => operating_system.try(:media).try(:first).try(:id),
-                                          :ptable_id => operating_system.try(:ptables).try(:first).try(:id))
+          hostgroup = ::Hostgroup.create!(hostgroup_params)
 
           ::GroupParameter.create!(:hostgroup => hostgroup,
                                    :name => "kt_activation_keys",
-                                   :value => activation_key_name)
+                                   :value => activation_key_name(deployment_name))
         end
       end
 
-      def find_hostgroup(organization_id, hostgroup_name)
+      def find_hostgroup(organization_id, hostgroup_name, parent)
         ::Hostgroup.where(:name => hostgroup_name).
+                    where(:ancestry => parent.try(:id).try(:to_s)).
                     joins(:organizations).
                     where("taxonomies.id in (?)", [organization_id]).first
       end
 
-      def find_content_view(organization_id)
-        ::Katello::ContentView.where(:organization_id => organization_id, :name => content_view_name).first
+      def find_content_view(organization_id, view_name)
+        ::Katello::ContentView.where(:organization_id => organization_id, :name => view_name).first
       end
 
       def find_operating_system(lifecycle_environment, content_view)
@@ -138,12 +151,14 @@ module Actions
         ::Redhat.where(:name => os_name, :major => major, :minor => minor).first
       end
 
-      def content_view_name
-        SETTINGS[:fusor][:content][:content_view][:composite_view_name]
+      def content_view_name(deployment_name)
+        name = SETTINGS[:fusor][:content][:content_view][:composite_view_name]
+        return [name, deployment_name].join(' - ') if name
       end
 
-      def activation_key_name
-        SETTINGS[:fusor][:activation_key][:name]
+      def activation_key_name(deployment_name)
+        name = SETTINGS[:fusor][:activation_key][:name]
+        return [name, deployment_name].join(' - ') if name
       end
     end
   end

--- a/server/app/lib/actions/fusor/configure_host_groups.rb
+++ b/server/app/lib/actions/fusor/configure_host_groups.rb
@@ -1,0 +1,150 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Fusor
+    class ConfigureHostGroups < Actions::Base
+      def humanized_name
+        _("Configure Host Groups")
+      end
+
+      def plan(organization, lifecycle_environment, hostgroup_settings)
+        unless hostgroup_settings && hostgroup_settings[:host_groups]
+          fail _("Unable to locate host group settings in config/settings.plugins.d/fusor.yaml")
+        end
+
+        plan_self(:organization_id => organization.id,
+                  :lifecycle_environment_id => lifecycle_environment.id,
+                  :hostgroup_settings => hostgroup_settings,
+                  :user_id => ::User.current.id)
+      end
+
+      def finalize
+        # Note: user_id is being passed in and then used to set User.current to address an error
+        # that could occur when we later attempt to access ::Katello.pulp_server indirectly through
+        # this action.  In the future, we may want to see if there are alternatives to this approach.
+        ::User.current = ::User.find(input[:user_id])
+
+        input[:hostgroup_settings][:host_groups].each do |hostgroup|
+          find_or_ensure_hostgroup(input[:organization_id], input[:lifecycle_environment_id], hostgroup)
+        end
+      ensure
+        ::User.current = nil
+      end
+
+      private
+
+      def find_or_ensure_hostgroup(organization_id, lifecycle_environment_id, hostgroup_settings)
+        if content_view = find_content_view(organization_id)
+          if parent_name = hostgroup_settings[:parent_name]
+            parent = ::Hostgroup.where(:name => parent_name).
+                joins(:organizations).
+                where("taxonomies.id in (?)", [organization_id]).first
+          end
+          lifecycle_environment = ::Katello::KTEnvironment.find(lifecycle_environment_id)
+          content_view_puppet_environment = content_view.puppet_env(lifecycle_environment)
+
+          if puppet_class_settings = hostgroup_settings[:puppet_classes]
+            puppet_classes = Puppetclass.where(:name => puppet_class_settings).
+                joins(:environment_classes).
+                where("environment_classes.environment_id in (?)",
+                      content_view_puppet_environment.puppet_environment.id).uniq
+            puppet_class_ids = puppet_classes.map(&:id)
+          end
+
+          operating_system = find_operating_system(lifecycle_environment, content_view)
+          default_capsule_id = ::Katello::CapsuleContent.default_capsule.try(:capsule).try(:id)
+        else
+          fail _("Unable to locate content view '%s'.") % content_view_name
+        end
+
+        if hostgroup = find_hostgroup(organization_id, hostgroup_settings[:name])
+          hostgroup.update_attributes!(:parent_id => parent.id,
+                                       :name => hostgroup_settings[:name],
+                                       :organization_ids => [organization_id],
+                                       :lifecycle_environment_id => lifecycle_environment_id,
+                                       :environment_id => content_view_puppet_environment.puppet_environment.id,
+                                       :content_view_id => content_view.id,
+                                       :content_source_id => default_capsule_id,
+                                       :puppet_ca_proxy_id => default_capsule_id,
+                                       :puppet_proxy_id => default_capsule_id,
+                                       :puppetclass_ids => puppet_class_ids,
+                                       :operatingsystem_id => operating_system.id,
+                                       :medium_id => operating_system.try(:media).try(:first).try(:id),
+                                       :ptable_id => operating_system.try(:ptables).try(:first).try(:id))
+
+          parameter = ::GroupParameter.where(:type => "GroupParameter",
+                                             :reference_id => hostgroup.id,
+                                             :name => "kt_activation_keys").first
+          parameter.update_attributes!(:reference_id => hostgroup.id,
+                                       :name => "kt_activation_keys",
+                                       :value => activation_key_name)
+        else
+          # Note: when setting the arch, medium and ptable, we assume that there will only be 1
+          # associated with the operating system.  If we need to support multiple in the future,
+          # we'll need to update this behavior.
+          hostgroup = ::Hostgroup.create!(:parent_id => parent.id,
+                                          :name => hostgroup_settings[:name],
+                                          :organization_ids => [organization_id],
+                                          :lifecycle_environment_id => lifecycle_environment_id,
+                                          :environment_id => content_view_puppet_environment.puppet_environment.id,
+                                          :content_view_id => content_view.id,
+                                          :content_source_id => default_capsule_id,
+                                          :puppet_ca_proxy_id => default_capsule_id,
+                                          :puppet_proxy_id => default_capsule_id,
+                                          :puppetclass_ids => puppet_class_ids,
+                                          :operatingsystem_id => operating_system.id,
+                                          :medium_id => operating_system.try(:media).try(:first).try(:id),
+                                          :ptable_id => operating_system.try(:ptables).try(:first).try(:id))
+
+          ::GroupParameter.create!(:hostgroup => hostgroup,
+                                   :name => "kt_activation_keys",
+                                   :value => activation_key_name)
+        end
+      end
+
+      def find_hostgroup(organization_id, hostgroup_name)
+        ::Hostgroup.where(:name => hostgroup_name).
+                    joins(:organizations).
+                    where("taxonomies.id in (?)", [organization_id]).first
+      end
+
+      def find_content_view(organization_id)
+        ::Katello::ContentView.where(:organization_id => organization_id, :name => content_view_name).first
+      end
+
+      def find_operating_system(lifecycle_environment, content_view)
+        content_view_version = content_view.version(lifecycle_environment)
+
+        # Find the first repo that has a distribution.
+        # Note: at this time, the assumption is that there will only be 1 repo containing distro.
+        repo = content_view_version.repositories.find{ |repo| repo.bootable_distribution }
+        distribution = repo.bootable_distribution
+
+        # Locate the operating system using the information from the distribution
+        os_name = ::Redhat.construct_name(distribution.family)
+        major, minor = distribution.version.split('.')
+        minor ||= '' # treat minor versions as empty string to not confuse with nil
+
+        ::Redhat.where(:name => os_name, :major => major, :minor => minor).first
+      end
+
+      def content_view_name
+        SETTINGS[:fusor][:content][:content_view][:composite_view_name]
+      end
+
+      def activation_key_name
+        SETTINGS[:fusor][:activation_key][:name]
+      end
+    end
+  end
+end

--- a/server/app/lib/actions/fusor/configure_host_groups.rb
+++ b/server/app/lib/actions/fusor/configure_host_groups.rb
@@ -54,7 +54,7 @@ module Actions
           content_view_puppet_environment = content_view.puppet_env(lifecycle_environment)
 
           if puppet_class_settings = hostgroup_settings[:puppet_classes]
-            puppet_classes = Puppetclass.where(:name => puppet_class_settings).
+            puppet_classes = Puppetclass.where(:name => puppet_class_settings.map{ |c| c[:name] }).
                 joins(:environment_classes).
                 where("environment_classes.environment_id in (?)",
                       content_view_puppet_environment.puppet_environment.id).uniq

--- a/server/app/lib/actions/fusor/content/publish_content_view.rb
+++ b/server/app/lib/actions/fusor/content/publish_content_view.rb
@@ -18,25 +18,30 @@ module Actions
           _("Publish Content View")
         end
 
-        def plan(organization, lifecycle_environment, repositories)
+        def plan(deployment, repositories)
+
+          unless composite_content_view_name(deployment) &&
+                 rpm_content_view_name &&
+                 puppet_content_view_name
+            fail _("Unable to locate content view settings in config/settings.plugins.d/fusor.yaml")
+          end
+
           sequence do
-            composite_view = find_or_create_content_view(organization,
-                                                         SETTINGS[:fusor][:content][:content_view][:composite_view_name],
+            composite_view = find_or_create_content_view(deployment.organization,
+                                                         composite_content_view_name(deployment),
                                                          true)
 
-            rpm_view = find_or_create_content_view(organization,
-                                                   SETTINGS[:fusor][:content][:content_view][:rpm_component_view_name])
+            rpm_view = find_or_create_content_view(deployment.organization, rpm_content_view_name)
             repo_ids = repositories.map(&:id)
             unless rpm_view.repository_ids == repo_ids
               plan_action(::Actions::Katello::ContentView::Update, rpm_view, :repository_ids => repo_ids)
               plan_action(::Actions::Katello::ContentView::Publish, rpm_view)
             end
-            rpm_view_version = rpm_view.version(organization.library)
+            rpm_view_version = rpm_view.version(deployment.organization.library)
 
             #The puppet view is created during the seeding of the plugin; therefore, we should not need to create it
-            puppet_view = find_content_view(organization,
-                                            SETTINGS[:fusor][:content][:content_view][:puppet_component_view_name])
-            puppet_view_version = puppet_view.try(:version, organization.library)
+            puppet_view = find_content_view(deployment.organization, puppet_content_view_name)
+            puppet_view_version = puppet_view.try(:version, deployment.organization.library)
 
             component_version_ids = [rpm_view_version.id, puppet_view_version.try(:id)].compact
             unless composite_view.component_ids == component_version_ids
@@ -47,10 +52,10 @@ module Actions
 
             # Promote content view to target lifecycle environment (Note: if the target env is library
             # no need to promote...)
-            unless lifecycle_environment.library?
+            unless deployment.lifecycle_environment.library?
               plan_action(::Actions::Katello::ContentView::Promote,
-                          composite_view.version(organization.library),
-                          lifecycle_environment)
+                          composite_view.version(deployment.organization.library),
+                          deployment.lifecycle_environment)
             end
           end
         end
@@ -70,6 +75,19 @@ module Actions
 
         def find_content_view(organization, view_name)
           ::Katello::ContentView.where(:organization_id => organization.id, :name => view_name).first
+        end
+
+        def composite_content_view_name(deployment)
+          name = SETTINGS[:fusor][:content][:content_view][:composite_view_name]
+          return [name, deployment.name].join(' - ') if name
+        end
+
+        def rpm_content_view_name
+          SETTINGS[:fusor][:content][:content_view][:rpm_component_view_name]
+        end
+
+        def puppet_content_view_name
+          SETTINGS[:fusor][:content][:content_view][:puppet_component_view_name]
         end
       end
     end

--- a/server/app/lib/actions/fusor/deploy.rb
+++ b/server/app/lib/actions/fusor/deploy.rb
@@ -47,8 +47,7 @@ module Actions
               # TODO: need to update to support multiple deployments per organization... to support this, we could
               # incorporate the deployment name in to the content view, activation key and host groups
               plan_action(::Actions::Fusor::Content::PublishContentView,
-                          deployment.organization,
-                          deployment.lifecycle_environment,
+                          deployment,
                           repositories)
 
               plan_configure_activation_key(deployment)
@@ -56,8 +55,7 @@ module Actions
               enable_smart_class_parameter_overrides(products_host_groups[index])
 
               plan_action(::Actions::Fusor::ConfigureHostGroups,
-                          deployment.organization,
-                          deployment.lifecycle_environment,
+                          deployment,
                           products_host_groups[index])
             end
           end
@@ -70,9 +68,7 @@ module Actions
         # At this time, 1 activation key can be used to support all products; therefore,
         # we only need to plan the action once.
         return if @configure_activation_key_planned
-        plan_action(::Actions::Fusor::ActivationKey::ConfigureActivationKey,
-                    deployment.organization,
-                    deployment.lifecycle_environment)
+        plan_action(::Actions::Fusor::ActivationKey::ConfigureActivationKey, deployment)
         @configure_activation_key_planned = true
       end
 

--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -12,6 +12,11 @@
         :releasever: "6Server"
 
       - :product_name: "Red Hat Enterprise Linux Server"
+        :repository_set_name: "Red Hat Enterprise Linux 6 Server (Kickstart)"
+        :basearch: "x86_64"
+        :releasever: "6.6"
+
+      - :product_name: "Red Hat Enterprise Linux Server"
         :repository_set_name: "Red Hat Enterprise Linux 6 Server - Supplementary (RPMs)"
         :basearch: "x86_64"
         :releasever: "6Server"
@@ -30,3 +35,27 @@
         :repository_set_name: "JBoss Enterprise Application Platform 6 (RHEL 6 Server) (RPMs)"
         :basearch: "x86_64"
         :releasever: "6Server"
+
+  :host_groups:
+    :rhev:
+     :root_name: "Fusor Base" # seeded by the fusor-installer
+     :host_groups:
+       - :name: "RHEV-Engine"
+         :parent_name: "Fusor Base"
+         :puppet_classes:
+           - "ovirt"
+           - "ovirt::repo"
+           - "ovirt::engine::config"
+           - "ovirt::engine::packages"
+           - "ovirt::engine::setup"
+
+       - :name: "RHEV-Hypervisor"
+         :parent_name: "Fusor Base"
+         :puppet_classes:
+           - "ovirt"
+           - "ovirt::hypervisor::packages"
+
+  :activation_key:
+    :name: "Fusor_Key"
+    :subscription_descriptions:
+      - "Red Hat Cloud Infrastructure"

--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -43,17 +43,25 @@
        - :name: "RHEV-Engine"
          :parent_name: "Fusor Base"
          :puppet_classes:
-           - "ovirt"
-           - "ovirt::repo"
-           - "ovirt::engine::config"
-           - "ovirt::engine::packages"
-           - "ovirt::engine::setup"
+           - :name: "ovirt"
+           - :name: "ovirt::repo"
+           - :name: "ovirt::engine::config"
+             :parameters:
+             - "cluster_name"
+             - "cpu_type"
+             - "host_name"
+             - "share_path"
+             - "storage_name"
+             - "storage_type"
+             - "storage_address"
+           - :name: "ovirt::engine::packages"
+           - :name: "ovirt::engine::setup"
 
        - :name: "RHEV-Hypervisor"
          :parent_name: "Fusor Base"
          :puppet_classes:
-           - "ovirt"
-           - "ovirt::hypervisor::packages"
+           - :name: "ovirt"
+           - :name: "ovirt::hypervisor::packages"
 
   :activation_key:
     :name: "Fusor_Key"

--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -1,7 +1,7 @@
 :fusor:
   :content:
     :content_view:
-      :composite_view_name: "Fusor Deployment Content"
+      :composite_view_name: "Fusor Deployment"
       :rpm_component_view_name: "Fusor RPM Content"
       :puppet_component_view_name: "Fusor Puppet Content"
 


### PR DESCRIPTION
This commit will create hostgroups and activation key for a rhev deployment based upon the: deployment and content management actions that are performed for the deployment.

E.g. 
create activation key (e.g. Fusor_Key)
create hostgroup X with lifecyle environment A, content view B, puppet environment C, puppet classes M, N, O, activation key 'Fusor_Key'...etc
