### PR TITLE
fusor server: deployment: update to support root password per product

### DIFF
--- a/server/app/lib/actions/fusor/deploy.rb
+++ b/server/app/lib/actions/fusor/deploy.rb
@@ -25,6 +25,7 @@ module Actions
         fail _("Unable to locate puppet class settings in config/settings.plugins.d/fusor.yaml") unless SETTINGS[:fusor][:puppet_classes]
 
         sequence do
+          product_types = [:rhev, :cfme, :openstack]  # array of supported products
           products_enabled = [deployment.deploy_rhev, deployment.deploy_cfme, deployment.deploy_openstack]
 
           content = SETTINGS[:fusor][:content]
@@ -59,6 +60,7 @@ module Actions
 
               plan_action(::Actions::Fusor::ConfigureHostGroups,
                           deployment,
+                          product_types[index],
                           products_host_groups[index])
             end
           end

--- a/server/db/migrate/20150429180751_add_root_passwords_to_deployments.rb
+++ b/server/db/migrate/20150429180751_add_root_passwords_to_deployments.rb
@@ -1,0 +1,6 @@
+class AddRootPasswordsToDeployments < ActiveRecord::Migration
+  def change
+    add_column :fusor_deployments, :rhev_root_password, :string
+    add_column :fusor_deployments, :cfme_root_password, :string
+  end
+end


### PR DESCRIPTION
This commit contains changes to allow the user to specify a different root
password for each product (currently rhev & cfme).