### PR TITLE
Add the scl repo for the undercloud so that we can install egon

### DIFF
--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -84,6 +84,11 @@
         :basearch: "x86_64"
         :releasever: "7Server"
 
+      - :product_name: "Red Hat Software Collections for RHEL Server"
+        :repository_set_name: "Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 Server"
+        :basearch: "x86_64"
+        :releasever: "7Server"
+
   :puppet_classes:
     - :name: "ovirt"
     - :name: "ovirt::engine::config"


### PR DESCRIPTION
We need the software collections so that we can get updates to ruby193, which egon requires.