### PR TITLE
Use 6.7 kickstart, sync rhel optional, don't sync hypervisor repo

### DIFF
--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -29,11 +29,6 @@
         :basearch: "x86_64"
         :releasever: "6Server"
 
-      - :product_name: "Red Hat Enterprise Linux Server"
-        :repository_set_name: "Red Hat Enterprise Linux 6 Server - Optional (RPMs)"
-        :basearch: "x86_64"
-        :releasever: "6Server"
-
       - :product_name: "Red Hat Enterprise Virtualization"
         :repository_set_name: "Red Hat Enterprise Virtualization Management Agents (RPMs)"
         :basearch: "x86_64"

--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -17,7 +17,7 @@
       - :product_name: "Red Hat Enterprise Linux Server"
         :repository_set_name: "Red Hat Enterprise Linux 6 Server (Kickstart)"
         :basearch: "x86_64"
-        :releasever: "6.6"
+        :releasever: "6.7"
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :repository_set_name: "Red Hat Enterprise Linux 6 Server - RH Common (RPMs)"
@@ -29,8 +29,8 @@
         :basearch: "x86_64"
         :releasever: "6Server"
 
-      - :product_name: "Red Hat Enterprise Virtualization"
-        :repository_set_name: "Red Hat Enterprise Virtualization Hypervisor (RPMs)"
+      - :product_name: "Red Hat Enterprise Linux Server"
+        :repository_set_name: "Red Hat Enterprise Linux 6 Server - Optional (RPMs)"
         :basearch: "x86_64"
         :releasever: "6Server"
 


### PR DESCRIPTION
1) We should use the RHEL 6.7 kickstart repo instead of 6.6 to avoid the metadata sync issue it's having.

2) We should not be syncing / using the RHEV Hypervisor repo. That is for the RHEV hosts that are running only the thin RHEV Hypervisor OS, ie they do not have RHEL installed.

3) According to the RHEV docs, we need to sync / enable RHEL Optional on the RHEL Host machines in order to be able to install the RHEV agent.