### PR TITLE
Add a bit more validation to nfs paths

### DIFF
--- a/server/app/lib/fusor/validators/deployment_validator.rb
+++ b/server/app/lib/fusor/validators/deployment_validator.rb
@@ -32,9 +32,18 @@ module Fusor
 
             if deployment.rhev_share_path.empty?
               deployment.errors[:rhev_share_path] << _('NFS share specified but missing path to the share')
+            else
+              # See https://tools.ietf.org/html/rfc2224#section-1
+              # NFS paths cannot end in slash or contain non-ascii chars
+              if deployment.rhev_share_path.end_with?("/") && deployment.rhev_share_path.length > 1
+                deployment.errors[:rhev_share_path] << _('NFS path specified ends in a "/", which is invalid')
+              end
+
+              if not deployment.rhev_share_path.ascii_only?
+                deployment.errors[:rhev_share_path] << _('NFS path specified contains non-ascii characters, which is invalid')
+              end
             end
           end
-
 
           if deployment.rhev_storage_type == 'Local' 
             if deployment.rhev_local_storage_path.empty?

--- a/server/test/models/deployment_test.rb
+++ b/server/test/models/deployment_test.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'test_plugin_helper'
 
 class DeploymentTest < ActiveSupport::TestCase
@@ -90,6 +91,20 @@ class DeploymentTest < ActiveSupport::TestCase
     rhev.rhev_storage_type = 'NFS'
     rhev.rhev_share_path = nil
     assert_not rhev.save, "Saved rhev deployment that used nfs but had no path"
+  end
+
+  test "should not save rhev deployment if nfs path ends in slash" do
+    rhev = fusor_deployments(:rhev)
+    rhev.rhev_storage_type = 'NFS'
+    rhev.rhev_share_path = '/invalid/path/'
+    assert_not rhev.save, "Saved rhev deployment who's nfs path ended in a slash"
+  end
+
+  test "should not save rhev deployment if nfs path contains non-ascii characters" do
+    rhev = fusor_deployments(:rhev)
+    rhev.rhev_storage_type = 'NFS'
+    rhev.rhev_share_path = '/å'
+    assert_not rhev.save, "Saved rhev deployment who's nfs path contained non-ascii characters"
   end
 
   test "should not save rhev deployment if storage type is local and missing local path" do


### PR DESCRIPTION
Add additional validation for NFS paths to ensure that they'll work. Specifically, nfs paths cannot end in / or have non-ascii characters.