### PR TITLE
customer portal - remove leading slash from resource

### DIFF
--- a/server/app/lib/fusor/resources/customer_portal.rb
+++ b/server/app/lib/fusor/resources/customer_portal.rb
@@ -64,7 +64,7 @@ module Fusor
 
         def self.rest_client(path, credentials)
           settings = SETTINGS[:fusor][:customer_portal]
-          prefix = (settings && settings[:url]) || "https://subscription.rhn.redhat.com:443/subscription/"
+          prefix = (settings && settings[:url]) || "https://subscription.rhn.redhat.com:443/subscription"
 
           if ::Katello.config.cdn_proxy && ::Katello.config.cdn_proxy.host
             proxy_config = ::Katello.config.cdn_proxy


### PR DESCRIPTION
All of a sudden, we are observing errors 404 errors when proxying
requests to the customer portal.

The errors are similar to:

2015-06-30 14:12:55 [D] Sending GET request to Customer Portal: /users/rhci-test/owners
2015-06-30 14:12:56 [E] exception when talking to a remote client: 404 Resource Not Found RestClient::ResourceNotFound: 404 Resource Not Found
Body: {"displayMessage":"Runtime Error Could not find resource for relative : //users/rhci-test/owners of full path: http://subscription.rhn.redhat.com/candlepin//users/rhci-test/owners at

This commit removes the additional / located at the end of the base URL.
Once removed, I am no longer seeing the errors and am able to properly
interact with the customer portal.