### PR TITLE
Ember-drag-drop with firefox fix served from fusor github org

### DIFF
--- a/fusor-ember-cli/package.json
+++ b/fusor-ember-cli/package.json
@@ -36,6 +36,7 @@
     "ember-data": "1.0.0-beta.16.1",
     "ember-devtools": "^3.1.0",
     "ember-drag-drop": "^0.1.4",
+    "ember-drag-drop": "fusor/ember-drag-drop",
     "ember-export-application-global": "^1.0.2",
     "ember-idx-button": "0.1.3",
     "ember-idx-forms": "0.5.1",


### PR DESCRIPTION
(cherry picked from commit 7a3f0cf198e21dfeabd9d32e3a9453a750e6677e)