### PR TITLE
fusor server: customer portal: store/use credentials in/from session & manage manifest during deploy

### DIFF
--- a/server/app/lib/actions/fusor/deploy.rb
+++ b/server/app/lib/actions/fusor/deploy.rb
@@ -24,11 +24,8 @@ module Actions
         fail _("Unable to locate host group settings in config/settings.plugins.d/fusor.yaml") unless SETTINGS[:fusor][:host_groups]
 
         sequence do
-          # TODO: add an action to support importing a manifest created as part of the deployment
           Rails.logger.warn "XXX Entered sequence"
-
           products_enabled = [deployment.deploy_rhev, deployment.deploy_cfme, deployment.deploy_openstack]
-
           Rails.logger.warn "XXX #{products_enabled}"
 
           content = SETTINGS[:fusor][:content]

--- a/server/app/lib/actions/fusor/subscription/download_manifest.rb
+++ b/server/app/lib/actions/fusor/subscription/download_manifest.rb
@@ -1,0 +1,56 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Fusor
+    module Subscription
+      class DownloadManifest < Actions::Base
+        def humanized_name
+          _("Download Subscription Manifest from Customer Portal")
+        end
+
+        def plan(deployment, customer_portal_credentials, download_file_path)
+          unless customer_portal_credentials[:username] && customer_portal_credentials[:password]
+            fail _("Customer portal credentials are not available.")
+          end
+          fail _("Deployment does not have an upstream consumer UUID.") unless deployment.upstream_consumer_uuid
+
+          plan_self(username: customer_portal_credentials[:username],
+                    password: customer_portal_credentials[:password],
+                    upstream_consumer_uuid: deployment.upstream_consumer_uuid,
+                    download_file_path: download_file_path,
+                    user_id: ::User.current.id)
+        end
+
+        def run
+          ::User.current = ::User.find(input[:user_id])
+
+          consumer = ::Fusor::Resources::CustomerPortal::Consumer.get(input[:upstream_consumer_uuid],
+                                                                      { username: input[:username],
+                                                                        password: input[:password] })
+
+          export = ::Fusor::Resources::CustomerPortal::Consumer.export(input[:upstream_consumer_uuid],
+                                                                       { client_cert: consumer['idCert']['cert'],
+                                                                         client_key: consumer['idCert']['key'] })
+
+          File.open(input[:download_file_path], 'w') do |f|
+            f.binmode
+            f.write export
+          end
+
+        ensure
+          ::User.current = nil
+        end
+      end
+    end
+  end
+end

--- a/server/app/lib/actions/fusor/subscription/manage_manifest.rb
+++ b/server/app/lib/actions/fusor/subscription/manage_manifest.rb
@@ -1,0 +1,72 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+
+module Actions
+  module Fusor
+    module Subscription
+      class ManageManifest < Actions::Base
+        def humanized_name
+          _("Manage Subscription Manifest")
+        end
+
+        def plan(deployment, customer_portal_credentials)
+          upstream_consumer = deployment.organization.owner_details['upstreamConsumer']
+          if upstream_consumer.blank?
+            # If there isn't an upstream consumer, a manifest has not yet been imported
+
+            download_file_path = File.join("#{Rails.root}/tmp", "import_#{SecureRandom.hex(10)}.zip")
+
+            sequence do
+              plan_action(::Actions::Fusor::Subscription::DownloadManifest,
+                          deployment,
+                          customer_portal_credentials,
+                          download_file_path)
+
+              plan_action(::Actions::Katello::Provider::ManifestImport,
+                          deployment.organization.redhat_provider,
+                          download_file_path,
+                          nil)
+            end
+
+          else
+            # If there is an upstream consumer, a manifest has been previously imported; therefore, we
+            # either need to refresh or delete it and import another
+
+            if upstream_consumer['uuid'] == deployment.upstream_consumer_uuid
+              plan_action(::Actions::Katello::Provider::ManifestRefresh,
+                          deployment.organization.redhat_provider,
+                          upstream_consumer)
+            else
+              download_file_path = File.join("#{Rails.root}/tmp", "import_#{SecureRandom.hex(10)}.zip")
+
+              sequence do
+                plan_action(::Actions::Fusor::Subscription::DownloadManifest,
+                            deployment,
+                            customer_portal_credentials,
+                            download_file_path)
+
+                plan_action(::Actions::Katello::Provider::ManifestDelete,
+                            deployment.organization.redhat_provider)
+
+                plan_action(::Actions::Katello::Provider::ManifestImport,
+                            deployment.organization.redhat_provider,
+                            download_file_path,
+                            nil)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/app/lib/fusor/resources/customer_portal.rb
+++ b/server/app/lib/fusor/resources/customer_portal.rb
@@ -17,23 +17,23 @@ module Fusor
 
     module CustomerPortal
       class Proxy
