### PR TITLE
fusor server: update activation key subscriptions to support multiple pools

### DIFF
--- a/server/app/lib/actions/fusor/activation_key/add_subscriptions.rb
+++ b/server/app/lib/actions/fusor/activation_key/add_subscriptions.rb
@@ -44,8 +44,8 @@ module Actions
 
         def associate_subscriptions(key)
           subscription_descriptions.each do |description|
-            subscription = key.available_subscriptions.find{ |key| key.description == description }
-            key.subscribe(subscription.cp_id) if subscription
+            subscriptions = key.available_subscriptions.find_all{ |key| key.description == description }
+            subscriptions.each{ |subscription| key.subscribe(subscription.cp_id) } if subscriptions
           end
         end
 


### PR DESCRIPTION
This commit will update the logic for attaching subscriptions to
an activation key to include all subscriptions of the configured
type.  This is needed as there could be multiple pools and a single
pool may not support the needs of the deployment.