### PR TITLE
fusor server: update akey logic to enable repositories

### DIFF
--- a/server/app/lib/actions/fusor/activation_key/configure_activation_key.rb
+++ b/server/app/lib/actions/fusor/activation_key/configure_activation_key.rb
@@ -18,7 +18,7 @@ module Actions
           _("Configure Activation Key")
         end
 
-        def plan(deployment)
+        def plan(deployment, repositories)
           unless activation_key_name(deployment)
             fail _("Unable to locate activation key settings in config/settings.plugins.d/fusor.yaml")
           end
@@ -36,7 +36,7 @@ module Actions
             # TODO: update to support UpdateSubscriptions, which could add or remove based
             # on changes in configuration... not urgent, since currently there is only a single
             # subscription in the configuration
-            plan_action(::Actions::Fusor::ActivationKey::AddSubscriptions, deployment)
+            plan_action(::Actions::Fusor::ActivationKey::AddSubscriptions, deployment, repositories)
           end
         end
 
@@ -45,6 +45,7 @@ module Actions
         def find_or_ensure_key(deployment, content_view)
           key = ::Katello::ActivationKey.where(:organization_id => deployment.organization.id,
                                                :name => activation_key_name(deployment)).first
+
           if key
             attributes = { :name => activation_key_name(deployment),
                            :organization_id => deployment.organization.id,
@@ -78,7 +79,7 @@ module Actions
 
         def activation_key_name(deployment)
           name = SETTINGS[:fusor][:activation_key][:name]
-          return [name, deployment.name].join(' - ') if name
+          return [name, deployment.name].join('-') if name
         end
       end
     end

--- a/server/app/lib/actions/fusor/configure_host_groups.rb
+++ b/server/app/lib/actions/fusor/configure_host_groups.rb
@@ -167,7 +167,7 @@ module Actions
 
       def activation_key_name(deployment_name)
         name = SETTINGS[:fusor][:activation_key][:name]
-        return [name, deployment_name].join(' - ') if name
+        return [name, deployment_name].join('-') if name
       end
     end
   end

--- a/server/app/lib/actions/fusor/deploy.rb
+++ b/server/app/lib/actions/fusor/deploy.rb
@@ -50,7 +50,7 @@ module Actions
                           deployment,
                           repositories)
 
-              plan_configure_activation_key(deployment)
+              plan_configure_activation_key(deployment, repositories)
 
               enable_smart_class_parameter_overrides(products_host_groups[index])
 
@@ -64,11 +64,11 @@ module Actions
 
       private
 
-      def plan_configure_activation_key(deployment)
+      def plan_configure_activation_key(deployment, repositories)
         # At this time, 1 activation key can be used to support all products; therefore,
         # we only need to plan the action once.
         return if @configure_activation_key_planned
-        plan_action(::Actions::Fusor::ActivationKey::ConfigureActivationKey, deployment)
+        plan_action(::Actions::Fusor::ActivationKey::ConfigureActivationKey, deployment, repositories)
         @configure_activation_key_planned = true
       end
 


### PR DESCRIPTION
This commit will update the activation key logic to
also enable the repositories needed by the deployment.