### PR TITLE
refresh nodes and flavors when introspection task is done

### DIFF
--- a/fusor-ember-cli/app/controllers/register-nodes.js
+++ b/fusor-ember-cli/app/controllers/register-nodes.js
@@ -158,19 +158,6 @@ export default Ember.Controller.extend(ProgressBarMixin, {
   }).readOnly(),
 
   actions: {
-    refreshNodesAndFlavors() {
-      // manually set manual rather than using this.get('model').reload() which looks at data store changes
-      // since the nodes changes or db changes happened outside of ember-data.
-      console.log('refreshing model.nodes and model.profiles');
-      var deploymentId = this.get('deploymentId');
-      var self = this;
-      Ember.RSVP.hash({nodes: this.store.query('node', {deployment_id: deploymentId}),
-                       profiles: this.store.query('flavor', {deployment_id: deploymentId})
-                     }).then(function(result) {
-                         return self.set('model', result);
-                     });
-    },
-
     showNodeRegistrationModal() {
       // stop polling when opening the modal
       this.stopPolling();
@@ -376,6 +363,7 @@ export default Ember.Controller.extend(ProgressBarMixin, {
               deployment_id: self.get('deploymentId')
         });
         self.get('deployment.introspection_tasks').addObject(newTask);
+        self.startPolling();
       }, function(reason) {
             reason = reason.jqXHR;
             self.set('initRegInProcess', false);

--- a/fusor-ember-cli/app/models/introspection-task.js
+++ b/fusor-ember-cli/app/models/introspection-task.js
@@ -2,6 +2,7 @@ import DS from 'ember-data';
 
 export default DS.Model.extend({
   task_id: DS.attr('string'),
-  deployment: DS.belongsTo('deployment', {async: true})
+  deployment: DS.belongsTo('deployment', {async: true}),
+  poll: DS.attr('boolean', {defaultValue: true})
 
 });


### PR DESCRIPTION
This will make the nodes and flavors show up after node introspection is done once more.

It also as an added bonus stops the tasks from refreshing when they're completed.