-        def self.post(path, body)
+        def self.post(path, credentials, body)
           Rails.logger.debug "Sending POST request to Customer Portal: #{ path }"
-          client = CustomerPortalResource.rest_client(path)
+          client = CustomerPortalResource.rest_client(path, credentials)
           client.post(body, { :accept => :json, :content_type => :json })
         end
 
-        def self.delete(path, body = nil)
+        def self.delete(path, credentials, body = nil)
           Rails.logger.debug "Sending DELETE request to Customer Portal: #{ path }"
-          client = CustomerPortalResource.rest_client(path)
+          client = CustomerPortalResource.rest_client(path, credentials)
           # Some candlepin calls will set the body in DELETE requests.
           client.options[:payload] = body unless body.nil?
           client.delete({ :accept => :json, :content_type => :json })
         end
 
-        def self.get(path)
+        def self.get(path, credentials)
           Rails.logger.debug "Sending GET request to Customer Portal: #{ path }"
-          client = CustomerPortalResource.rest_client(path)
+          client = CustomerPortalResource.rest_client(path, credentials)
           client.get({ :accept => :json })
         end
       end
@@ -49,11 +49,11 @@ module Fusor
           a_name.tr(' ', '_')
         end
 
-        def self.rest_client(path)
+        def self.rest_client(path, credentials)
           settings = SETTINGS[:fusor][:customer_portal]
-          prefix = settings[:url] || "https://subscription.rhn.redhat.com:443/subscription/"
-          username = settings[:username]
-          password = settings[:password]
+          prefix = (settings && settings[:url]) || "https://subscription.rhn.redhat.com:443/subscription/"
+          username = credentials[:username]
+          password = credentials[:password]
 
           if ::Katello.config.cdn_proxy && ::Katello.config.cdn_proxy.host
             proxy_config = ::Katello.config.cdn_proxy

--- a/server/config/routes/api/customer_portal.rb
+++ b/server/config/routes/api/customer_portal.rb
@@ -3,6 +3,9 @@ Fusor::Engine.routes.draw do
     match '/customer_portal' => 'v2/root#resource_list', :via => :get
 
     scope :path => :customer_portal, :module => :customer_portal, :as => :customer_portal do
+      match '/login' => 'customer_portal_proxies#login', :via => :post
+      match '/logout' => 'customer_portal_proxies#logout', :via => :post
+
       match '/users/:login/owners' => 'customer_portal_proxies#get', :via => :get, :as => :proxy_users_owners_path, :constraints => { :login => /\S+/ }
       match '/owners/:id/consumers' => 'customer_portal_proxies#get', :via => :get, :as => :proxy_owners_consumers_path
       match '/consumers' => 'customer_portal_proxies#post', :via => :post, :as => :proxy_consumer_create_path

--- a/server/db/migrate/20150427155245_add_upstream_consumer_uuid_to_deployments.rb
+++ b/server/db/migrate/20150427155245_add_upstream_consumer_uuid_to_deployments.rb
@@ -1,0 +1,5 @@
+class AddUpstreamConsumerUuidToDeployments < ActiveRecord::Migration
+  def change
+    add_column :fusor_deployments, :upstream_consumer_uuid, :string
+  end
+end


### PR DESCRIPTION
This commit contains modifications to the customer portal proxying
interface to support the following:

1. Add login API to allow user to provide their portal credentials.
   This will store the credentials in the user's session on the server.
   If the session times out or the user logs out, they must provide
   the credentials again, when they want to use the proxy interface.

2. Add logout API to allow user to clear the portal credentials

3. Use the credentials from the session when proxying requests to
   the customer portal.  If the credentials are not available,
   fail the request.  Failure could be that user didn't 'login'
   or session timed out.

EDIT: This PR also contains the addition of the manifest import as part of the 'deploy' API.  Refer to commit for details.