### PR TITLE
Fix progress bar for content syncing

### DIFF
--- a/fusor-ember-cli/app/components/progress-bar.js
+++ b/fusor-ember-cli/app/components/progress-bar.js
@@ -58,13 +58,7 @@ export default Ember.Component.extend({
   }.property('deploymentStatus', 'model.result'),
 
   progressBarMsg: function() {
-    if (this.get('isFinished')) {
-      if (this.get('isSatelliteProgressBar')) {
-        return "Sync content and setup successful";
-      } else {
-        return "Deployment successful";
-      }
-    } else if ((this.get('deploymentStatus') === 'In Process') && (this.get('model.result') === 'pending')) {
+    if ((this.get('deploymentStatus') === 'In Process') && (this.get('model.result') === 'pending')) {
       if (this.get('isSatelliteProgressBar')) {
         return "Syncing content";
       } else {
@@ -76,6 +70,12 @@ export default Ember.Component.extend({
       return "Warning";
     } else if (!this.get('isStarted')) {
       return "Waiting for content";
+    } else if (this.get('isFinished')) {
+      if (this.get('isSatelliteProgressBar')) {
+        return "Sync content and setup successful";
+      } else {
+        return "Deployment successful";
+      }
     }
   }.property('deploymentStatus', 'model.result', 'isFinished', 'isSatelliteProgressBar'),
 


### PR DESCRIPTION
When content sync fails and you reload the page, you get the message "Sync content and setup successful" even though the sync failed. It should show an error.

Steps to reproduce:
1. Change a repo id in your fusor.yaml file to an erroneous value
2. Sync
3. After sync has failed, reload the page.