### PR TITLE
Revert "fail here if we can't save"

### DIFF
--- a/server/app/lib/actions/fusor/host/trigger_provisioning.rb
+++ b/server/app/lib/actions/fusor/host/trigger_provisioning.rb
@@ -85,14 +85,7 @@ module Actions
             Rails.logger.debug "XXX saving host of type: #{host.type}"
             Rails.logger.debug "XXX calling save"
 
-            begin
-              host.save!
-            rescue ActiveRecord::RecordInvalid
-              if @host.errors.any? && @host.errors.are_all_conflicts?
-                host.overwrite = true
-                host.save!
-              end
-            end
+            host.save
 
             return host
           end


### PR DESCRIPTION
This reverts commit fdef6bb8a7ab5576c374e3977d95fa5ca1418d32. Hosts are failing to convert from Discovered Host with this change.