### PR TITLE
Have an OpenStack deployment register the undercloud back to Satellite.

### DIFF
--- a/server/app/controllers/fusor/api/openstack/underclouds_controller.rb
+++ b/server/app/controllers/fusor/api/openstack/underclouds_controller.rb
@@ -54,6 +54,8 @@ module Fusor
             else
               deployment.openstack_undercloud_password = admin
               deployment.openstack_undercloud_ip_addr = ip_addr
+              deployment.openstack_undercloud_user = underuser
+              deployment.openstack_undercloud_user_password = underpass
               deployment.save(:validate => false)
               render :json => {:undercloud => deployment.id}
             end

--- a/server/app/lib/actions/fusor/deployment/openstack/ssh_command.rb
+++ b/server/app/lib/actions/fusor/deployment/openstack/ssh_command.rb
@@ -1,0 +1,49 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions::Fusor::Deployment::OpenStack
+  class SshCommand < Actions::Base
+    def humanized_name
+      _("SSH and run an arbitrary command on the Undercloud")
+    end
+
+    def plan(deployment, cmd)
+      plan_self(deployment_id: deployment.id,
+                cmd: cmd)
+    end
+
+    def run
+      Rails.logger.debug "================ SshCommand run method ===================="
+
+      deployment = ::Fusor::Deployment.find(input[:deployment_id])
+
+      ssh_host = deployment.openstack_undercloud_ip_addr
+      ssh_username = deployment.openstack_undercloud_user
+      ssh_password = deployment.openstack_undercloud_user_password
+
+      client = Utils::Fusor::SSHConnection.new(ssh_host, ssh_username, ssh_password)
+      client.on_complete(lambda { ssh_command_completed })
+      client.on_failure(lambda { ssh_command_failed })
+      client.execute(input[:cmd])
+
+      Rails.logger.debug "================ Leaving SshCommand run method ===================="
+    end
+
+    def ssh_command_completed
+      Rails.logger.info "Command succeeded: " + input[:cmd]
+    end
+
+    def ssh_command_failed
+      fail _("Command failed: " + input[:cmd])
+    end
+  end
+end

--- a/server/app/lib/actions/fusor/deployment/openstack/transfer_consumer_rpm.rb
+++ b/server/app/lib/actions/fusor/deployment/openstack/transfer_consumer_rpm.rb
@@ -1,0 +1,48 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+require 'net/scp'
+
+module Actions::Fusor::Deployment::OpenStack
+  class TransferConsumerRpm < Actions::Base
+    def humanized_name
+      _("Transfer Satellite's consumer rpm to Undercloud machine")
+    end
+
+    def plan(deployment)
+      plan_self(deployment_id: deployment.id)
+    end
+
+    def run
+      Rails.logger.debug "================ TransferConsumerRpm run method ===================="
+
+      deployment = ::Fusor::Deployment.find(input[:deployment_id])
+
+      latest_consumer_rpm = '/var/www/html/pub/katello-ca-consumer-latest.noarch.rpm'
+      scp_file(deployment, latest_consumer_rpm)
+
+
+      Rails.logger.debug "================ Leaving TransferConsumerRpm run method ===================="
+    end
+
+    private
+
+    def scp_file(deployment, image_file)
+      host_address = deployment.openstack_undercloud_ip_addr
+      user = deployment.openstack_undercloud_user
+      password = deployment.openstack_undercloud_user_password
+      Net::SCP.start(host_address, user, :password => password, :paranoid => false) do |scp|
+        scp.upload!(image_file, "/tmp/")
+      end
+    end
+
+  end
+end

--- a/server/app/lib/actions/fusor/deployment/openstack/transfer_consumer_rpm.rb
+++ b/server/app/lib/actions/fusor/deployment/openstack/transfer_consumer_rpm.rb
@@ -29,7 +29,6 @@ module Actions::Fusor::Deployment::OpenStack
       latest_consumer_rpm = '/var/www/html/pub/katello-ca-consumer-latest.noarch.rpm'
       scp_file(deployment, latest_consumer_rpm)
 
-
       Rails.logger.debug "================ Leaving TransferConsumerRpm run method ===================="
     end
 

--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -69,6 +69,11 @@
         :basearch: "x86_64"
         :releasever: "7Server"
 
+      - :product_name: "Red Hat Enterprise Linux Server"
+        :repository_set_name: "Red Hat Enterprise Linux 7 Server - RH Common (RPMs)"
+        :basearch: "x86_64"
+        :releasever: "7Server"
+
       - :product_name: "Red Hat OpenStack"
         :repository_set_name: "Red Hat OpenStack 7.0 for RHEL 7 (RPMs)"
         :basearch: "x86_64"

--- a/server/db/migrate/20150911141415_add_undercloud_user.rb
+++ b/server/db/migrate/20150911141415_add_undercloud_user.rb
@@ -1,0 +1,6 @@
+class AddUndercloudUser < ActiveRecord::Migration
+  def change
+    add_column :fusor_deployments, :openstack_undercloud_user, :string
+    add_column :fusor_deployments, :openstack_undercloud_user_password, :string
+  end
+end


### PR DESCRIPTION
This will cause the undercloud machine to register back to Satellite and set up the appropriate repos / content views and install access-insights if necessary. It notably does not configure the undercloud for Puppet management, as the puppet cert signing process is complicated and fragile to try to do programatically. Puppet configuration is left as an exercise to the user.