### PR TITLE
fusor server: add deploy option to 'skip_content'

### DIFF
--- a/server/app/controllers/fusor/api/v2/deployments_controller.rb
+++ b/server/app/controllers/fusor/api/v2/deployments_controller.rb
@@ -39,7 +39,7 @@ module Fusor
     end
 
     def deploy
-      task = async_task(::Actions::Fusor::Deploy, @deployment)
+      task = async_task(::Actions::Fusor::Deploy, @deployment, params[:skip_content])
       respond_for_async :resource => task
     end
 


### PR DESCRIPTION
Adding a parameter to the deploy API so that a user may
pass in 'skip_content=true' to skip some of the lengthy actions
that are executed by a deploy, specifically:
- repo enablement
- repo syncing
- content view creation/publishing/promotion

The default behavior will be to execute all content actions; however,
users could use this to speed up a deployment if they already have
content seeded and do not desire to re-run the above actions.