### PR TITLE
Update so we will silence all requests for foreman_tasks polling

### DIFF
--- a/server/lib/fusor/engine.rb
+++ b/server/lib/fusor/engine.rb
@@ -11,7 +11,7 @@ module Fusor
     initializer 'fusor.silenced_logger', :after => :build_middleware_stack do |app|
       # Add additional paths below if you want logging silenced
       #  we want the polling of ForemanTasksController#show silenced to reduce noise in logs
-      silenced_paths = ["api/v21/foreman_tasks/"]
+      silenced_paths = ["api/v21/foreman_tasks"]
         
       if Katello.config.respond_to? 'logging' and Katello.config.logging.respond_to? 'ignored_paths'
         for sil_path in silenced_paths


### PR DESCRIPTION
We used to poll to /api/v21/foreman_tasks/ID
now we are polling to
 /api/v21/foreman_tasks?search=parent_task_id.....

So this PR removes the '/' at the end of foreman_tasks/