### PR TITLE
Make labels twice as wide to avoid stupid line wrapping

### DIFF
--- a/fusor-ember-cli/app/components/base-f.js
+++ b/fusor-ember-cli/app/components/base-f.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Component.extend({
 
   labelClassSize: function () {
-    return this.getWithDefault('labelSize', 'col-md-2');
+    return this.getWithDefault('labelSize', 'col-md-4');
   }.property(),
 
   inputClassSize: function () {


### PR DESCRIPTION
The "better" solution is to get a UX person to review our usage of bootstrap to make sure that column widths adjust dynamically and all the available space is used. For now, I'll just make the label column twice as wide to temporarily avoid our label-wrapping problem.