### PR TITLE
fusor server: updates so host deployment completes only after all hosts are provisioned

### DIFF
--- a/server/app/lib/actions/fusor/activation_key/add_subscriptions.rb
+++ b/server/app/lib/actions/fusor/activation_key/add_subscriptions.rb
@@ -29,7 +29,7 @@ module Actions
                     :repository_cp_labels => repositories.map(&:cp_label))
         end
 
-        def finalize
+        def run
           ::User.current = ::User.find(input[:user_id])
 
           key = ::Katello::ActivationKey.where(:organization_id => input[:organization_id],

--- a/server/app/lib/actions/fusor/activation_key/configure_activation_key.rb
+++ b/server/app/lib/actions/fusor/activation_key/configure_activation_key.rb
@@ -63,7 +63,7 @@ module Actions
                                                :auto_attach => true,
                                                :user_id => ::User.current.id)
 
-            plan_action(::Actions::Katello::ActivationKey::Create, key)
+            plan_action(::Actions::Fusor::ActivationKey::Create, key)
           end
         end
 

--- a/server/app/lib/actions/fusor/activation_key/create.rb
+++ b/server/app/lib/actions/fusor/activation_key/create.rb
@@ -1,0 +1,36 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Fusor
+    module ActivationKey
+      class Create < Actions::Katello::ActivationKey::Create
+        def plan(activation_key)
+          super(activation_key)
+        end
+
+        def humanized_name
+          _("Create")
+        end
+
+        def run
+          # Invoke the finalize method from the parent
+          ::Actions::Katello::ActivationKey::Create.instance_method(:finalize).bind(self).call
+        end
+
+        def finalize
+          # Do nothing; however, override the method to avoid the parent's finalize being called
+        end
+      end
+    end
+  end
+end

--- a/server/app/lib/actions/fusor/configure_host_groups.rb
+++ b/server/app/lib/actions/fusor/configure_host_groups.rb
@@ -30,7 +30,7 @@ module Actions
                   :user_id => ::User.current.id)
       end
 
-      def finalize
+      def run
         # Note: user_id is being passed in and then used to set User.current to address an error
         # that could occur when we later attempt to access ::Katello.pulp_server indirectly through
         # this action.  In the future, we may want to see if there are alternatives to this approach.

--- a/server/app/lib/actions/fusor/deployment/deploy_rhev.rb
+++ b/server/app/lib/actions/fusor/deployment/deploy_rhev.rb
@@ -19,203 +19,35 @@ module Actions
         end
 
         def plan(deployment)
-          Rails.logger.warn "XXX ================ Planning RHEV Deployment ===================="
+          fail _("Unable to locate a RHEV Engine Host") unless deployment.rhev_engine_host
 
-          # VERIFY PARAMS HERE
-          if deployment.deploy_rhev
-            fail _("Unable to locate a RHEV Engine Host") unless deployment.rhev_engine_host
-          end
+          sequence do
+            concurrence do
+              deployment.discovered_hosts.each do |host|
+                plan_action(::Actions::Fusor::Host::TriggerProvisioning,
+                            deployment,
+                            "RHEV-Hypervisor",
+                            host)
 
