### PR TITLE
Adding a sleep between saving a Host to build it and rebooting it.

### DIFF
--- a/server/app/lib/actions/fusor/host/trigger_provisioning.rb
+++ b/server/app/lib/actions/fusor/host/trigger_provisioning.rb
@@ -28,6 +28,7 @@ module Actions
           host = ::Host::Base.find(input[:host_id])
 
           success, host = assign_host_to_hostgroup(host, hostgroup)
+          sleep_before_reboot
           reboot_host(host) if host
         end
 
@@ -154,6 +155,21 @@ module Actions
               joins(:organizations).
               where("taxonomies.id in (?)", [deployment.organization.id]).first
         end
+
+        def sleep_before_reboot
+          sleep_seconds = 60
+          if SETTINGS[:fusor][:provision]
+            if SETTINGS[:fusor][:provision][:sleep_before_reboot]
+              sleep_seconds = SETTINGS[:fusor][:provision][:sleep_before_reboot].to_i
+              Rails.logger.warn "XXX using setting for [:fusor][:provision][:sleep_before_reboot] = #{sleep_seconds} seconds"
+            end
+          end
+
+          Rails.logger.warn "XXX sleeping for #{sleep_seconds} seconds"
+          sleep sleep_seconds
+          Rails.logger.warn "XXX woke up from sleep for #{sleep_seconds} seconds"
+        end
+
       end
     end
   end

--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -1,4 +1,7 @@
 :fusor:
+  :provision:
+    :sleep_before_reboot: "60"
+
   :content:
     :content_view:
       :composite_view_name: "Fusor Deployment"


### PR DESCRIPTION
This is a short term workaround until we can learn a way to determine if the
required callbacks have executed after the Host.save! has completed.

Without this change we run the risk of intermittent problems provisioning a node.
We've seen the problems with 2+ hypervisors, doesn't seem to appear with a single
node being provisioned