### PR TITLE
fusor server: hard-code root_pass and set storage_path param on hostgroup

### DIFF
--- a/server/app/lib/actions/fusor/configure_host_groups.rb
+++ b/server/app/lib/actions/fusor/configure_host_groups.rb
@@ -94,6 +94,11 @@ module Actions
             hostgroup_params[:medium_id] = operating_system.try(:media).try(:first).try(:id)
             hostgroup_params[:ptable_id] = operating_system.try(:ptables).try(:first).try(:id)
             hostgroup_params[:architecture_id] = operating_system.try(:architectures).try(:first).try(:id)
+
+            # TODO: the root_pass should later be configurable by the user.  In addition, we'll need to make
+            # sure that it aligns with the password (if any) used by the puppet modules
+            # (e.g. ovirt::engine::config, root_password)
+            hostgroup_params[:root_pass] = "changeme"
           end
         else
           fail _("Unable to locate content view '%s'.") % content_view_name(deployment.name)
@@ -148,7 +153,6 @@ module Actions
         # TODO: ISSUE: the following attributes exist on the deployment object, but I do not know
         # if they should be mapping to puppet class parameters and if so, which class & parameter?
         # :name => , :value => deployment.rhev_database_name,
-        # :name => , :value => deployment.rhev_share_path,
         # :name => , :value => deployment.cfme_install_loc,
         # :name => , :value => deployment.rhev_is_self_hosted,
 
@@ -172,6 +176,7 @@ module Actions
                     { :name => "storage_name", :value => deployment.rhev_storage_name },
                     { :name => "storage_address", :value => deployment.rhev_storage_address },
                     { :name => "storage_type", :value => deployment.rhev_storage_type },
+                    { :name => "storage_path", :value => deployment.rhev_share_path },
                     { :name => "cpu_type", :value => deployment.rhev_cpu_type }
                   ]
                 },


### PR DESCRIPTION
This commit addresses 2 small changes:

1. hard-code the root_pass on the deployment hostgroup
   This is a temporary change and we'll make it configurable in future
   commits; however, that will require UI, schema, backend...etc

2. set the storage_path parameter from the deployment rhev_share
   attribute