### PR TITLE
Minor UI fixes for RHCI Step 5A

### DIFF
--- a/fusor-ember-cli/app/styles/custom.scss
+++ b/fusor-ember-cli/app/styles/custom.scss
@@ -287,6 +287,10 @@ table.fusor-table {
   padding-bottom: 10px;
 }
 
+.accordion-item-title {
+  cursor: pointer;
+}
+
 .invalid-input {
   border:2px solid red;
 }

--- a/fusor-ember-cli/app/templates/components/accordion-item.hbs
+++ b/fusor-ember-cli/app/templates/components/accordion-item.hbs
@@ -1,6 +1,6 @@
 <div class='row'>
   <div class='col-md-12'>
-    <h3 {{action 'openItem'}}>
+    <h3 class="accordion-item-title" {{action 'openItem'}}>
     <i class="fa {{if isOpen 'fa-angle-down' 'fa-angle-right'}}"></i>
       &nbsp;{{name}}
     </h3>

--- a/fusor-ember-cli/app/templates/components/review-link.hbs
+++ b/fusor-ember-cli/app/templates/components/review-link.hbs
@@ -1,9 +1,9 @@
 <div class='row'>
-  <div class='col-md-2 text-right bold'>
+  <div class='col-sm-6 col-md-4 col-lg-3 text-right bold'>
     {{label}}
   </div>
 
-  <div class='col-md-10'>
+  <div class='col-sm-6 col-md-8 col-lg-9'>
     {{#if isExternalURL}}
       <a href={{value}} target="_blank">{{value}}</a>
     {{else if isNotALink}}


### PR DESCRIPTION
Change cursor over clickable title/icon of accordion.
Change column widths to avoid wrapping labels of the review links on RHCI step 5A.
![label_wrap](https://cloud.githubusercontent.com/assets/1448375/10760266/1b08682e-7c92-11e5-95ad-2bbf0227d7ed.png)
