### PR TITLE
[DO NOT MERGE] Allow concurrent updates in openstack assign-nodes.

### DIFF
--- a/fusor-ember-cli/app/components/node-profile.js
+++ b/fusor-ember-cli/app/components/node-profile.js
@@ -18,41 +18,12 @@ export default Ember.Component.extend({
     return paramValue;
   },
 
-  assignedRoles: Ember.computed('profile', 'plan', 'plan.roles', 'plan.parameters', function() {
-    var assignedRoles = Ember.A();
-    var profile = this.get('profile');
-    var params = this.get('plan.parameters');
-    var self = this;
-    var roles = this.get('plan.roles') || Ember.A();
-    roles.forEach(function(role) {
-      if ( self.getParamValue(role.get('flavorParameterName'), params) === profile.get('name') ) {
-        assignedRoles.addObject(role);
-      }
+  assignedRoles: Ember.computed('roles.[]', 'roleParams.[]', function() {
+    var self = this, roles = this.get('roles'), params = this.get('roleParams');
+    return roles.filter(function(role) {
+      var param = params.findBy('id', role.get('flavorParameterName'));
+      return param && param.get('value') === self.get('profile.name');
     });
-    return assignedRoles;
-  }),
-
-  unassignedRoles: Ember.computed('assignedRoles', 'plan', 'plan.roles', function() {
-    var unassignedRoles = Ember.A();
-    var assignedRoles = this.get('assignedRoles');
-    var roles = this.get('plan.roles') || Ember.A();
-    roles.forEach(function(role) {
-      var unassignedRole = true;
-      for (var i=0; i<assignedRoles.length; i++) {
-        if ( role.get('name') === assignedRoles[i].get('name') ) {
-          unassignedRole = false;
-          break;
-        }
-      }
-      if ( unassignedRole ) {
-        unassignedRoles.addObject(role);
-      }
-    });
-    return unassignedRoles;
-  }),
-
-  allRolesAssigned: Ember.computed('unassignedRoles.[]', function() {
-    return (this.get('unassignedRoles.length') === 0);
   }),
 
   /* jshint ignore:start */

--- a/fusor-ember-cli/app/routes/assign-nodes.js
+++ b/fusor-ember-cli/app/routes/assign-nodes.js
@@ -5,32 +5,77 @@ import DeploymentRouteMixin from "../mixins/deployment-route-mixin";
 export default Ember.Route.extend(DeploymentRouteMixin, {
 
   model() {
-      var deploymentId = this.modelFor('deployment').get('id');
-      return Ember.RSVP.hash({
-          plan: this.store.findRecord('deployment-plan', deploymentId),
-          images: this.store.query('image', {deployment_id: deploymentId}),
-          nodes: this.store.query('node', {deployment_id: deploymentId}),
-          profiles: this.store.query('flavor', {deployment_id: deploymentId}),
-      });
+    var deploymentId = this.modelFor('deployment').get('id');
+    return Ember.RSVP.hash({
+      plan: this.store.findRecord('deployment-plan', deploymentId),
+      images: this.store.query('image', {deployment_id: deploymentId}),
+      nodes: this.store.query('node', {deployment_id: deploymentId}),
+      profiles: this.store.query('flavor', {deployment_id: deploymentId}),
+    });
   },
 
   setupController(controller, model) {
     controller.set('model', model);
+    this.updateRoles();
     this.fixBadDefaults();
   },
 
+  actions: {
+    updateRoles() {
+      this.updateRoles();
+    }
+  },
+
+  updateRoles() {
+    var params, roles, roleParams, controller, unassignedRoles = [], assignedRoles = [];
+
+    controller = this.get('controller');
+    params = controller.get('model.plan.parameters');
+    roles = controller.get('model.plan.roles');
+
+    if (!params) {
+      return;
+    }
+
+    roleParams = params.filter(function (param) {
+      return !!param.get('id').match(/.*::Flavor/);
+    });
+
+    if (!roleParams) {
+      return;
+    }
+
+    roleParams.forEach(function (rp) {
+      var role = roles.find(function (role) {
+        return rp.get('id') === role.get('flavorParameterName');
+      });
+
+      if (!role) {
+        return;
+      }
+
+      if (!rp.get('value') || rp.get('value') === 'baremetal') {
+        unassignedRoles.pushObject(role);
+      } else {
+        assignedRoles.pushObject(role);
+      }
+    });
+
+    controller.set('unassignedRoles', unassignedRoles);
+    controller.set('assignedRoles', assignedRoles);
+    controller.set('roleParams', roleParams);
+  },
+
   fixBadDefaults() {
-    var id, value,
-      existingParams = this.get('controller').get('model.plan.parameters'),
-      newParams = [];
+    var newParams = [], existingParams = this.get('controller').get('model.plan.parameters');
 
     if (!existingParams) {
       return;
     }
 
-    existingParams.forEach(function(param) {
-      id = param.get('id');
-      value = param.get('value');
+    existingParams.forEach(function (param) {
+      var id = param.get('id'), value = param.get('value');
+
       if (id === 'Controller-1::NeutronPublicInterface' &&
         (!value || value === 'nic1')) {
         param.set('value', 'eth1');

--- a/fusor-ember-cli/app/routes/openstack.js
+++ b/fusor-ember-cli/app/routes/openstack.js
@@ -27,8 +27,7 @@ export default Ember.Route.extend({
           "X-CSRF-Token": token
         },
         data: JSON.stringify({ 'parameters': params })
-      }).then(
-        function() {},
+      }).catch(
         function(error) {
           error = error.jqXHR;
           console.log('ERROR updating parameters');

--- a/fusor-ember-cli/app/templates/assign-nodes.hbs
+++ b/fusor-ember-cli/app/templates/assign-nodes.hbs
@@ -3,6 +3,7 @@
         <p >
             <h2 style="vertical-align: bottom;display:inline-block;">Available Deployment Roles</h2>
             <a class="edit-global-config" {{action "editGlobalServiceConfig"}}> Edit Global Configuration</a>
+            {{#if requestActive}}<div class="spinner spinner-lg spinner-inline pull-right"></div>{{/if}}
         </p>
         {{#draggable-object-target action="unassignRole"}}
             <div class="row col-md-12 deployment-roles deployment-roles-unassigned deployment-roles-assignable {{droppableClass}}">
@@ -25,9 +26,11 @@
             <div class="row">
                 <div class='col-md-7'>
                   {{#if nodes}}
-                    {{node-profile profile=profile nodes=nodes plan=model.plan doAssign=true assignRole="assignRole" unassignRole="unassignRole" editRole="editRole" setRoleCount="setRoleCount"  removeRole="removeRole"}}
+                    {{node-profile profile=profile nodes=nodes plan=model.plan roles=assignedRoles roleParams=roleParams showAssign=notAllRolesAssigned
+                    doAssign=true assignRole="assignRole" unassignRole="unassignRole" editRole="editRole" setRoleCount="setRoleCount"  removeRole="removeRole"}}
                  {{else}}
-                    {{node-profile profile=profile plan=model.plan doAssign=true assignRole="assignRole" unassignRole="unassignRole" editRole="editRole" setRoleCount="setRoleCount"  removeRole="removeRole"}}
+                    {{node-profile profile=profile plan=model.plan roles=assignedRoles roleParams=roleParams showAssign=notAllRolesAssigned
+                    doAssign=true assignRole="assignRole" unassignRole="unassignRole" editRole="editRole" setRoleCount="setRoleCount"  removeRole="removeRole"}}
                  {{/if}}
                 </div>
             </div>

--- a/fusor-ember-cli/app/templates/components/node-profile.hbs
+++ b/fusor-ember-cli/app/templates/components/node-profile.hbs
@@ -45,7 +45,7 @@
                             {{deployment-role role=role profile=profile nodeCount=matchingNodeCount plan=plan edit="editRole" setRoleCount="setRoleCount" remove="removeRole" readOnly=false}}
                           {{/draggable-object}}
                         {{/each}}
-                        {{#unless allRolesAssigned}}
+                        {{#if showAssign}}
                           {{#draggable-object-target action='assignDroppedRole'}}
                               <li class="role-target {{assignMenuOpenClass}}  dropdown">
                                   <a id="role-target-dropdown-1" {{action "showAssignMenu" profile bubbles=false}} data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -58,7 +58,7 @@
                                   </ul>
                               </li>
                           {{/draggable-object-target}}
-                        {{/unless}}
+                        {{/if}}
                       </ul>
                   </div>
               {{else}}


### PR DESCRIPTION
Allowed update_role_count to put without waiting for the response.
Allowed update_parameters to put without waiting for response and used the action from the openstack route.
Allowed multiple roles to be assigned/unassigned without locking the UI.  A new spinner is displayed and next is disabled until all requests are complete.  At that point the plan will refresh and next enable.