### PR TITLE
1240791 - fixed wrapping issue for table headers on small screens.

### DIFF
--- a/fusor-ember-cli/app/templates/engine/discovered-host.hbs
+++ b/fusor-ember-cli/app/templates/engine/discovered-host.hbs
@@ -1,5 +1,5 @@
 <div class='row'>
-  <div class='col-md-9'>
+  <div class='col-lg-9'>
 
     {{#if isLoadingHosts}}
       <div class="spinner spinner-md spinner-inline"></div>
@@ -11,7 +11,7 @@
 
       <div class="rhev-searchbar clearfix">
         <form class="form-inline">
-          <div class='col-md-9'>
+          <div class='col-md-5'>
             <div class="form-group">
               <div class='rhev-search-box'>
                   {{input type='text' class='form-control rhev-search-input'
@@ -21,7 +21,7 @@
             </div>
           </div>
 
-          <div class='col-md-3 text-right'>
+          <div class='col-md-7 text-right'>
 
             {{numSelected}} selected
 

--- a/fusor-ember-cli/app/templates/hypervisor/discovered-host.hbs
+++ b/fusor-ember-cli/app/templates/hypervisor/discovered-host.hbs
@@ -1,5 +1,5 @@
 <div class='row'>
-  <div class='col-md-9'>
+  <div class='col-lg-9'>
 
     {{#if isLoadingHosts}}
       <div class="spinner spinner-md spinner-inline"></div>
@@ -11,7 +11,7 @@
 
       <div class="rhev-searchbar clearfix">
         <form class="form-inline">
-          <div class='col-md-7'>
+          <div class='col-md-5'>
             <div class="form-group">
               <div class='rhev-search-box'>
                   {{input type='text' class='form-control rhev-search-input'
@@ -22,7 +22,7 @@
             </div>
           </div>
 
-          <div class='col-md-5 text-right'>
+          <div class='col-md-7 text-right'>
 
             {{model.length}} selected
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1240791

set machine tables to full width on smaller screens
changed header of table to give more room to selection status to avoid wrapping on small screens