### PR TITLE
fusor server: update foreman puppet classes during content view publishing

### DIFF
--- a/server/app/lib/actions/fusor/content/publish_content_view.rb
+++ b/server/app/lib/actions/fusor/content/publish_content_view.rb
@@ -59,7 +59,20 @@ module Actions
                           composite_view.version(deployment.organization.library),
                           deployment.lifecycle_environment)
             end
+
+            plan_self(:content_view_id => composite_view.id,
+                      :environment_id => deployment.lifecycle_environment.id)
           end
+        end
+
+        def run
+          content_view = ::Katello::ContentView.find(input[:content_view_id])
+          environment  = ::Katello::KTEnvironment.find(input[:environment_id])
+
+          # The foreman puppet environment is typically updated in the finalize phase
+          # of content publish/promotion; however, we need this to occur earlier,
+          # since we'll need the puppet classes created by the update.
+          ::Katello::Foreman.update_puppet_environment(content_view, environment)
         end
 
         private

--- a/server/app/models/fusor/concerns/hostgroup_extensions.rb
+++ b/server/app/models/fusor/concerns/hostgroup_extensions.rb
@@ -28,15 +28,17 @@ module Fusor::Concerns::HostgroupExtensions
   end
 
   def set_param_value_if_changed(puppetclass, key, value)
-    lookup_key         = puppetclass.class_params.where(:key => key).first
-    lookup_value_value = current_param_value(lookup_key)[0]
-    current_value      = lookup_key.value_before_type_cast(lookup_value_value).to_s.chomp
-    if current_value != value
-      lookup       = LookupValue.where(:match         => hostgroup.send(:lookup_value_match),
-                                       :lookup_key_id => lookup_key.id).first_or_initialize
-      lookup.value = value
-      lookup.use_puppet_default = value.blank? ? true : false
-      lookup.save!
+    if puppetclass
+      lookup_key         = puppetclass.class_params.where(:key => key).first
+      lookup_value_value = current_param_value(lookup_key)[0]
+      current_value      = lookup_key.value_before_type_cast(lookup_value_value).to_s.chomp
+      if current_value != value
+        lookup       = LookupValue.where(:match         => hostgroup.send(:lookup_value_match),
+                                         :lookup_key_id => lookup_key.id).first_or_initialize
+        lookup.value = value
+        lookup.use_puppet_default = value.blank? ? true : false
+        lookup.save!
+      end
     end
   end
 end


### PR DESCRIPTION
This commit addresses an issue where we observed puppet classes
not getting assigned to the hostgroups when a deployment
was using a lifecycle environment (e.g. Library, dev...etc).
The issue was that the puppet classes were not being imported
in to foreman until the 'finalize' phase (of the the
content view publish/promotion action).  This causes troubles for
fusor, as we need to have those imported during the run phase
so that they are available for the hostgroup assignments.