### PR TITLE
Disable updates of deployment.openstack_undercloud_password

### DIFF
--- a/server/app/controllers/fusor/api/v21/deployments_controller.rb
+++ b/server/app/controllers/fusor/api/v21/deployments_controller.rb
@@ -40,8 +40,7 @@ module Fusor
       # controller (after it has validated them), never by directly updating
       # the deployment object.
 
-      # commented out :openstack_undercloud_password since mock UI application needs to set this value
-      # params[:deployment].delete :openstack_undercloud_password
+      params[:deployment].delete :openstack_undercloud_password
       params[:deployment].delete :openstack_undercloud_ip_addr
       params[:deployment].delete :openstack_undercloud_user
       params[:deployment].delete :openstack_undercloud_user_password


### PR DESCRIPTION
Possible fix for blanking out openstack_undercloud_password after the server has set it.