-          plan_self deployment_id: deployment.id
-        end
-
-        def finalize
-          Rails.logger.warn "XXX ================ Deploy RHEV finalize method ===================="
-
-          deployment_id = input.fetch(:deployment_id)
-
-          deployment = ::Fusor::Deployment.find(deployment_id)
-
-          if deployment.rhev_engine_host.nil?
-            Rails.logger.warn "XXX finalize: WE DO NOT HAVE A RHEV ENGINE HOST."
-          else
-            Rails.logger.warn "XXX finalize: managed host? #{deployment.rhev_engine_host.managed?}"
-          end
-          Rails.logger.warn "XXX finalize: deployment name is: #{deployment.name}"
-          Rails.logger.warn "XXX finalize: deployment org is: #{deployment.organization.id}"
-
-          Rails.logger.warn "XXX ================ RHEV Hypervisor piece ===================="
-
-          # let's find the proper hostgroup and associate it with the
-          # hypervisors
-          hypervisor_group = find_hypervisor_hostgroup(deployment)
-
-          Rails.logger.warn "XXX finalize: calling assign_host_to_hostgroup (hypervisor)"
-
-          deployment.discovered_hosts.each do |da_host|
-            success, da_host = assign_host_to_hostgroup(da_host, hypervisor_group)
-
-            Rails.logger.warn "XXX finalize: returned from assign_host_to_hostgroup. #{success}"
-            if da_host
-              Rails.logger.warn "XXX finalize: hypervisor host is NOT null! YAY!"
-              reboot_host(da_host)
-            else
-              Rails.logger.warn "XXX finalize: damn what happened to the hypervisor host"
-            end
-          end
-
-          Rails.logger.warn "XXX ================ RHEV Engine piece ===================="
-
-          # let's find the proper hostgroup and associate it with the engine
-          engine_group = find_engine_hostgroup(deployment)
-
-          Rails.logger.warn "XXX finalize: calling assign_host_to_hostgroup (engine)"
-
-          success, host = assign_host_to_hostgroup(deployment.rhev_engine_host, engine_group)
-
-          Rails.logger.warn "XXX returned from assign_host_to_hostgroup. #{success}"
-          if host
-            Rails.logger.warn "XXX engine host is NOT null! YAY!"
-            reboot_host(host)
-          else
-            Rails.logger.warn "XXX damn what happened to the engine host"
-          end
-
-          Rails.logger.warn "XXX ================ Leaving finalize method ===================="
-        end
-
-        def find_engine_hostgroup(deployment)
-          find_hostgroup(deployment, "RHEV-Engine")
-        end
-
-        def find_hypervisor_hostgroup(deployment)
-          find_hostgroup(deployment, "RHEV-Hypervisor")
-        end
-
-        #
-        # "borrowed" from staypuft:
-        # https://github.com/theforeman/staypuft/blob/master/app/controllers/staypuft/deployments_controller.rb#L158-L216
-        #
-        def assign_host_to_hostgroup(assignee_host, hostgroup)
-          raise "no host available to assign" if assignee_host.nil?
-
-          converting_discovered = assignee_host.is_a? Host::Discovered
-
-          if converting_discovered
-            Rails.logger.warn "XXX ================ Converting a discovered host ===================="
-
-            hosts_facts = FactValue.joins(:fact_name).where(host_id: assignee_host.id)
-            discovery_bootif = hosts_facts.where(fact_names: { name: 'discovery_bootif' }).first or
-                raise 'unknown discovery_bootif fact'
-
-            Rails.logger.warn "XXX the discovery bootif is #{discovery_bootif.value}"
-
-            interface = hosts_facts.
-                includes(:fact_name).
-                where(value: [discovery_bootif.value.upcase, discovery_bootif.value.downcase]).
-                find { |v| v.fact_name.name =~ /^macaddress_.*$/ }.
-                fact_name.name.split('_').last
-
-            Rails.logger.warn "XXX the interface is #{interface}"
-
-            network = hosts_facts.where(fact_names: { name: "network_#{interface}" }).first
-
-            Rails.logger.warn "XXX the network is #{network.value}"
-
-            if hostgroup.subnet
-              hostgroup.subnet.network == network.value or
-                  raise "networks do not match: #{hostgroup.subnet.network} #{network.value}"
-            else
-              Rails.logger.warn "XXX subnet is NIL! why?"
+                plan_action(::Actions::Fusor::Host::WaitUntilProvisioned,
+                            host)
+              end
             end
 
-            ip = hosts_facts.where(fact_names: { name: "ipaddress_#{interface}" }).first
+            plan_action(::Actions::Fusor::Host::TriggerProvisioning,
+                        deployment,
+                        "RHEV-Engine",
+                        deployment.rhev_engine_host)
 
