### PR TITLE
Stop using showmount to check for nfs paths

### DIFF
--- a/scripts/safe-mount.sh
+++ b/scripts/safe-mount.sh
@@ -32,6 +32,7 @@ mount -r -t nfs --target "$mount" --source "$2:$3"
 
 if [[ $? -ne 0 ]]; then
   echo "Failed to mount NFS share"
+  exit 1
 else
   echo $mount
 fi


### PR DESCRIPTION
@jmontleon found that we couldn't reliably use showmount to check to see if our `path` was available as showmount will only display mounts if they've previously been mounted. This check was redundant though as we also try to mount the path to inspect it. I figure we can still use showmount to check that the NFS server is up..? 