### PR TITLE
Use product / repo set ids instead of names; the latter can change

### DIFF
--- a/server/app/lib/actions/fusor/content/enable_repositories.rb
+++ b/server/app/lib/actions/fusor/content/enable_repositories.rb
@@ -29,11 +29,11 @@ module Actions
 
         def enable_repo(organization, repo_details)
           product = ::Katello::Product.where(:organization_id => organization.id,
-                                             :name => repo_details[:product_name]).first
+                                             :cp_id => repo_details[:product_id]).first
 
           if product
             product_content = product.productContent.find do |content|
-              content.content.name == repo_details[:repository_set_name]
+              content.content.id == repo_details[:repository_set_id]
             end
 
             substitutions = { basearch: repo_details[:basearch] }

--- a/server/app/lib/actions/fusor/content/manage_content.rb
+++ b/server/app/lib/actions/fusor/content/manage_content.rb
@@ -116,11 +116,11 @@ module Actions
 
         def find_repository(organization, repo_details)
           product = ::Katello::Product.where(:organization_id => organization.id,
-                                             :name => repo_details[:product_name]).first
+                                             :cp_id => repo_details[:product_id]).first
 
           if product
             product_content = product.productContent.find do |content|
-              content.content.name == repo_details[:repository_set_name]
+              content.content.id == repo_details[:repository_set_id]
             end
 
             substitutions = { basearch: repo_details[:basearch], releasever: repo_details[:releasever] }

--- a/server/app/lib/actions/fusor/deployment/cloud_forms/deploy.rb
+++ b/server/app/lib/actions/fusor/deployment/cloud_forms/deploy.rb
@@ -111,11 +111,11 @@ module Actions
 
           def find_repository(organization, repo_details)
             product = ::Katello::Product.where(:organization_id => organization.id,
-                                               :name => repo_details[:product_name]).first
+                                               :cp_id => repo_details[:product_id]).first
 
             if product
               product_content = product.productContent.find do |content|
-                content.content.name == repo_details[:repository_set_name]
+                content.content.id == repo_details[:repository_set_id]
               end
 
               substitutions = { basearch: repo_details[:basearch], releasever: repo_details[:releasever] }

--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -5,103 +5,147 @@
       :rpm_component_view_name: "Fusor RPM Content"
       :puppet_component_view_name: "Fusor Puppet Content"
 
+    # NOTE: product_name and repository_set_name are provided only for
+    # convencience / display purposes. All repository finding should be
+    # driven off of product_id / repository_set_id, as those are the only
+    # things guaranteed not to change.
     :rhevm:
       - :product_name: "Red Hat Enterprise Linux Server"
+        :product_id: "69"
+        :repository_set_id: "168"
         :repository_set_name: "Red Hat Enterprise Linux 6 Server (RPMs)"
         :basearch: "x86_64"
         :releasever: "6Server"
 
       - :product_name: "Red Hat Enterprise Linux Server"
+        :product_id: "69"
+        :repository_set_id: "1952"
         :repository_set_name: "Red Hat Enterprise Linux 6 Server (Kickstart)"
         :basearch: "x86_64"
         :releasever: "6.7"
 
       - :product_name: "Red Hat Enterprise Linux Server"
+        :product_id: "69"
+        :repository_set_id: "4185"
         :repository_set_name: "Red Hat Satellite Tools 6.1 (for RHEL 6 Server) (RPMs)"
         :basearch: "x86_64"
 
       - :product_name: "Red Hat Enterprise Linux Server"
+        :product_id: "69"
+        :repository_set_id: "1673"
         :repository_set_name: "Red Hat Enterprise Linux 6 Server - Supplementary (RPMs)"
         :basearch: "x86_64"
         :releasever: "6Server"
 
       - :product_name: "Red Hat Enterprise Virtualization"
+        :product_id: "150"
+        :repository_set_id: "3790"
         :repository_set_name: "Red Hat Enterprise Virtualization Manager 3.5 (RPMs)"
         :basearch: "x86_64"
         :releasever: "6Server"
 
       - :product_name: "JBoss Enterprise Application Platform"