-            Rails.logger.warn "XXX ip address is #{ip.value}"
-            Rails.logger.warn "XXX ================ Finished converting discovered host ===================="
-          end
-
-          original_type = assignee_host.type
-          host          = if converting_discovered
-                            assignee_host.becomes(::Host::Managed).tap do |host|
-                              host.type    = 'Host::Managed'
-                              host.managed = true
-                              host.ip      = ip.value
-                              host.mac     = discovery_bootif.value
-                            end
-                          else
-                            assignee_host
-                          end
-
-          host.hostgroup = hostgroup
-          # set build to true so the PXE config-template takes effect under discovery environment
-          host.build = true if assignee_host.managed?
-
-          # root_pass is not copied for some reason
-          host.root_pass = hostgroup.root_pass
-
-          # clear all virtual devices that may have been created during previous assignment
-          # host.clean_vlan....
-          host.interfaces.virtual.map(&:destroy)
-          # by default foreman will try to manage all NICs unless user disables manually after assignment
-          #host.make_all_interfaces_managed
-          host.interfaces.each do |interface|
-            interface.managed = true
-            interface.save!
-          end
-
-          # I do not [know] why but the final save! adds following condytion to the update SQL command
-          # "WHERE "hosts"."type" IN ('Host::Managed') AND "hosts"."id" = 283"
-          # which will not find the record since it's still Host::Discovered.
-          # Using #update_column to change it directly in DB
-          # (assignee_host is used to avoid same WHERE condition problem here).
-          # FIXME this is definitely ugly, needs to be properly fixed
-          assignee_host.update_column :type, 'Host::Managed'
-
-          Rails.logger.warn "XXX assignee host type is now: #{assignee_host.type}"
-
-          # TODO: calling save to explicitly see errors in log
-          host.save!
-
-          [host.save, host].tap do |saved, _|
-            assignee_host.becomes(Host::Base).update_column(:type, original_type) unless saved
-            Rails.logger.warn "XXX we finished becoming a Host::Base"
-            assignee_host
+            plan_action(::Actions::Fusor::Host::WaitUntilProvisioned,
+                        deployment.rhev_engine_host)
           end
         end
 
         private
 
-        def reboot_host(host)
-          Rails.logger.warn "XXX About to reboot host"
-          host.becomes(::Host::Discovered).reboot unless host.nil?
-          Rails.logger.warn "XXX host rebooted"
-        end
-
-        def find_hostgroup(deployment, name)
-          # locate the top-level hostgroup for the deployment...
-          # currently, we'll create a hostgroup with the same name as the deployment...
-          # Note: you need to scope the query to organization
-          parent = ::Hostgroup.where(:name => deployment.name).
-                               joins(:organizations).
-                               where("taxonomies.id in (?)", [deployment.organization.id]).first
-
-          # generate the ancestry, so that we can locate the hostgroups based on the hostgroup hierarchy, which assumes:
-          # "Fusor Base"/"My Deployment"
-          # Note: there may be a better way in foreman to locate the hostgroup
-          if parent
-            if parent.ancestry
-              ancestry = [parent.ancestry, parent.id.to_s].join('/')
-            else
-              ancestry = parent.id.to_s
-            end
-          end
-
-          # locate the engine hostgroup...
-          host_group = ::Hostgroup.where(:name => name).
-                                   where(:ancestry => ancestry).
-                                   joins(:organizations).
-                                   where("taxonomies.id in (?)", [deployment.organization.id]).first
+        def hosts_to_provision(deployment)
+          deployment.discovered_hosts + [deployment.rhev_engine_host]
         end
       end
     end

