### PR TITLE
fusor server: deploy: updates to support CloudForms content

### DIFF
--- a/server/app/lib/actions/fusor/content/enable_repositories.rb
+++ b/server/app/lib/actions/fusor/content/enable_repositories.rb
@@ -36,7 +36,8 @@ module Actions
               content.content.name == repo_details[:repository_set_name]
             end
 
-            substitutions = { basearch: repo_details[:basearch], releasever: repo_details[:releasever] }
+            substitutions = { basearch: repo_details[:basearch] }
+            substitutions[:releasever] = repo_details[:releasever] if repo_details[:releasever]
             if repo_mapper(product, product_content.content, substitutions).find_repository
               Rails.logger.info("Repository already enabled for: Product: #{product.name},"\
                                 " Repository Set: #{product_content.content.name}")

--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -46,14 +46,10 @@
         :basearch: "x86_64"
         :releasever: "6Server"
 
-  :puppet_classes:
-    - :name: "ovirt"
-    - :name: "ovirt::engine::config"
-    - :name: "ovirt::engine::packages"
-    - :name: "ovirt::engine::setup"
-    - :name: "ovirt::engine::import_template"
-    - :name: "ovirt::engine::run_vm"
-    - :name: "ovirt::hypervisor::packages"
+    :cloudforms:
+      - :product_name: "Red Hat CloudForms"
+        :repository_set_name: "Red Hat CloudForms Management Engine 5.3 (Files)"
+        :basearch: "x86_64"
 
   :host_groups:
     :rhev:


### PR DESCRIPTION
This commit contains several changes that are needed to support
CloudForms content during a 'deploy'.  Such as:
- Enabling the CloudForms Red Hat repository
- Updates to support file based repositories.  e.g.
  - do not include them in activation keys & content views
- Updates to ensure that we correctly execute multiple passes
  on content views as new products are introduced.
This commit contains a couple of changes that are needed to support
CloudForms content.