### PR TITLE
Fixes BZ#1247918 - ipmi iface mac can't be blank (iface should not be managed)

### DIFF
--- a/server/app/lib/actions/fusor/host/trigger_provisioning.rb
+++ b/server/app/lib/actions/fusor/host/trigger_provisioning.rb
@@ -96,12 +96,6 @@ module Actions
           # clear all virtual devices that may have been created during previous assignment
           # host.clean_vlan....
           host.interfaces.virtual.map(&:destroy)
-          # by default foreman will try to manage all NICs unless user disables manually after assignment
-          #host.make_all_interfaces_managed
-          host.interfaces.each do |interface|
-            interface.managed = true
-            interface.save!
-          end
 
           # I do not [know] why but the final save! adds following condytion to the update SQL command
           # "WHERE "hosts"."type" IN ('Host::Managed') AND "hosts"."id" = 283"


### PR DESCRIPTION
We should let Foreman manage just the first interface as is normally done. If we set all interfaces, including ipmi interfaces, as this does, we need to provide a MAC for each and there is no way that Foreman can find the ipmi interface MAC Address.