### PR TITLE
Silences logging noise from ForemanTasksController#show, uses SilencedLogger from Katello

### DIFF
--- a/server/lib/fusor/engine.rb
+++ b/server/lib/fusor/engine.rb
@@ -12,12 +12,15 @@ module Fusor
       # Add additional paths below if you want logging silenced
       #  we want the polling of ForemanTasksController#show silenced to reduce noise in logs
       silenced_paths = ["api/v21/foreman_tasks/"]
-
-      Rails.logger.warn "fusor_server will update 'Katello.config.logging.ignored_paths' to silence logging of paths '#{silenced_paths}'"
-      for sil_path in silenced_paths
-        Katello.config.logging.ignored_paths.push(sil_path)
+        
+      if Katello.config.respond_to? 'logging' and Katello.config.logging.respond_to? 'ignored_paths'
+        for sil_path in silenced_paths
+          Katello.config.logging.ignored_paths.push(sil_path)
+        end
+        Rails.logger.warn "fusor_server has added '#{silenced_paths}' to 'Katello.config.logging.ignored_paths': #{Katello.config.logging.ignored_paths}"
+      else
+        Rails.logger.warn "fusor_server did not find 'Katello.config.logging.ignored_paths' available, skipping silence of logs for '#{silenced_paths}'"
       end
-      Rails.logger.warn "fusor_server has updated 'Katello.config.logging.ignored_paths' to #{Katello.config.logging.ignored_paths}"
     end
 
     # Add any db migrations

--- a/server/lib/fusor/engine.rb
+++ b/server/lib/fusor/engine.rb
@@ -8,6 +8,18 @@ module Fusor
     config.autoload_paths += Dir["#{config.root}/app/overrides"]
     config.autoload_paths += Dir["#{config.root}/app/serializers"]
 
+    initializer 'fusor.silenced_logger', :after => :build_middleware_stack do |app|
+      # Add additional paths below if you want logging silenced
+      #  we want the polling of ForemanTasksController#show silenced to reduce noise in logs
+      silenced_paths = ["api/v21/foreman_tasks/"]
+
+      Rails.logger.warn "fusor_server will update 'Katello.config.logging.ignored_paths' to silence logging of paths '#{silenced_paths}'"
+      for sil_path in silenced_paths
+        Katello.config.logging.ignored_paths.push(sil_path)
+      end
+      Rails.logger.warn "fusor_server has updated 'Katello.config.logging.ignored_paths' to #{Katello.config.logging.ignored_paths}"
+    end
+
     # Add any db migrations
     initializer "fusor.load_app_instance_data" do |app|
       app.config.paths['db/migrate'] += Fusor::Engine.paths['db/migrate'].existent


### PR DESCRIPTION

We are polling ForemanTasksController#show, hence our log file has many unneeded
statements related to the logging of #show being called, this is making it hard
to sift through the log for useful info.