### PR TITLE
Make our error handling methods work again after the ic-ajax migration

### DIFF
--- a/fusor-ember-cli/app/controllers/assign-nodes.js
+++ b/fusor-ember-cli/app/controllers/assign-nodes.js
@@ -127,6 +127,7 @@ export default Ember.Controller.extend({
         console.log('SUCCESS');
         self.store.push('deployment_plan', self.store.normalize('deployment_plan', result.deployment_plan));
       }, function(error) {
+        error = error.jqXHR;
         console.log('ERROR');
         console.log(error);
         // TODO: Remove the reload call once we determine how to get around the failure
@@ -268,6 +269,7 @@ export default Ember.Controller.extend({
             self.set('showLoadingSpinner', false);
           });
         }, function(error) {
+          error = error.jqXHR;
           console.log('ERROR');
           console.log(error);
           self.set('showLoadingSpinner', false);
@@ -303,6 +305,7 @@ export default Ember.Controller.extend({
             self.set('showLoadingSpinner', false);
           });
         }, function(error) {
+             error = error.jqXHR;
              console.log('ERROR');
              console.log(error);
              self.set('showLoadingSpinner', false);
@@ -401,6 +404,7 @@ export default Ember.Controller.extend({
           self.set('showLoadingSpinner', false);
         },
           function(error) {
+            error = error.jqXHR;
             console.log('ERROR');
             console.log(error);
             self.set('showLoadingSpinner', false);

--- a/fusor-ember-cli/app/controllers/register-nodes.js
+++ b/fusor-ember-cli/app/controllers/register-nodes.js
@@ -431,6 +431,7 @@ export default Ember.Controller.extend({
         self.addIntrospectionNode(registeredNode);
         self.doNextNodeRegistration(registeredNode);
       }, function(reason) {
+            reason = reason.jqXHR;
             self.set('initRegInProcess', false);
             node.errorMessage = node.ipAddress + ": " + self.getErrorMessageFromReason(reason);
             self.get('errorNodes').pushObject(node);
@@ -474,6 +475,7 @@ export default Ember.Controller.extend({
         }).then(function(results) {
             resolve({done: results.node.ready});
           },  function(results) {
+                results = results.jqXHR;
                 if (results.status === 0) {
                   // Known problem during introspection, return response is empty, keep trying
                   resolve({done: false});

--- a/fusor-ember-cli/app/controllers/undercloud-deploy.js
+++ b/fusor-ember-cli/app/controllers/undercloud-deploy.js
@@ -95,6 +95,7 @@ export default Ember.Controller.extend({
                 console.log(response);
                 Ember.run.later(checkForDone, 3000);
               },  function(error) {
+                error = error.jqXHR;
                 self.set('deploymentError', error.responseJSON.errors);
                 self.set('showLoadingSpinner', false);
                 console.log('create failed');
@@ -127,6 +128,7 @@ export default Ember.Controller.extend({
               Ember.run.later(checkForDone, 3000);
             }
           }, function(error) {
+              error = error.jqXHR;
               console.log('api check error');
               console.log(error);
               self.set('deploymentError', 'Status check failed');


### PR DESCRIPTION
The migration to the ic-ajax library changed the type of object that was being passed to the error handling function.

Instead of being the request object itself, it now was an object that wrapped the request object as an jqXHR member. I here am updating our error handling functions to get the request objects they were expecting.

@isratrade, is there something similar that we need to do for the success handlers?