### PR TITLE
Hosts should be Discovered, not base, and update travisci to use new …

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -3,12 +3,6 @@
 if [ $1 == "install" ]; then 
   cd ..
   gem install bundler
-  # I don't think these are needed in Travis Ci environment, will have to test though
-  #sudo su -c 'echo "local all all trust" > /etc/postgresql/9.1/main/pg_hba.conf'
-  #sudo su -c 'echo "host all all 127.0.0.1/32 trust" >> /etc/postgresql/9.1/main/pg_hba.conf'
-  #sudo su -c 'echo "host all all ::1/128 trust" >> /etc/postgresql/9.1/main/pg_hba.conf'
-  #sudo service postgresql restart
-  #sudo -u postgres createuser katello --superuser
 
   # Our db migrations don't apply to foreman 1.8-stable and katello-2.2, but we don't want our tests breaking everytime develop and master branches are unstable either. There may be a better way to do this, but for now let's get develop / master branches and then checkout out a known working state.
   git clone -b develop https://github.com/theforeman/foreman.git
@@ -43,7 +37,7 @@ if [ $1 == "install" ]; then
   # katello / fusor fixtures in to forman so they all will be loaded
   cd test/fixtures
   ln -s ../../../fusor/server/test/fixtures/* .
-  ln -s ln -s ../../../katello/test/fixtures/models/* .
+  ln -s ../../../katello/test/fixtures/models/* .
 else
   cd ../foreman
   rake db:create

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,24 @@ branches:
 notifications:
  email: false
 
-sudo: required
+sudo: false
 
-# we break the entire process up into smaller bits to avoid travisci timing out
-before_install:
- - sudo apt-get update -qq
- - sudo apt-get install libvirt-dev libxml2-dev libxslt1-dev ruby-dev libmysqld-dev libpq-dev postgresql postgresql-contrib -y
- 
+addons:
+  apt:
+    packages:
+      - libvirt-dev
+      - libxml2-dev
+      - libxslt1-dev
+      - ruby-dev
+      - libmysqld-dev
+      - libpq-dev
+      - postgresql
+      - postgresql-contrib
+
 install: ./.travis.sh install
 
 before_script: ./.travis.sh migrate
 
-script: 
+script:
  - cd ../foreman
  - rake test:fusor

--- a/server/test/test_plugin_helper.rb
+++ b/server/test/test_plugin_helper.rb
@@ -54,7 +54,7 @@ module FixtureTestCase
     # fusor fixtures
     self.set_fixture_class :fusor_deployments => "Fusor::Deployment"
     self.set_fixture_class :fusor_deployment_hosts => "Fusor::DeploymentHost"
-    self.set_fixture_class :hosts => "::Host::Base"
+    self.set_fixture_class :hosts => "::Host::Discovered"
 
     load_fixtures
     fixtures(:all)


### PR DESCRIPTION
…infrastructure

This pull request makes 2 changes:

1) Update the fixuture class to be Host::Discovered, not Host::Base. In real life hosts are never Host::Base, just either Discovered or Managed.

2) Update TravisCI infrastructure to use their new container-based solution, now that they've added support for installing packages in containers. This should hopefully make builds faster and more future-proof.