### PR TITLE
Bundle in Travis without development gemset

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -38,7 +38,7 @@ if [ $1 == "install" ]; then
   echo "gem 'logger'" >> bundler.d/local.rb
   echo "gem 'egon'" >> bundler.d/local.rb
   echo "gem 'coveralls', require: false" >> bundler.d/local.rb
-  bundle install --retry 3
+  bundle install --retry 3 --without development
 
   # hacky, find a better way to do this...
   # rails only supports loading fixtures from one directory, so link the


### PR DESCRIPTION
This should speed up the bundle install command and allow us to avoid potential gem problems in the development gemset like this:

https://github.com/theforeman/foreman/pull/2898