+        :product_id: "183"
+        :repository_set_id: "1559"
         :repository_set_name: "JBoss Enterprise Application Platform 6 (RHEL 6 Server) (RPMs)"
         :basearch: "x86_64"
         :releasever: "6Server"
 
     :rhevh:
       - :product_name: "Red Hat Enterprise Linux Server"
+        :product_id: "69"
+        :repository_set_id: "168"
         :repository_set_name: "Red Hat Enterprise Linux 6 Server (RPMs)"
         :basearch: "x86_64"
         :releasever: "6Server"
 
       - :product_name: "Red Hat Enterprise Linux Server"
+        :product_id: "69"
+        :repository_set_id: "1952"
         :repository_set_name: "Red Hat Enterprise Linux 6 Server (Kickstart)"
         :basearch: "x86_64"
         :releasever: "6.7"
 
       - :product_name: "Red Hat Enterprise Linux Server"
+        :product_id: "69"
+        :repository_set_id: "4185"
         :repository_set_name: "Red Hat Satellite Tools 6.1 (for RHEL 6 Server) (RPMs)"
         :basearch: "x86_64"
 
       - :product_name: "Red Hat Enterprise Virtualization"
+        :product_id: "150"
+        :repository_set_id: "1099"
         :repository_set_name: "Red Hat Enterprise Virtualization Management Agents (RPMs)"
         :basearch: "x86_64"
         :releasever: "6Server"
 
     :cloudforms:
       - :product_name: "Red Hat CloudForms"
+        :product_id: "167"
+        :repository_set_id: "3237"
         :repository_set_name: "Red Hat CloudForms Management Engine 5.3 (Files)"
         :basearch: "x86_64"
         #:image_file_name: "cfme-rhevm-5.3-54.x86_64.rhevm.ova" # Default behavior uses the 'latest' image file.
 
     :openstack:
       - :product_name: "Red Hat Enterprise Linux Server"
+        :product_id: "69"
+        :repository_set_id: "2456"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server (RPMs)"
         :basearch: "x86_64"
         :releasever: "7Server"
 
       - :product_name: "Red Hat Enterprise Linux Server"
+        :product_id: "69"
+        :repository_set_id: "2455"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server (Kickstart)"
         :basearch: "x86_64"
         :releasever: "7.1"
 
       - :product_name: "Red Hat Enterprise Linux Server"
+        :product_id: "69"
+        :repository_set_id: "3030"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server - Extras (RPMs)"
         :basearch: "x86_64"
 
       - :product_name: "Red Hat Enterprise Linux Server"
+        :product_id: "69"
+        :repository_set_id: "2463"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server - Optional (RPMs)"
         :basearch: "x86_64"
         :releasever: "7Server"
 
       - :product_name: "Red Hat Enterprise Linux Server"
+        :product_id: "69"
+        :repository_set_id: "2472"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server - RH Common (RPMs)"
         :basearch: "x86_64"
         :releasever: "7Server"
 
       - :product_name: "Red Hat OpenStack"
+        :product_id: "191"
+        :repository_set_id: "4492"
         :repository_set_name: "Red Hat Enterprise Linux OpenStack Platform 7.0 for RHEL 7 (RPMs)"
         :basearch: "x86_64"
         :releasever: "7Server"
 
       - :product_name: "Red Hat OpenStack"
+        :product_id: "191"
+        :repository_set_id: "4495"
         :repository_set_name: "Red Hat Enterprise Linux OpenStack Platform 7.0 director for RHEL 7 (RPMs)"
         :basearch: "x86_64"
         :releasever: "7Server"
 
       - :product_name: "Red Hat OpenStack"
+        :product_id: "191"
+        :repository_set_id: "4497"
         :repository_set_name: "Red Hat Enterprise Linux OpenStack Platform 7.0 for RHEL 7 (Files)"
         :basearch: "x86_64"
         :releasever: "7Server"
 
       - :product_name: "Red Hat Software Collections for RHEL Server"
+        :product_id: "201"
+        :repository_set_id: "2808"
         :repository_set_name: "Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 Server"
         :basearch: "x86_64"
         :releasever: "7Server"


### PR DESCRIPTION
We need to use product / repo set id to identify repos, not names as they can change. See https://engineering.redhat.com/trac/RHCI/wiki/IdentifyingRepos