### PR TITLE
Updates to base-f and subs to allow units, move required indicator to left

### DIFF
--- a/fusor-ember-cli/app/components/base-f.js
+++ b/fusor-ember-cli/app/components/base-f.js
@@ -6,5 +6,11 @@ export default Ember.Component.extend({
   }.property(),
   inputClassSize: function () {
     return this.getWithDefault('inputSize', 'col-md-4');
+  }.property(),
+  showUnits: function() {
+    return this.get('unitsLabel') !== undefined;
+  }.property('unitsLabel'),
+  unitsClassSize: function () {
+    return this.getWithDefault('unitsSize', 'col-md-2');
   }.property()
 });

--- a/fusor-ember-cli/app/templates/components/base-f.hbs
+++ b/fusor-ember-cli/app/templates/components/base-f.hbs
@@ -2,15 +2,21 @@
    <div class="form-group">
 
       <label {{bind-attr class=":control-label labelClassSize class"}}>
-        {{label}}
         {{# if isRequired}}
           <span class='errorForValidation'>*</span>
         {{/if}}
+        {{label}}
       </label>
 
       <div {{bind-attr class="inputClassSize"}}>
         {{yield}}
       </div>
+
+      {{# if showUnits}}
+         <div {{bind-attr class="unitsClassSize"}}>
+           {{unitsLabel}}
+         </div>
+      {{/if}}
 
       <span class='help-block'>
       {{help-inline}}

--- a/fusor-ember-cli/app/templates/components/select-f.hbs
+++ b/fusor-ember-cli/app/templates/components/select-f.hbs
@@ -1,4 +1,4 @@
-{{#base-f label=label labelSize=labelSize inputSize=inputSize}}
+{{#base-f label=label labelSize=labelSize inputSize=inputSize unitsSize=unitsSize unitsLabel=unitsLabel isRequired=isRequired}}
 
   {{view Ember.Select content=content value=value optionLabelPath=optionLabelPath optionValuePath=optionValuePath selection=selection prompt=prompt class="form-control" id=cssId}}
 

--- a/fusor-ember-cli/app/templates/components/select-simple-f.hbs
+++ b/fusor-ember-cli/app/templates/components/select-simple-f.hbs
@@ -1,4 +1,4 @@
-{{#base-f label=label labelSize=labelSize inputSize=inputSize}}
+{{#base-f label=label labelSize=labelSize inputSize=inputSize unitsSize=unitsSize unitsLabel=unitsLabel isRequired=isRequired}}
 
   {{view Ember.Select content=content value=value selection=selection prompt=prompt class="form-control" id=cssId}}
 

--- a/fusor-ember-cli/app/templates/components/text-f.hbs
+++ b/fusor-ember-cli/app/templates/components/text-f.hbs
@@ -1,4 +1,4 @@
-{{#base-f label=label labelSize=labelSize inputSize=inputSize help-inline=help-inline errors=errors isRequired=isRequired}}
+{{#base-f label=label labelSize=labelSize inputSize=inputSize unitsSize=unitsSize unitsLabel=unitsLabel help-inline=help-inline errors=errors isRequired=isRequired}}
 
   {{input class="form-control" value=value placeholder=placeholder type=typeInput focus-out="showErrors" id=cssId}}
 

--- a/fusor-ember-cli/app/templates/components/textarea-f.hbs
+++ b/fusor-ember-cli/app/templates/components/textarea-f.hbs
@@ -1,4 +1,4 @@
-{{#base-f label=label labelSize=labelSize inputSize=inputSize help-inline=help-inline}}
+{{#base-f label=label labelSize=labelSize inputSize=inputSize unitsSize=unitsSize unitsLabel=unitsLabel isRequired=isRequired help-inline=help-inline}}
 
   {{! DRY THIS UP. HOW TO DO CONDITIONAL WITHIN HANDLEBARS HELPER}}
   {{#if rowsPassed}}


### PR DESCRIPTION
Update base-f to:
1) put asterisk to the left of the label when required
2) allow for a ‘units’ label after the input area

Update base-f based components to pass along
isRequired, unitsLabel, and unitsClassSize