### PR TITLE
fusor server: update config and deploy action to support overriding parameters on hostgroups

### DIFF
--- a/server/app/lib/actions/fusor/deploy.rb
+++ b/server/app/lib/actions/fusor/deploy.rb
@@ -87,9 +87,9 @@ module Actions
 
                 parameter_settings = puppet_class_setting[:parameters]
                 unless parameter_settings.blank?
-
+                  parameter_names = parameter_settings.map{ |p| p[:name] }
                   if puppet_class = Puppetclass.where(:name => puppet_class_setting[:name]).first
-                    smart_class_parameters = puppet_class.smart_class_parameters.where(:key => parameter_settings)
+                    smart_class_parameters = puppet_class.smart_class_parameters.where(:key => parameter_names)
                     smart_class_parameters.each do |parameter|
                       parameter.override = true
                       parameter.save!

--- a/server/app/models/fusor/concerns/hostgroup_extensions.rb
+++ b/server/app/models/fusor/concerns/hostgroup_extensions.rb
@@ -1,0 +1,41 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Fusor::Concerns::HostgroupExtensions
+  extend ActiveSupport::Concern
+
+  def current_param_value(key)
+    lookup_value = LookupValue.where(:lookup_key_id => key.id, :id => lookup_values).first
+    if lookup_value
+      [lookup_value.value, to_label]
+    else
+      inherited_lookup_value(key)
+    end
+  end
+
+  def current_param_value_str(key)
+    lookup_value, _ = current_param_value(key)
+    return key.value_before_type_cast(lookup_value)
+  end
+
+  def set_param_value_if_changed(puppetclass, key, value)
+    lookup_key         = puppetclass.class_params.where(:key => key).first
+    lookup_value_value = current_param_value(lookup_key)[0]
+    current_value      = lookup_key.value_before_type_cast(lookup_value_value).to_s.chomp
+    if current_value != value
+      lookup       = LookupValue.where(:match         => hostgroup.send(:lookup_value_match),
+                                       :lookup_key_id => lookup_key.id).first_or_initialize
+      lookup.value = value
+      lookup.save!
+    end
+  end
+end

--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -46,26 +46,57 @@
          :parent: :root_deployment
          :puppet_classes:
            - :name: "ovirt"
-           - :name: "ovirt::repo"
+             :parameters:
+             - :name: "product"
+               :override: "RHEV"
            - :name: "ovirt::engine::config"
              :parameters:
-             - "cluster_name"
-             - "cpu_type"
-             - "host_name"
-             - "share_path"
-             - "storage_name"
-             - "storage_type"
-             - "storage_address"
+             - :name: "username"
+             - :name: "dc_name"
+             - :name: "cluster_name"
+             - :name: "cpu_type"
+             - :name: "host_name"
+             - :name: "host_address"
+             - :name: "root_password"
+             - :name: "storage_name"
+             - :name: "storage_address"
+             - :name: "storage_path"
+             - :name: "export_address"
+             - :name: "export_name"
+             - :name: "export_path"
+             - :name: "storage_type"
+             - :name: "share_path"
            - :name: "ovirt::engine::packages"
            - :name: "ovirt::engine::setup"
+             :parameters:
+             - :name: "application_mode"
+             - :name: "storage_type"
+             - :name: "organization"
+             - :name: "nfs_config_enabled"
+             - :name: "iso_domain_name"
+             - :name: "iso_domain_mount_point"
+             - :name: "admin_password"
+             - :name: "db_user"
+             - :name: "db_password"
+             - :name: "db_host"
+             - :name: "db_port"
+             - :name: "storage_domain_dir"
+             - :name: "firewall_manager"
+               :override: "iptables"
+             - :name: "url"
+             - :name: "username"
 
        - :name: "RHEV-Hypervisor"
          :parent: :root_deployment
          :puppet_classes:
            - :name: "ovirt"
+             :parameters:
+             - :name: "product"
+               :override: "RHEV"
            - :name: "ovirt::hypervisor::packages"
 
   :activation_key:
     :name: "Fusor_Key"
     :subscription_descriptions:
       - "Red Hat Cloud Infrastructure"
+

--- a/server/lib/fusor/engine.rb
+++ b/server/lib/fusor/engine.rb
@@ -46,6 +46,7 @@ module Fusor
     #Include concerns in this config.to_prepare block
     config.to_prepare do
       # include concerns
+      ::Hostgroup.send :include, Fusor::Concerns::HostgroupExtensions
     end
 
     rake_tasks do


### PR DESCRIPTION
This commit contains changes to enable for the deploy action
to provide override values on hostgroup puppet class parameters.
This is initially needed to allow for the ovirt puppet class to have
the product set to 'RHEV'.

This commit also enables the override flag on several additional
smart class parameters for the ovirt puppet classes.