### PR TITLE
refactor hostgroup OS configuration to accomodate multiple bootable OSs

### DIFF
--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -65,6 +65,9 @@
        - :parent: "Fusor Base"
 
        - :name: "RHEV-Engine"
+         :os: "RedHat"
+         :major: "6"
+         :minor: "7"
          :parent: :root_deployment
          :puppet_classes:
            - :name: "ovirt"
@@ -79,6 +82,9 @@
                :override: "iptables"
 
        - :name: "RHEV-Hypervisor"
+         :os: "RedHat"
+         :major: "6"
+         :minor: "7"
          :parent: :root_deployment
          :puppet_classes:
            - :name: "ovirt"


### PR DESCRIPTION
This commit moves the OS configuration from the top-level deployment hostgroup to the machine-type hostgroups, and makes the "what OS do I install" decision explicit and configurable instead of guessing at it.

This was originally motivated out of necessity because you could have a single deployment that deployed both RHEV (which needed to be installed on RHEL 6) and OpenStack (which needed to be installed on RHEL 7). That motivation may not longer be immediately present if we install the OpenStack undercloud from the ISO, but I believe this is still the correct way to do this.