### PR TITLE
Add deploy rhev action

### DIFF
--- a/server/app/lib/actions/fusor/deploy.rb
+++ b/server/app/lib/actions/fusor/deploy.rb
@@ -18,14 +18,18 @@ module Actions
       end
 
       def plan(deployment, skip_content = false)
+        Rails.logger.warn "XXX action plan called"
         fail _("Unable to locate fusor.yaml settings in config/settings.plugins.d") unless SETTINGS[:fusor]
         fail _("Unable to locate content settings in config/settings.plugins.d/fusor.yaml") unless SETTINGS[:fusor][:content]
         fail _("Unable to locate host group settings in config/settings.plugins.d/fusor.yaml") unless SETTINGS[:fusor][:host_groups]
 
         sequence do
           # TODO: add an action to support importing a manifest created as part of the deployment
+          Rails.logger.warn "XXX Entered sequence"
 
           products_enabled = [deployment.deploy_rhev, deployment.deploy_cfme, deployment.deploy_openstack]
+
+          Rails.logger.warn "XXX #{products_enabled}"
 
           content = SETTINGS[:fusor][:content]
           products_content = [content[:rhev], content[:cloudforms], content[:openstack]]
@@ -61,6 +65,12 @@ module Actions
                           deployment,
                           products_host_groups[index])
             end
+          end
+
+          if deployment.deploy_rhev
+            Rails.logger.warn "XXX RHEV is enabled, planning deployment of rhev"
+            plan_action(::Actions::Fusor::Deployment::DeployRhev, deployment)
+            Rails.logger.warn"XXX Deployment action planned"
           end
         end
       end

