### PR TITLE
Change perm name :destroy_discovered_hosts to :destroy_fusor_deployments 

### DIFF
--- a/server/lib/fusor/engine.rb
+++ b/server/lib/fusor/engine.rb
@@ -40,7 +40,7 @@ module Fusor
             :"fusor/api/v2/deployments" => [:update],
             :"fusor/api/v21/deployments" => [:update]
           }, :resource_type => 'Fusor::Deployment'
-          permission :destroy_discovered_hosts, {
+          permission :destroy_fusor_deployments, {
             :"fusor/api/v2/deployments" => [:destroy],
             :"fusor/api/v21/deployments" => [:destroy]
           }, :resource_type => 'Fusor::Deployment'


### PR DESCRIPTION
In an ISO environment (install from Fusor ISO) we are seeing failures from "foreman-rake db:seed".

# foreman-rake --trace db:seed
** Invoke db:seed (first_time)
** Execute db:seed
** Invoke db:abort_if_pending_migrations (first_time)
** Invoke environment (first_time)
** Execute environment
Apipie cache enabled but not present yet. Run apipie:cache rake task to speed up API calls.
rake aborted!
some permissions were not found
/usr/share/foreman/app/models/role.rb:131:in `add_permissions'
/usr/share/foreman/app/models/role.rb:146:in `add_permissions!'
/usr/share/foreman/app/services/foreman/plugin.rb:201:in `block in role'
/opt/rh/ruby193/root/usr/share/gems/gems/activerecord-3.2.8/lib/active_record/connection_adapters/abstract/database_statements.rb:192:in `transaction'
/opt/rh/ruby193/root/usr/share/gems/gems/activerecord-3.2.8/lib/active_record/transactions.rb:208:in `transaction'
/usr/share/foreman/app/services/foreman/plugin.rb:199:in `role'
/opt/rh/ruby193/root/usr/share/gems/gems/foreman_discovery-2.0.0.13/lib/foreman_discovery/engine.rb:90:in `block (2 levels) in <class:Engine>'
/usr/share/foreman/app/services/foreman/plugin.rb:64:in `instance_eval'
/usr/share/foreman/app/services/foreman/plugin.rb:64:in `register'
/opt/rh/ruby193/root/usr/share/gems/gems/foreman_discovery-2.0.0.13/lib/foreman_discovery/engine.rb:39:in `block in <class:Engine>'

Cause appears to be reuse of the same permission name on a different resource type.
The foreman-discovery engine is defining :destroy_discovered_hosts
  https://github.com/theforeman/foreman_discovery/blob/develop/lib/foreman_discovery/engine.rb#L59