### PR TITLE
fusor server: update fusor.yaml to support the chgs for hostgroup named by deployment

### DIFF
--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -40,8 +40,10 @@
     :rhev:
      :root_name: "Fusor Base" # seeded by the fusor-installer
      :host_groups:
+       - :parent: "Fusor Base"
+
        - :name: "RHEV-Engine"
-         :parent_name: "Fusor Base"
+         :parent: :root_deployment
          :puppet_classes:
            - :name: "ovirt"
            - :name: "ovirt::repo"
@@ -58,7 +60,7 @@
            - :name: "ovirt::engine::setup"
 
        - :name: "RHEV-Hypervisor"
-         :parent_name: "Fusor Base"
+         :parent: :root_deployment
          :puppet_classes:
            - :name: "ovirt"
            - :name: "ovirt::hypervisor::packages"


### PR DESCRIPTION
This commit contains minor changes so that a hostgroup will be
created with the name of the deployment.

The result would be a hostgroup structure similar to:

Fusor Base => My Deployment => RHEV-Engine