--- a/server/app/lib/actions/fusor/deployment/deploy_rhev.rb
+++ b/server/app/lib/actions/fusor/deployment/deploy_rhev.rb
@@ -1,0 +1,217 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Fusor
+    module Deployment
+      class DeployRhev < Actions::Base
+        def humanized_name
+          _("Deploy Red Hat Enterprise Virtualization")
+        end
+
+        def plan(deployment)
+          Rails.logger.warn "XXX Planing RHEV Deployment"
+          Rails.logger.warn deployment.deploy_rhev
+          Rails.logger.warn deployment.id
+          Rails.logger.warn "XXX -------"
+
+          # VERIFY PARAMS HERE
+          plan_self deployment_id: deployment.id
+
+          Rails.logger.warn "XXX plan_self called"
+          Rails.logger.warn "XXX leaving plan method"
+        end
+
+        def finalize
+          Rails.logger.warn "XXX Deploy RHEV Running. (finalize method)"
+          deployment_id = input.fetch(:deployment_id)
+          Rails.logger.warn deployment_id
+          deployment = ::Fusor::Deployment.find(deployment_id)
+          Rails.logger.warn "XXX finalize: deployment is a: #{deployment.class}"
+          if deployment.rhev_engine_host.nil?
+            Rails.logger.warn "XXX we don't have a rhev engine host."
+          else
+            Rails.logger.warn "XXX finalize: managed host? #{deployment.rhev_engine_host.managed?}"
+          end
+          Rails.logger.warn "XXX finalize: deployment name is: #{deployment.name}"
+          Rails.logger.warn "XXX finalize: deployment org is: #{deployment.organization.id}"
+
+          Rails.logger.warn "XXX ================ RHEV Hypervisor piece ===================="
+          hypervisor_group = find_hypervisor_hostgroup(deployment)
+
+          Rails.logger.warn "XXX H: calling assign_host_to_hostgroup"
+          deployment.discovered_hosts.each do |da_host|
+            success, da_host = assign_host_to_hostgroup(da_host, hypervisor_group)
+            Rails.logger.warn "XXX H: returned from assign_host_to_hostgroup. #{success}"
+            if da_host
+              Rails.logger.warn "XXX H: host is NOT null! YAY!"
+            else
+              Rails.logger.warn "XXX H: damn what happened to the host"
+            end
+          end
+
+          Rails.logger.warn "XXX ================ RHEV Engine piece ===================="
+          engine_group = find_engine_hostgroup(deployment)
+
+          Rails.logger.warn "XXX calling assign_host_to_hostgroup"
+          success, host = assign_host_to_hostgroup(deployment.rhev_engine_host, engine_group)
+          Rails.logger.warn "XXX returned from assign_host_to_hostgroup. #{success}"
+          if host
+            Rails.logger.warn "XXX host is NOT null! YAY!"
+          else
+            Rails.logger.warn "XXX damn what happened to the host"
+          end
+
+          Rails.logger.warn "XXX Leaving finalize method"
+        end
+
+        def find_engine_hostgroup(deployment)
+          find_hostgroup(deployment, "RHEV-Engine")
+        end
+
+        def find_hypervisor_hostgroup(deployment)
+          find_hostgroup(deployment, "RHEV-Hypervisor")
+        end
+
+        #
+        # "borrowed" from staypuft:
+        # https://github.com/theforeman/staypuft/blob/master/app/controllers/staypuft/deployments_controller.rb#L158-L216
+        #
+        def assign_host_to_hostgroup(assignee_host, hostgroup)
+          converting_discovered = assignee_host.is_a? Host::Discovered
+
+          if converting_discovered
+            Rails.logger.warn "XXX We have a discovered host that needs converting"
+            hosts_facts = FactValue.joins(:fact_name).where(host_id: assignee_host.id)
+            discovery_bootif = hosts_facts.where(fact_names: { name: 'discovery_bootif' }).first or
+                raise 'unknown discovery_bootif fact'
+
+            Rails.logger.warn "XXX the discovery bootif is #{discovery_bootif.value}"
+
+            interface = hosts_facts.
+                includes(:fact_name).
+                where(value: [discovery_bootif.value.upcase, discovery_bootif.value.downcase]).
+                find { |v| v.fact_name.name =~ /^macaddress_.*$/ }.
+                fact_name.name.split('_').last
+
+            Rails.logger.warn "XXX the interface is #{interface}"
+
+            network = hosts_facts.where(fact_names: { name: "network_#{interface}" }).first
+
+            Rails.logger.warn "XXX the network is #{network.value}"
+
+            if hostgroup.subnet
+              hostgroup.subnet.network == network.value or
+                  raise "networks do not match: #{hostgroup.subnet.network} #{network.value}"
+            else
+              Rails.logger.warn "XXX subnet is NIL! why?"
+            end
+
+            ip = hosts_facts.where(fact_names: { name: "ipaddress_#{interface}" }).first
+
+            Rails.logger.warn "XXX ip address is #{ip.value}"
+            Rails.logger.warn "XXX leaving converting_discovered"
+          end
+
+          original_type = assignee_host.type
+          host          = if converting_discovered
+                            assignee_host.becomes(::Host::Managed).tap do |host|
+                              host.type    = 'Host::Managed'
+                              host.managed = true
+                              host.ip      = ip.value
+                              host.mac     = discovery_bootif.value
+                            end
+                          else
+                            assignee_host
+                          end
+
+          host.hostgroup = hostgroup
+          # set build to true so the PXE config-template takes effect under discovery environment
+          host.build = true if assignee_host.managed?
+
+          # 2015-03-24 zeus Not sure we need this for RHCI
+          # set discovery environment to keep booting discovery image
+          # host.environment = Environment.get_discovery
+
+          Rails.logger.warn "XXX host is setup. Just got environment"
+
+          # root_pass is not copied for some reason
+          host.root_pass = hostgroup.root_pass
+
+          # clear all virtual devices that may have been created during previous assignment
+          # host.clean_vlan....
+          host.interfaces.virtual.map(&:destroy)
+          # by default foreman will try to manage all NICs unless user disables manually after assignment
+          #host.make_all_interfaces_managed
+          host.interfaces.each do |interface|
+            interface.managed = true
+            interface.save!
+          end
+
+          # I do not [know] why but the final save! adds following condytion to the update SQL command
+          # "WHERE "hosts"."type" IN ('Host::Managed') AND "hosts"."id" = 283"
+          # which will not find the record since it's still Host::Discovered.
+          # Using #update_column to change it directly in DB
+          # (assignee_host is used to avoid same WHERE condition problem here).
+          # FIXME this is definitely ugly, needs to be properly fixed
+          assignee_host.update_column :type, 'Host::Managed'
+
+          Rails.logger.warn "XXX assignee host type is now: #{assignee_host.type}"
+
+          host.save!
+
+          Rails.logger.warn "XXX do we have an error?"
+
+          [host.save, host].tap do |saved, _|
+            Rails.logger.warn "XXX we're tapping the host. whatever that means. Saved? #{saved}"
+            assignee_host.becomes(Host::Base).update_column(:type, original_type) unless saved
+            Rails.logger.warn "XXX we finished becoming a Host::Base"
+            assignee_host
+          end
+        end
+
+        private
+
+        def deploy_rhev
+          Rails.logger.warn "XXX Deploy RHEV"
+          # haven't figured out what I'm putting here yet
+        end
+
+        def find_hostgroup(deployment, name)
+          # locate the top-level hostgroup for the deployment...
+          # currently, we'll create a hostgroup with the same name as the deployment...
+          # Note: you need to scope the query to organization
+          parent = ::Hostgroup.where(:name => deployment.name).
+                               joins(:organizations).
+                               where("taxonomies.id in (?)", [deployment.organization.id]).first
+
+          # generate the ancestry, so that we can locate the hostgroups based on the hostgroup hierarchy, which assumes:
+          # "Fusor Base"/"My Deployment"
+          # Note: there may be a better way in foreman to locate the hostgroup
+          if parent
+            if parent.ancestry
+              ancestry = [parent.ancestry, parent.id.to_s].join('/')
+            else
+              ancestry = parent.id.to_s
+            end
+          end
+
+          # locate the engine hostgroup...
+          host_group = ::Hostgroup.where(:name => name).
+                                   where(:ancestry => ancestry).
+                                   joins(:organizations).
+                                   where("taxonomies.id in (?)", [deployment.organization.id]).first
+        end
+      end
+    end
+  end
+end

