### PR TITLE
Updated simplecov/coveralls setup to only track fusor/egon/foretello_api_v21

### DIFF
--- a/server/fusor_server.gemspec
+++ b/server/fusor_server.gemspec
@@ -1,4 +1,5 @@
 require File.expand_path('../lib/fusor/version', __FILE__)
+require 'date'
 
 Gem::Specification.new do |s|
   s.name        = "fusor_server"
@@ -17,5 +18,6 @@ Gem::Specification.new do |s|
   s.add_dependency "active_model_serializers", '~> 0.9'
   s.add_dependency "mechanize"
   s.add_development_dependency 'rubocop', '0.33.0'
+  s.add_development_dependency 'simplecov'
   s.add_development_dependency 'coveralls'
 end

--- a/server/test/test_plugin_helper.rb
+++ b/server/test/test_plugin_helper.rb
@@ -1,6 +1,26 @@
 # This calls the main test_helper in Foreman-core
+require 'simplecov'
 require 'coveralls'
-Coveralls.wear!
+
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+]
+
+# Configures simplecov to only track fusor, egon, and foretello_api_v21 gems
+SimpleCov.root(File.join(File.dirname(__FILE__), '../app'))
+SimpleCov.start 'rails' do
+  filters.clear # This will remove the :root_filter and :bundler_filter that come via simplecov's defaults
+  add_filter do |src|
+    !(src.filename =~ /^#{SimpleCov.root}/) unless ( (src.filename =~ /egon/) or (src.filename =~ /foretello_api_v21/) )
+  end
+  add_group "Egon" do |src_file|
+    src_file.filename =~ /egon/
+  end
+  add_group "Foretello_api_v21" do |src_file|
+    src_file.filename =~ /foretello_api_v21/
+  end
+end
 
 require 'yaml'
 require 'test_helper'

--- a/server/test/test_plugin_helper.rb
+++ b/server/test/test_plugin_helper.rb
@@ -12,7 +12,7 @@ SimpleCov.root(File.join(File.dirname(__FILE__), '../app'))
 SimpleCov.start 'rails' do
   filters.clear # This will remove the :root_filter and :bundler_filter that come via simplecov's defaults
   add_filter do |src|
-    !(src.filename =~ /^#{SimpleCov.root}/) unless ( (src.filename =~ /egon/) or (src.filename =~ /foretello_api_v21/) )
+    !(src.filename =~ /^#{SimpleCov.root}/) unless ((src.filename =~ /egon/) || (src.filename =~ /foretello_api_v21/))
   end
   add_group "Egon" do |src_file|
     src_file.filename =~ /egon/

--- a/server/test/test_plugin_helper.rb
+++ b/server/test/test_plugin_helper.rb
@@ -20,6 +20,9 @@ SimpleCov.start 'rails' do
   add_group "Foretello_api_v21" do |src_file|
     src_file.filename =~ /foretello_api_v21/
   end
+  add_group "Fusor" do |src_file|
+    src_file.filename =~ /fusor/
+  end
 end
 
 require 'yaml'


### PR DESCRIPTION
This will remove the data collected on foreman/katello/etc the code coverage will be for just our gems.

I included 'egon' and 'foretello_api_v21' in this report so we have an idea of coverage.
Feel it'd be worth to revisit in future and move their code coverage to their own reports.




