### PR TITLE
fusor server: deploy: activation key : assign 0 quantity

### DIFF
--- a/server/app/lib/actions/fusor/activation_key/add_subscriptions.rb
+++ b/server/app/lib/actions/fusor/activation_key/add_subscriptions.rb
@@ -45,7 +45,7 @@ module Actions
         def associate_subscriptions(key)
           subscription_descriptions.each do |description|
             subscriptions = key.available_subscriptions.find_all{ |key| key.description == description }
-            subscriptions.each{ |subscription| key.subscribe(subscription.cp_id) } if subscriptions
+            subscriptions.each{ |subscription| key.subscribe(subscription.cp_id, 0) } if subscriptions
           end
         end
 


### PR DESCRIPTION
Updating the logic for activation keys to use 0 quantity which
is treated by candlepin as 'automatic'.