### PR TITLE
fusor server: update to use org manifest, if one not provided on deployment

### DIFF
--- a/server/app/lib/actions/fusor/subscription/manage_manifest.rb
+++ b/server/app/lib/actions/fusor/subscription/manage_manifest.rb
@@ -39,13 +39,19 @@ module Actions
             end
 
           else
-            # If there is an upstream consumer, a manifest has been previously imported; therefore, we
-            # either need to refresh or delete it and import another
+            # If there is an upstream consumer, a manifest has been previously imported in to the org;
+            # therefore,if the user didn't associate a consumer with the deployment, use the existing upstream
+            # consumer from the organization; otherwise, either refresh it or delete it and import another
 
-            if upstream_consumer['uuid'] == deployment.upstream_consumer_uuid || deployment.upstream_consumer_uuid.nil?
+            if deployment.upstream_consumer_uuid.nil?
+              deployment.upstream_consumer_uuid = upstream_consumer['uuid']
+              deployment.save!
+
+            elsif upstream_consumer['uuid'] == deployment.upstream_consumer_uuid
               plan_action(::Actions::Katello::Provider::ManifestRefresh,
                           deployment.organization.redhat_provider,
                           upstream_consumer)
+
             else
               download_file_path = File.join("#{Rails.root}/tmp", "import_#{SecureRandom.hex(10)}.zip")
 


### PR DESCRIPTION
This is a minor change to the server-side behavior for handling the
subscription manifest.  It will support the following:
- If the user selects a subscription management application, it will
  be used when performing the deployment.
- If the user does not select a subscription management application, but
  a manifest has already been imported in to the organization, assign
  the one from the organization to the deployment and use it.
- If the user doesn't have either of the above, then error out indicating
  that one is required.