--- a/server/app/lib/actions/fusor/host/trigger_provisioning.rb
+++ b/server/app/lib/actions/fusor/host/trigger_provisioning.rb
@@ -1,0 +1,160 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Fusor
+    module Host
+      class TriggerProvisioning < Actions::Base
+        def humanized_name
+          _("Trigger Provisoning of Host")
+        end
+
+        def plan(deployment, hostgroup_name, host)
+          plan_self(deployment_id: deployment.id, hostgroup_name: hostgroup_name, host_id: host.id)
+        end
+
+        def run
+          deployment = ::Fusor::Deployment.find(input[:deployment_id])
+          hostgroup = find_hostgroup(deployment, input[:hostgroup_name])
+          host = ::Host::Base.find(input[:host_id])
+
+          success, host = assign_host_to_hostgroup(host, hostgroup)
+          reboot_host(host) if host
+        end
+
+        #
+        # "borrowed" from staypuft:
+        # https://github.com/theforeman/staypuft/blob/master/app/controllers/staypuft/deployments_controller.rb#L158-L216
+        #
+        def assign_host_to_hostgroup(assignee_host, hostgroup)
+          raise "no host available to assign" if assignee_host.nil?
+
+          converting_discovered = assignee_host.is_a? ::Host::Discovered
+          if converting_discovered
+            Rails.logger.warn "XXX ================ Converting a discovered host ===================="
+
+            hosts_facts = FactValue.joins(:fact_name).where(host_id: assignee_host.id)
+            discovery_bootif = hosts_facts.where(fact_names: { name: 'discovery_bootif' }).first or
+                raise 'unknown discovery_bootif fact'
+
+            Rails.logger.warn "XXX the discovery bootif is #{discovery_bootif.value}"
+
+            interface = hosts_facts.
+                includes(:fact_name).
+                where(value: [discovery_bootif.value.upcase, discovery_bootif.value.downcase]).
+                find { |v| v.fact_name.name =~ /^macaddress_.*$/ }.
+                fact_name.name.split('_').last
+
+            Rails.logger.warn "XXX the interface is #{interface}"
+
+            network = hosts_facts.where(fact_names: { name: "network_#{interface}" }).first
+
+            Rails.logger.warn "XXX the network is #{network.value}"
+
+            if hostgroup.subnet
+              hostgroup.subnet.network == network.value or
+                  raise "networks do not match: #{hostgroup.subnet.network} #{network.value}"
+            else
+              Rails.logger.warn "XXX subnet is NIL! why?"
+            end
+
+            ip = hosts_facts.where(fact_names: { name: "ipaddress_#{interface}" }).first
+
+            Rails.logger.warn "XXX ip address is #{ip.value}"
+            Rails.logger.warn "XXX ================ Finished converting discovered host ===================="
+          end
+
+          original_type = assignee_host.type
+          host          = if converting_discovered
+                            assignee_host.becomes(::Host::Managed).tap do |host|
+                              host.type    = 'Host::Managed'
+                              host.managed = true
+                              host.ip      = ip.value
+                              host.mac     = discovery_bootif.value
+                            end
+                          else
+                            assignee_host
+                          end
+
+          host.hostgroup = hostgroup
+          # set build to true so the PXE config-template takes effect under discovery environment
+          host.build = true if assignee_host.managed?
+
+          # root_pass is not copied for some reason
+          host.root_pass = hostgroup.root_pass
+
+          # clear all virtual devices that may have been created during previous assignment
+          # host.clean_vlan....
+          host.interfaces.virtual.map(&:destroy)
+          # by default foreman will try to manage all NICs unless user disables manually after assignment
+          #host.make_all_interfaces_managed
+          host.interfaces.each do |interface|
+            interface.managed = true
+            interface.save!
+          end
+
+          # I do not [know] why but the final save! adds following condytion to the update SQL command
+          # "WHERE "hosts"."type" IN ('Host::Managed') AND "hosts"."id" = 283"
+          # which will not find the record since it's still Host::Discovered.
+          # Using #update_column to change it directly in DB
+          # (assignee_host is used to avoid same WHERE condition problem here).
+          # FIXME this is definitely ugly, needs to be properly fixed
+          assignee_host.update_column :type, 'Host::Managed'
+
+          Rails.logger.warn "XXX assignee host type is now: #{assignee_host.type}"
+
+          host.save!
+
+          [host.save, host].tap do |saved, _|
+            assignee_host.becomes(Host::Base).update_column(:type, original_type) unless saved
+            Rails.logger.warn "XXX we finished becoming a Host::Base"
+            assignee_host
+          end
+        end
+
+        private
+
+        def reboot_host(host)
+          Rails.logger.warn "XXX About to reboot host"
+          host.becomes(::Host::Discovered).reboot unless host.nil?
+          Rails.logger.warn "XXX host rebooted"
+        end
+
+        def find_hostgroup(deployment, name)
+          # locate the top-level hostgroup for the deployment...
+          # currently, we'll create a hostgroup with the same name as the deployment...
+          # Note: you need to scope the query to organization
+          parent = ::Hostgroup.where(:name => deployment.name).
+              joins(:organizations).
+              where("taxonomies.id in (?)", [deployment.organization.id]).first
+
+          # generate the ancestry, so that we can locate the hostgroups based on the hostgroup hierarchy, which assumes:
+          # "Fusor Base"/"My Deployment"
+          # Note: there may be a better way in foreman to locate the hostgroup
+          if parent
+            if parent.ancestry
+              ancestry = [parent.ancestry, parent.id.to_s].join('/')
+            else
+              ancestry = parent.id.to_s
+            end
+          end
+
+          # locate the engine hostgroup...
+          ::Hostgroup.where(:name => name).
+              where(:ancestry => ancestry).
+              joins(:organizations).
+              where("taxonomies.id in (?)", [deployment.organization.id]).first
+        end
+      end
+    end
+  end
+end

