### PR TITLE
Spec file update to trigger asset precompilation

### DIFF
--- a/ui/rubygem-fusor_ui.spec
+++ b/ui/rubygem-fusor_ui.spec
@@ -95,7 +95,7 @@ cp -a .%{gem_dir}/* \
         %{buildroot}%{gem_dir}/
 
 %foreman_bundlerd_file
-%foreman_precompile_plugin
+%foreman_precompile_plugin -s
 
 mkdir -p %{buildroot}%{foreman_dir}/public/assets
 ln -s %{foreman_assets_plugin} %{buildroot}%{foreman_dir}/public/assets/fusor_ui
@@ -110,7 +110,7 @@ ln -s %{foreman_assets_plugin} %{buildroot}%{foreman_dir}/public/assets/fusor_ui
 %{gem_spec}
 %{foreman_bundlerd_dir}/%{gem_name}.rb
 %{foreman_dir}/public/assets/fusor_ui
-#%{foreman_assets_plugin}
+%{foreman_assets_plugin}
 
 %files doc
 %{gem_dir}/doc/%{gem_name}-%{version}


### PR DESCRIPTION
The foreman macro:  
  %foreman_precompile_plugin  

now requires a "-s" option to do the asset precompiling.  

Also added back the previously commented out: 
  {foreman_assets_plugin}


Tested RPM compiles and installs the assets.
Will likely need further updates to fix asset precompiling once we update fusor-ember-cli.css with latest code under "fusor-ember-cli" directory.


