### PR TITLE
Add CSRF token to openstack PUT and POSTS so that it will work with ssl on

### DIFF
--- a/fusor-ember-cli/app/controllers/assign-nodes.js
+++ b/fusor-ember-cli/app/controllers/assign-nodes.js
@@ -108,11 +108,16 @@ export default Ember.Controller.extend(DeploymentControllerMixin, {
 
     me.set('loadingSpinnerText', "Loading...");
     me.set('showLoadingSpinner', true);
+    var token = Ember.$('meta[name="csrf-token"]').attr('content');
 
     Ember.$.ajax({
       url: '/fusor/api/openstack/deployment_plans/' + plan.get('id') + '/update_role_flavor',
       type: 'PUT',
-      contentType: 'application/json',
+      headers: {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "X-CSRF-Token": token,
+      },
       data: JSON.stringify(data),
       success: function() {
         me.set('showLoadingSpinner', false);

--- a/fusor-ember-cli/app/controllers/register-nodes.js
+++ b/fusor-ember-cli/app/controllers/register-nodes.js
@@ -441,12 +441,17 @@ export default Ember.Controller.extend(DeploymentControllerMixin, {
       },
       address: node.nicMacAddress
     };
+    var token = Ember.$('meta[name="csrf-token"]').attr('content');
 
     this.set('initRegInProcess', true);
     Ember.$.ajax({
       url: '/fusor/api/openstack/nodes',
       type: 'POST',
-      contentType: 'application/json',
+      headers: {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "X-CSRF-Token": token,
+      },
       data: JSON.stringify({ 'node': createdNode }),
       success: function(registeredNode) {
         me.set('initRegInProcess', false);

--- a/fusor-ember-cli/app/controllers/undercloud-deploy.js
+++ b/fusor-ember-cli/app/controllers/undercloud-deploy.js
@@ -50,12 +50,17 @@ export default Ember.Controller.extend(DeploymentControllerMixin, {
 
       var promiseFunction = function (resolve) {
         me.set('deploymentError', null);
+      var token = Ember.$('meta[name="csrf-token"]').attr('content');
 
       Ember.$.ajax({
           url: '/fusor/api/openstack/underclouds',
           type: 'POST',
           data: JSON.stringify(data),
-          contentType: 'application/json',
+          headers: {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "X-CSRF-Token": token,
+          },
           success: function(response) {
             promise.then(fulfill);
             console.log('create success');


### PR DESCRIPTION
In order to work with ssl turned on any PUT and POST requests must include the CSRF token. This adds it into the OpenStack pages so that those calls will work properly.