### PR TITLE
fusor server: update customer_portal_proxies_controller definition

### DIFF
--- a/server/app/controllers/fusor/api/customer_portal/customer_portal_proxies_controller.rb
+++ b/server/app/controllers/fusor/api/customer_portal/customer_portal_proxies_controller.rb
@@ -11,41 +11,45 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 module Fusor
-  class Api::CustomerPortal::CustomerPortalProxiesController < Api::V2::BaseController
+  module Api
+    module CustomerPortal
+      class CustomerPortalProxiesController < Api::V2::BaseController
 
-    before_filter :proxy_request_path, :proxy_request_body
+        before_filter :proxy_request_path, :proxy_request_body
 
-    def get
-      response = Resources::CustomerPortal::Proxy.get(@request_path)
-      logger.debug response
-      render :json => response
-    end
+        def get
+          response = Resources::CustomerPortal::Proxy.get(@request_path)
+          logger.debug response
+          render :json => response
+        end
 
-    def post
-      response = Resources::CustomerPortal::Proxy.post(@request_path, @request_body.read)
-      logger.debug response
-      render :json => response
-    end
+        def post
+          response = Resources::CustomerPortal::Proxy.post(@request_path, @request_body.read)
+          logger.debug response
+          render :json => response
+        end
 
-    def delete
-      response = Resources::CustomerPortal::Proxy.delete(@request_path, @request_body.read)
-      logger.debug response
-      render :json => response
-    end
+        def delete
+          response = Resources::CustomerPortal::Proxy.delete(@request_path, @request_body.read)
+          logger.debug response
+          render :json => response
+        end
 
-    private
+        private
 
-    def proxy_request_path
-      @request_path = drop_api_namespace(@_request.fullpath)
-    end
+        def proxy_request_path
+          @request_path = drop_api_namespace(@_request.fullpath)
+        end
 
-    def proxy_request_body
-      @request_body = @_request.body
-    end
+        def proxy_request_body
+          @request_body = @_request.body
+        end
 
-    def drop_api_namespace(original_request_path)
-      prefix = "/customer_portal"
-      original_request_path.gsub(prefix, '')
+        def drop_api_namespace(original_request_path)
+          prefix = "/customer_portal"
+          original_request_path.gsub(prefix, '')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This commit restructures the controller to use nested modules.
Without the change, the user could seen an error similar to the following
when accessing the webui in production:

Web application could not be started

uninitialized constant Api::CustomerPortal (NameError)
  /opt/rh/ruby193/root/usr/share/gems/gems/foreman_hooks-0.3.7/lib/foreman_hooks.rb:83:in `load_missing_constant_with_hooks'
  /opt/rh/ruby193/root/usr/share/gems/gems/rake-0.9.2.2/lib/rake/ext/module.rb:36:in `const_missing'
  /opt/rh/ruby193/root/usr/share/gems/gems/fusor_server-0.0.1/app/controllers/fusor/api/customer_portal/customer_portal_proxies_controller.rb:14:in `<module:Fusor>'
  /opt/rh/ruby193/root/usr/share/gems/gems/fusor_server-0.0.1/app/controllers/fusor/api/customer_portal/customer_portal_proxies_controller.rb:13:in `<top (required)>'
...
...