--- a/server/app/lib/actions/fusor/host/wait_until_provisioned.rb
+++ b/server/app/lib/actions/fusor/host/wait_until_provisioned.rb
@@ -1,0 +1,79 @@
+#
+# Copyright 2014 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Fusor
+    module Host
+
+      class WaitUntilProvisioned < Actions::Base
+
+        TIMEOUT = 7200
+
+        middleware.use Actions::Fusor::Middleware::AsCurrentUser
+        # Using the Timeout middleware to make sure input[:timeout] is
+        # set. The actual timeout check is performed separately for
+        # the WaitUntilProvisioned because it's not a polling action.
+        middleware.use Actions::Fusor::Middleware::Timeout
+
+        def plan(host)
+          Rails.logger.warn "BRAD ================ Planning WaitUntilProvisioned ===================="
+
+          plan_self host_id: host.id
+        end
+
+        def run(event = nil)
+          Rails.logger.warn "BRAD ================ Run WaitUntilProvisioned ===================="
+
+          case event
+          when nil
+            suspend do |suspended_action|
+              Rails.logger.warn "BRAD ================ event=nil suspend ===================="
+              # schedule timeout
+              world.clock.ping suspended_action, input[:timeout], "timeout"
+
+              # wake up when provisioning is finished
+              Rails.cache.write(
+                  ::Fusor::Concerns::HostOrchestrationBuildHook.cache_id(input[:host_id]),
+                  { execution_plan_id: suspended_action.execution_plan_id,
+                    step_id:           suspended_action.step_id })
+            end
+          when "timeout"
+            Rails.logger.warn "BRAD ================ event=timeout ===================="
+            # clear timeout_start so that the action can be resumed/skipped
+            output[:timeout_start] = nil
+            fail(::Foreman::Exception,
+                 "You've reached the timeout set for this action. If the " +
+                 "action is still ongoing, you can click on the " +
+                 "\"Resume Deployment\" button to continue.")
+          when Hash
+            Rails.logger.warn "BRAD ================ event=Hash ===================="
+            output[:installed_at] = event.fetch(:installed_at).to_s
+          when Dynflow::Action::Skip
+            Rails.logger.warn "BRAD ================ event=Skip ===================="
+            output[:installed_at] = Time.now.utc.to_s
+          else
+            raise TypeError
+          end
+        end
+
+        def run_progress_weight
+          4
+        end
+
+        def run_progress
+          0.1
+        end
+
+      end
+    end
+  end
+end

--- a/server/app/lib/actions/fusor/host/wait_until_provisioned.rb
+++ b/server/app/lib/actions/fusor/host/wait_until_provisioned.rb
@@ -25,18 +25,13 @@ module Actions
         middleware.use Actions::Fusor::Middleware::Timeout
 
         def plan(host)
-          Rails.logger.warn "BRAD ================ Planning WaitUntilProvisioned ===================="
-
           plan_self host_id: host.id
         end
 
         def run(event = nil)
-          Rails.logger.warn "BRAD ================ Run WaitUntilProvisioned ===================="
-
           case event
           when nil
             suspend do |suspended_action|
-              Rails.logger.warn "BRAD ================ event=nil suspend ===================="
               # schedule timeout
               world.clock.ping suspended_action, input[:timeout], "timeout"
 
@@ -47,7 +42,6 @@ module Actions
                     step_id:           suspended_action.step_id })
             end
           when "timeout"
-            Rails.logger.warn "BRAD ================ event=timeout ===================="
             # clear timeout_start so that the action can be resumed/skipped
             output[:timeout_start] = nil
             fail(::Foreman::Exception,
@@ -55,10 +49,8 @@ module Actions
                  "action is still ongoing, you can click on the " +
                  "\"Resume Deployment\" button to continue.")
           when Hash
