### PR TITLE
Don't validate deployment in OvercloudCredentials or ManageManifest

### DIFF
--- a/server/app/lib/actions/fusor/deployment/openstack/overcloud_credentials.rb
+++ b/server/app/lib/actions/fusor/deployment/openstack/overcloud_credentials.rb
@@ -32,7 +32,7 @@ module Actions
             deployment = ::Fusor::Deployment.find(input[:deployment_id])
             deployment.openstack_overcloud_password = get_passwd(deployment)
             deployment.openstack_overcloud_address = get_address(deployment)
-            deployment.save!
+            deployment.save!(:validate => false)
             Rails.logger.debug '=== Leaving OvercloudCredentials run method ==='
           end
 

--- a/server/app/lib/actions/fusor/subscription/manage_manifest.rb
+++ b/server/app/lib/actions/fusor/subscription/manage_manifest.rb
@@ -55,8 +55,7 @@ module Actions
             # consumer from the organization; otherwise, either refresh it or delete it and import another
 
             if deployment.upstream_consumer_uuid.nil?
-              deployment.upstream_consumer_uuid = upstream_consumer['uuid']
-              deployment.save!
+              deployment.update_attribute(:upstream_consumer_uuid, upstream_consumer['uui'])
 
             elsif upstream_consumer['uuid'] == deployment.upstream_consumer_uuid
               plan_action(::Actions::Katello::Provider::ManifestRefresh,


### PR DESCRIPTION
We don't want to run through validations such as NFS validation in these places.