--- a/server/app/lib/actions/fusor/deployment/deploy_rhev.rb
+++ b/server/app/lib/actions/fusor/deployment/deploy_rhev.rb
@@ -24,6 +24,10 @@ module Actions
           Rails.logger.warn "XXX deployment.id? #{deployment.id}"
 
           # VERIFY PARAMS HERE
+          if deployment.deploy_rhev
+            fail _("Unable to locate a RHEV Engine Host") unless deployment.rhev_engine_host
+          end
+
           plan_self deployment_id: deployment.id
 
           Rails.logger.warn "XXX plan_self called, leaving plan method"
@@ -99,6 +103,8 @@ module Actions
         # https://github.com/theforeman/staypuft/blob/master/app/controllers/staypuft/deployments_controller.rb#L158-L216
         #
         def assign_host_to_hostgroup(assignee_host, hostgroup)
+          raise "no host available to assign" if assignee_host.nil?
+
           converting_discovered = assignee_host.is_a? Host::Discovered
 
           if converting_discovered


### PR DESCRIPTION
The deploy rhev action will inspect the deployment object and determine if it needs to deploy a RHEV Engine & Hypervisors. It will find the proper hostgroups for each, assign them to the proper host. Convert any discovered hosts to managed hosts for provisioning.

There is quite a bit of DEBUG logging marked with XXX. Normally this wouldn't be kept but while we're still anticipating some weird bugs it will be helpful until we can iron them all out. The XXX makes it easier to find the messages in the log file as well as making it easier to find them for removal later.