### PR TITLE
fusor server: fix apipie doc cache

### DIFF
--- a/server/app/controllers/fusor/api/v2/base_controller.rb
+++ b/server/app/controllers/fusor/api/v2/base_controller.rb
@@ -20,6 +20,7 @@ module Fusor
         include Api::V2::Rendering
 
         resource_description do
+          resource_id 'fusor'
           api_version 'v2'
           api_base_url '/fusor/api'
         end


### PR DESCRIPTION
This change is needed to address an issue where the api_url
generated in the apipie doc cache was always prepended with /fusor.

For example:
   foreman/public/apipie-cache/apidoc/v2.json

   contained api_urls similar to:
      "api_url":"/fusor/api/hostgroups/:hostgroup_id/hosts"