### PR TITLE
fusor server: initial code for proxying api requests to the customer portal

### DIFF
--- a/server/app/controllers/fusor/api/customer_portal/customer_portal_proxies_controller.rb
+++ b/server/app/controllers/fusor/api/customer_portal/customer_portal_proxies_controller.rb
@@ -1,0 +1,51 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Fusor
+  class Api::CustomerPortal::CustomerPortalProxiesController < Api::V2::BaseController
+
+    before_filter :proxy_request_path, :proxy_request_body
+
+    def get
+      response = Resources::CustomerPortal::Proxy.get(@request_path)
+      logger.debug response
+      render :json => response
+    end
+
+    def post
+      response = Resources::CustomerPortal::Proxy.post(@request_path, @request_body.read)
+      logger.debug response
+      render :json => response
+    end
+
+    def delete
+      response = Resources::CustomerPortal::Proxy.delete(@request_path, @request_body.read)
+      logger.debug response
+      render :json => response
+    end
+
+    private
+
+    def proxy_request_path
+      @request_path = drop_api_namespace(@_request.fullpath)
+    end
+
+    def proxy_request_body
+      @request_body = @_request.body
+    end
+
+    def drop_api_namespace(original_request_path)
+      prefix = "/customer_portal"
+      original_request_path.gsub(prefix, '')
+    end
+  end
+end

--- a/server/app/lib/fusor/resources/customer_portal.rb
+++ b/server/app/lib/fusor/resources/customer_portal.rb
@@ -1,0 +1,79 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+# rubocop:disable SymbolName
+module Fusor
+  module Resources
+    require 'rest_client'
+
+    module CustomerPortal
+      class Proxy
+        def self.post(path, body)
+          Rails.logger.debug "Sending POST request to Customer Portal: #{ path }"
+          client = CustomerPortalResource.rest_client(path)
+          client.post(body, { :accept => :json, :content_type => :json })
+        end
+
+        def self.delete(path, body = nil)
+          Rails.logger.debug "Sending DELETE request to Customer Portal: #{ path }"
+          client = CustomerPortalResource.rest_client(path)
+          # Some candlepin calls will set the body in DELETE requests.
+          client.options[:payload] = body unless body.nil?
+          client.delete({ :accept => :json, :content_type => :json })
+        end
+
+        def self.get(path)
+          Rails.logger.debug "Sending GET request to Customer Portal: #{ path }"
+          client = CustomerPortalResource.rest_client(path)
+          client.get({ :accept => :json })
+        end
+      end
+
+      class CustomerPortalResource
+        def self.default_headers
+          { 'accept' => 'application/json',
+            'accept-language' => I18n.locale,
+            'content-type' => 'application/json' }
+        end
+
+        def self.name_to_key(a_name)
+          a_name.tr(' ', '_')
+        end
+
+        def self.rest_client(path)
+          settings = SETTINGS[:fusor][:customer_portal]
+          prefix = settings[:url] || "https://subscription.rhn.redhat.com:443/subscription/"
+          username = settings[:username]
+          password = settings[:password]
+
+          if ::Katello.config.cdn_proxy && ::Katello.config.cdn_proxy.host
+            proxy_config = ::Katello.config.cdn_proxy
+            uri = URI('')
+
+            uri.scheme = URI.parse(proxy_config.host).scheme
+            uri.host = URI.parse(proxy_config.host).host
+            uri.port = proxy_config.port
+            uri.user = proxy_config.user
+            uri.password = proxy_config.password
+
+            RestClient.proxy = uri.to_s
+          end
+
+          RestClient::Resource.new(prefix + path,
+                                   :user => username,
+                                   :password => password,
+                                   :headers => self.default_headers)
+        end
+      end
+    end
+  end
+end

--- a/server/config/routes/api/customer_portal.rb
+++ b/server/config/routes/api/customer_portal.rb
@@ -1,0 +1,17 @@
+Fusor::Engine.routes.draw do
+  scope :api, :module => :api do
+    match '/customer_portal' => 'v2/root#resource_list', :via => :get
+
+    scope :path => :customer_portal, :module => :customer_portal, :as => :customer_portal do
+      match '/users/:login/owners' => 'customer_portal_proxies#get', :via => :get, :as => :proxy_users_owners_path, :constraints => { :login => /\S+/ }
+      match '/owners/:id/consumers' => 'customer_portal_proxies#get', :via => :get, :as => :proxy_owners_consumers_path
+      match '/consumers' => 'customer_portal_proxies#post', :via => :post, :as => :proxy_consumer_create_path
+      match '/consumers/:id' => 'customer_portal_proxies#get', :via => :get, :as => :proxy_consumer_show_path
+      match '/pools' => 'customer_portal_proxies#get', :via => :get, :as => :proxy_pools_path
+      match '/consumers/:id/entitlements' => 'customer_portal_proxies#get', :via => :get, :as => :proxy_consumer_entitlements_path
+      match '/consumers/:id/entitlements' => 'customer_portal_proxies#post', :via => :post, :as => :proxy_consumer_entitlements_post_path
+      match '/consumers/:id/entitlements' => 'customer_portal_proxies#delete', :via => :delete, :as => :proxy_consumer_entitlements_delete_path
+      match '/consumers/:id/export' => 'customer_portal_proxies#export', :via => :get, :as => :proxy_consumer_export_path
+    end
+  end
+end

--- a/server/lib/fusor/engine.rb
+++ b/server/lib/fusor/engine.rb
@@ -20,6 +20,7 @@ module Fusor
     initializer "fusor.paths" do |app|
       app.routes_reloader.paths << "#{Fusor::Engine.root}/config/routes/api/v2.rb"
       app.routes_reloader.paths << "#{Fusor::Engine.root}/config/routes/api/v21.rb"
+      app.routes_reloader.paths << "#{Fusor::Engine.root}/config/routes/api/customer_portal.rb"
     end
 
     initializer 'fusor.register_plugin', :after => :finisher_hook do |app|


### PR DESCRIPTION
This pull request contains initial code to support proxying API requests through fusor/katello/foreman to the RH customer portal.  In order to support proxying requests, the user must have an active fusor/katello/foreman session; otherwise, the requests will be denied by the server.  In addition, portal credentials must be available when communicating with the portal.

The PR currently assumes that the user has specified their portal credentials in the fusor.yaml, similar to the following:
```
:fusor:
  :customer_portal:
    :url: https://subscription.rhn.redhat.com:443/subscription/
    :username: myportalaccount
    :password: mypassword
```

The use of credentials within the configuration file is only temporary; however, this PR was opened so work on the UI could proceed, if desired.

Also, the APIs that will be proxied have been placed on a separate namespace (i.e. customer_portal).  This way, if there is a desire to pull these in to katello, it can be easily done without impacting the UI.  This is also similar to how katello performs proxying of rhsm requests today.