### PR TITLE
Re-enable deployment validation for when we deploy only

### DIFF
--- a/server/app/lib/fusor/validators/deployment_validator.rb
+++ b/server/app/lib/fusor/validators/deployment_validator.rb
@@ -3,7 +3,7 @@ module Fusor
     class DeploymentValidator < ActiveModel::Validator
       def validate(deployment)
         if not (deployment.deploy_rhev or deployment.deploy_cfme or deployment.deploy_openstack)
-          deployment.errors[:deploy_rhev] << _('You must deploy something...')
+          deployment.errors[:base] << _('You must deploy something...')
         end
 
         if deployment.deploy_rhev

--- a/server/app/models/fusor/deployment.rb
+++ b/server/app/models/fusor/deployment.rb
@@ -12,9 +12,9 @@
 
 module Fusor
   class Deployment < ActiveRecord::Base
-    # can't use simple validates_with, need to save empty object and validate
-    # before deploy
-    #validates_with Fusor::Validators::DeploymentValidator
+    # on update because we don't want to validate the empty object when
+    # it is first created
+    validates_with Fusor::Validators::DeploymentValidator, on: :update
     belongs_to :organization
     belongs_to :lifecycle_environment, :class_name => "Katello::KTEnvironment"
 


### PR DESCRIPTION
The object here is for the DeploymentValidator to not be called when we create / update the deployment (because we create them empty and then update as the user progresses through pages), but that it should be called when users calls deploy().

This should make the unit tests work again (and give appropriate feedback to the user if something is invalid when they go to deploy), while not breaking the flow of the ui.

The thing I'm nervous about is the changes made to the deploy method of the controllers, I was not able to test that manually in the UI because I was having a problem with importing subscription manifests, but I tested via the API and it seemed to work.