### PR TITLE
fusor server: allow creation of hostgroup with no parent

### DIFF
--- a/server/app/lib/actions/fusor/configure_host_groups.rb
+++ b/server/app/lib/actions/fusor/configure_host_groups.rb
@@ -89,7 +89,7 @@ module Actions
           fail _("Unable to locate content view '%s'.") % content_view_name(deployment_name)
         end
 
-        hostgroup_params = { :parent_id => parent.id,
+        hostgroup_params = { :parent_id => parent.try(:id),
                              :name => hostgroup_name,
                              :organization_ids => [organization_id],
                              :lifecycle_environment_id => lifecycle_environment_id,


### PR DESCRIPTION
In general, this will not be necessary; however, this will
cleanly handle the case of a development environment where
the "Fusor Base" hostgroup was not created.  In that case, the
base hostgroup will be one named as the deployment.