-            Rails.logger.warn "BRAD ================ event=Hash ===================="
             output[:installed_at] = event.fetch(:installed_at).to_s
           when Dynflow::Action::Skip
-            Rails.logger.warn "BRAD ================ event=Skip ===================="
             output[:installed_at] = Time.now.utc.to_s
           else
             raise TypeError

--- a/server/app/lib/actions/fusor/middleware/as_current_user.rb
+++ b/server/app/lib/actions/fusor/middleware/as_current_user.rb
@@ -1,0 +1,38 @@
+module Actions
+  module Fusor
+    module Middleware
+      class AsCurrentUser < Dynflow::Middleware
+
+        def plan(*args)
+          pass(*args).tap do
+            raise 'no current user' unless Type? User.current, User
+            action.input.update current_user_id: User.current.id
+          end
+        end
+
+        def run(*args)
+          as_current_user { pass(*args) }
+        end
+
+        def finalize
+          as_current_user { pass }
+        end
+
+        private
+
+        def current_user_id
+          action.input.fetch(:current_user_id)
+        end
+
+        def as_current_user
+          old          = User.current
+          User.current = User.find current_user_id
+          yield
+        ensure
+          User.current = old
+        end
+
+      end
+    end
+  end
+end

--- a/server/app/lib/actions/fusor/middleware/timeout.rb
+++ b/server/app/lib/actions/fusor/middleware/timeout.rb
@@ -1,0 +1,39 @@
+module Actions
+  module Fusor
+    module Middleware
+      class Timeout < Dynflow::Middleware
+
+        def plan(*args)
+          pass(*args).tap do
+            action.input[:timeout] ||= action.class::TIMEOUT
+          end
+        end
+
+        def run(*args)
+          assert_timeout_not_reached
+          pass(*args)
+        end
+
+        private
+
+        def assert_timeout_not_reached
+          action.output[:timeout_start] ||= Time.now.to_i
+
+          timeout_start = action.output[:timeout_start]
+          now = Time.now.to_i
+          timeout = action.input[:timeout]
+
+          if now - timeout_start > timeout
+            # clear timeout_start so that the action can be resumed/skipped
+            action.output[:timeout_start] = nil
+            fail(::Foreman::Exception,
+                 "You've reached the timeout set for this action. If the " +
+                 "action is still ongoing, you can click on the " +
+                 "\"Resume Deployment\" button to continue.")
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/server/app/models/fusor/concerns/host_orchestration_build_hook.rb
+++ b/server/app/models/fusor/concerns/host_orchestration_build_hook.rb
@@ -1,0 +1,24 @@
+module Fusor
+  module Concerns
+    module HostOrchestrationBuildHook
+      extend ActiveSupport::Concern
+
+      included do
+        before_provision :wake_up_orchestration
+      end
+
+      def wake_up_orchestration
+        key = HostOrchestrationBuildHook.cache_id(id)
+        ids = Rails.cache.read(key)
+        Rails.cache.delete key
+        ForemanTasks.dynflow.world.event *ids.values_at(:execution_plan_id, :step_id),
+                                         installed_at: installed_at
+      end
+
+      def self.cache_id(host_id)
+        "host.#{host_id}.wake_up_orchestration"
+      end
+
+    end
+  end
+end

--- a/server/lib/fusor/engine.rb
+++ b/server/lib/fusor/engine.rb
@@ -61,6 +61,7 @@ module Fusor
     config.to_prepare do
       # include concerns
       ::Hostgroup.send :include, Fusor::Concerns::HostgroupExtensions
+      ::Host::Managed.send :include, Fusor::Concerns::HostOrchestrationBuildHook
       # The following line disabled CSRF and should only be uncommented in development environments
       # ::ActionController::Base.send :include, Fusor::Concerns::ApplicationControllerExtension
     end


### PR DESCRIPTION
This pull request contains a couple of commits to improve the behavior of host provisioning as part of a deployment by ensuring the 'deploy' action is not completed until the provisioning of all hosts are provisioned.  For the case of rhev, it will also ensure that the provisioning of the hypervisors is completed before the engine is provisioned.

Refer to each commit abstract and description for details.
