### PR TITLE
Add RH Common to fusor.yaml

### DIFF
--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -17,6 +17,11 @@
         :releasever: "6.6"
 
       - :product_name: "Red Hat Enterprise Linux Server"
+        :repository_set_name: "Red Hat Enterprise Linux 6 Server - RH Common (RPMs)"
+        :basearch: "x86_64"
+        :releasever: "6.6"
+
+      - :product_name: "Red Hat Enterprise Linux Server"
         :repository_set_name: "Red Hat Enterprise Linux 6 Server - Supplementary (RPMs)"
         :basearch: "x86_64"
         :releasever: "6Server"


### PR DESCRIPTION
In order to get puppet for the clients we need to add RH Common.