### PR TITLE
fusor server: set open_timeout when interacting with cfme to add rhev provider

### DIFF
--- a/server/app/lib/utils/cloud_forms/provider.rb
+++ b/server/app/lib/utils/cloud_forms/provider.rb
@@ -21,6 +21,7 @@ module Utils
 
         agent = Mechanize.new
         agent.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        agent.open_timeout = 180
 
         # 2015/07/23 jesusr - change this to use cfme_admin_password instead of
         # smartvm once we have the entry in the UI.


### PR DESCRIPTION
We've seen some intermittent connection timeouts when attempting to
add a RHEV provider to CFME.  This commit will set the connection
open timeout, in an attempt to reduce the chances that this occurs.