### PR TITLE
fusor server: update trigger provisioning of hosts to be in sequence

### DIFF
--- a/server/app/lib/actions/fusor/deployment/deploy_rhev.rb
+++ b/server/app/lib/actions/fusor/deployment/deploy_rhev.rb
@@ -22,13 +22,15 @@ module Actions
           fail _("Unable to locate a RHEV Engine Host") unless deployment.rhev_engine_host
 
           sequence do
+            deployment.discovered_hosts.each do |host|
+              plan_action(::Actions::Fusor::Host::TriggerProvisioning,
+                          deployment,
+                          "RHEV-Hypervisor",
+                          host)
+            end
+
             concurrence do
               deployment.discovered_hosts.each do |host|
-                plan_action(::Actions::Fusor::Host::TriggerProvisioning,
-                            deployment,
-                            "RHEV-Hypervisor",
-                            host)
-
                 plan_action(::Actions::Fusor::Host::WaitUntilProvisioned,
                             host)
               end


### PR DESCRIPTION
This commit will cause the trigger of provisioning for the hypervisor
hosts to be done in 'sequence' vs using 'concurrence' (i.e. parallel).
This is to address a deadlock issue that was observed by the simultaneous
'host.save!' that occurs when the trigger occurs.

The error observed looked similar to:

ActiveRecord::StatementInvalid: PGError: ERROR:  deadlock detected
DETAIL:  Process 7957 waits for ShareLock on transaction 74849; blocked by process 7961.
Process 7961 waits for ExclusiveLock on tuple (0,7) of relation 18181 of database 17944; blocked by process 7957.
HINT:  See server log for query details.
: UPDATE "environments" SET "hosts_count" = 1 WHERE "environments"."id" = 2