### PR TITLE
1253057 - Update to use domain name from hostgroup 'Fusor Base'

### DIFF
--- a/fusor-ember-cli/app/routes/review/installation.js
+++ b/fusor-ember-cli/app/routes/review/installation.js
@@ -15,10 +15,9 @@ export default Ember.Route.extend({
     controller.set('showSpinner', false);
     controller.set('showErrorMessage', false);
     this.store.find('hostgroup').then(function(results) {
-        var engineDomain = results.filterBy('name', 'RHEV-Engine').get('firstObject').get('domain.name');
-        var hypervisorDomain = results.filterBy('name', 'RHEV-Hypervisor').get('firstObject').get('domain.name');
-        controller.set('engineDomain', engineDomain);
-        controller.set('hypervisorDomain', hypervisorDomain);
+        var fusorBaseDomain = results.filterBy('name', 'Fusor Base').get('firstObject').get('domain.name');
+        controller.set('engineDomain', fusorBaseDomain);
+        controller.set('hypervisorDomain', fusorBaseDomain);
     });
     return this.modelFor('deployment');
   }


### PR DESCRIPTION
@isratrade please review

This PR suggests we use the hostgroup "Fusor Base" to determine the domain name for the hosts in a deployment.

Currently we are looking at the host groups:
 "RHEV-Engine"
 "RHEV-Hypervisor"

I believe these hosts groups are created after a deployment is kicked off, so they won't be available on the first run of the webui.

I tested this on a setup and it resolved the issue, I saw the updated domain name reflected in the review page.
