### PR TITLE
fusor server: if deployment attribute is blank, use the puppet default

### DIFF
--- a/server/app/models/fusor/concerns/hostgroup_extensions.rb
+++ b/server/app/models/fusor/concerns/hostgroup_extensions.rb
@@ -35,6 +35,7 @@ module Fusor::Concerns::HostgroupExtensions
       lookup       = LookupValue.where(:match         => hostgroup.send(:lookup_value_match),
                                        :lookup_key_id => lookup_key.id).first_or_initialize
       lookup.value = value
+      lookup.use_puppet_default = value.blank? ? true : false
       lookup.save!
     end
   end


### PR DESCRIPTION
If a use doesn't specify a value for a deployment object attribute
that is being mapped to puppet class parameters, set the lookup key/value
to indicate to use the default value from the puppet module.