### PR TITLE
fusor server: support deploying using the 'Default Organization View' content view

### DIFF
--- a/server/app/lib/actions/fusor/activation_key/configure_activation_key.rb
+++ b/server/app/lib/actions/fusor/activation_key/configure_activation_key.rb
@@ -49,7 +49,7 @@ module Actions
           if key
             attributes = { :name => activation_key_name(deployment),
                            :organization_id => deployment.organization.id,
-                           :environment_id => deployment.lifecycle_environment.id,
+                           :environment_id => lifecycle_environment(deployment),
                            :content_view_id => content_view.id,
                            :auto_attach => true,
                            :user_id => ::User.current.id }
@@ -58,7 +58,7 @@ module Actions
           else
             key = ::Katello::ActivationKey.new(:name => activation_key_name(deployment),
                                                :organization_id => deployment.organization.id,
-                                               :environment_id => deployment.lifecycle_environment.id,
+                                               :environment_id => lifecycle_environment(deployment),
                                                :content_view_id => content_view.id,
                                                :auto_attach => true,
                                                :user_id => ::User.current.id)
@@ -72,9 +72,21 @@ module Actions
                                        :name => content_view_name(deployment)).first
         end
 
+        def lifecycle_environment(deployment)
+          if deployment.lifecycle_environment_id
+            deployment.lifecycle_environment_id
+          else
+            deployment.organization.library.id
+          end
+        end
+
         def content_view_name(deployment)
-          name = SETTINGS[:fusor][:content][:content_view][:composite_view_name]
-          return [name, deployment.name].join(' - ') if name
+          if deployment.lifecycle_environment_id
+            name = SETTINGS[:fusor][:content][:content_view][:composite_view_name]
+            [name, deployment.name].join(' - ') if name
+          else
+            deployment.organization.default_content_view.name
+          end
         end
 
         def activation_key_name(deployment)

--- a/server/app/lib/actions/fusor/deploy.rb
+++ b/server/app/lib/actions/fusor/deploy.rb
@@ -48,7 +48,7 @@ module Actions
 
                 plan_action(::Actions::Fusor::Content::PublishContentView,
                             deployment,
-                            repositories)
+                            repositories) if deployment.lifecycle_environment_id
               end
 
               unless repositories

--- a/server/app/models/fusor/deployment.rb
+++ b/server/app/models/fusor/deployment.rb
@@ -17,7 +17,6 @@ module Fusor
 
     validates :name, :presence => true, :uniqueness => {:scope => :organization_id}
     validates :organization_id, :presence => true
-    validates :lifecycle_environment_id, :presence => true
 
     belongs_to :rhev_engine_host, :class_name => "::Host::Base", :foreign_key => :rhev_engine_host_id
     has_many :rhev_hypervisor_hosts, :class_name => "::Host::Base", :through => :deployment_hosts

--- a/server/db/migrate/20150501114202_allow_null_lifecycle_environment_for_deployment.rb
+++ b/server/db/migrate/20150501114202_allow_null_lifecycle_environment_for_deployment.rb
@@ -1,0 +1,9 @@
+class AllowNullLifecycleEnvironmentForDeployment < ActiveRecord::Migration
+  def up
+    change_column :fusor_deployments, :lifecycle_environment_id, :integer, :null => true
+  end
+
+  def down
+    change_column :fusor_deployments, :lifecycle_environment_id, :integer, :null => false
+  end
+end


### PR DESCRIPTION
The changes provided in this commit will allow a user to perform
a deployment using RPM content that is in the 'Default Organization
View'.  This view is often referred to as the 'default content view'
and is published when the user syncs the repository.

In order to perform a deployment using the 'Default Organization View',
simply set 'deployment.lifecycle_environment_id = nil' prior to
performing the deploy.

When this is done,

- RPM content will come from the Default Organization View
- Puppet content will come from the 'Fusor Puppet Content' view
  currently in the Library.  Puppet content is not part of the
  'Default Organization View'; however, this particular content
  view is created and published as part of the fusor-installer.