### PR TITLE
fusor server: store cfme ip address during deployment

### DIFF
--- a/server/app/lib/actions/fusor/deployment/cloud_forms/deploy.rb
+++ b/server/app/lib/actions/fusor/deployment/cloud_forms/deploy.rb
@@ -80,6 +80,9 @@ module Actions
               plan_action(::Actions::Fusor::Deployment::CloudForms::AddRhevProvider,
                           deployment,
                           get_ip_action.output[:ip])
+
+              plan_action(::Actions::Fusor::Deployment::Update, deployment,
+                          { cfme_address: get_ip_action.output[:ip] })
             end
           end
 

--- a/server/app/lib/actions/fusor/deployment/update.rb
+++ b/server/app/lib/actions/fusor/deployment/update.rb
@@ -1,0 +1,33 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Fusor
+    module Deployment
+      class Update < Actions::Base
+        def humanized_name
+          _("Update Deployment")
+        end
+
+        def plan(deployment, deployment_params)
+          plan_self(:deployment_id => deployment.id,
+                    :deployment_params => deployment_params)
+        end
+
+        def run
+          deployment = ::Fusor::Deployment.find(input[:deployment_id])
+          deployment.update_attributes!(input[:deployment_params])
+        end
+      end
+    end
+  end
+end

--- a/server/db/migrate/20150728201308_add_cfme_address_to_deployment.rb
+++ b/server/db/migrate/20150728201308_add_cfme_address_to_deployment.rb
@@ -1,0 +1,5 @@
+class AddCfmeAddressToDeployment < ActiveRecord::Migration
+  def change
+    add_column :fusor_deployments, :cfme_address, :string
+  end
+end


### PR DESCRIPTION
This commit adds the 'cfme_address' attribute to the
deployment object.  It will store in it the IP address
of the CVME virtual machine created during the deployment.