### PR TITLE
store more than one subscription

### DIFF
--- a/server/app/controllers/fusor/api/v21/subscriptions_controller.rb
+++ b/server/app/controllers/fusor/api/v21/subscriptions_controller.rb
@@ -80,18 +80,21 @@ module Fusor
       Rails.logger.debug "XXX Import the manifest into the DB"
 
       mi = Fusor::Manifest::ManifestImporter.new
-      entitlement = mi.prepare_manifest(temp_file.path, deployment.id)
-      @subscription = Fusor::Subscription.where(:deployment_id => deployment.id).first_or_initialize
-      @subscription.deployment_id = deployment.id
-      @subscription.contract_number = entitlement['pool']['contractNumber']
-      @subscription.product_name = entitlement['pool']['productName']
-      #@subscription.product_name = entitlement['pool']['branding'].first['name']
-      @subscription.start_date = entitlement['startDate']
-      @subscription.end_date = entitlement['endDate']
-      @subscription.quantity_attached = entitlement['quantity']
-      @subscription.total_quantity = entitlement['pool']['quantity']
-      @subscription.source = "imported"
-      @subscription.save!
+      entitlements = mi.prepare_manifest(temp_file.path, deployment.id)
+
+      entitlements.each do |entitlement|
+        @subscription = Fusor::Subscription.where(:deployment_id => deployment.id, :contract_number => entitlement['pool']['contractNumber']).first_or_initialize
+        @subscription.deployment_id = deployment.id
+        @subscription.contract_number = entitlement['pool']['contractNumber']
+        @subscription.product_name = entitlement['pool']['productName']
+        #@subscription.product_name = entitlement['pool']['branding'].first['name']
+        @subscription.start_date = entitlement['startDate']
+        @subscription.end_date = entitlement['endDate']
+        @subscription.quantity_attached = entitlement['quantity']
+        @subscription.total_quantity = entitlement['pool']['quantity']
+        @subscription.source = "imported"
+        @subscription.save!
+      end
 
       render json: {manifest_file: temp_file.path}, status: 200
     end

--- a/server/app/lib/fusor/manifest/manifest_importer.rb
+++ b/server/app/lib/fusor/manifest/manifest_importer.rb
@@ -49,17 +49,17 @@ module Fusor
         entry.extract(File.join(tmp_dir, "consumer.zip"))
         zip_file.close
 
-        subscription = nil
+        subscriptions = []
         consumer_zip = Zip::File.open(File.join(tmp_dir, "consumer.zip"))
         consumer_zip.glob("export/entitlements/*.json") do |entitlement|
           Rails.logger.debug entitlement.name
-          subscription = parse_entitlement_json(entitlement.get_input_stream.read(entitlement.size))
+          subscriptions.push(parse_entitlement_json(entitlement.get_input_stream.read(entitlement.size)))
         end
 
         consumer_zip.close
 
         Rails.logger.debug "XXX ------------- Leaving prepare_manifest -------------"
-        return subscription
+        return subscriptions
       end
     end
   end


### PR DESCRIPTION
There was a problem with the manifest import where it would store only the last subscription found in the manifest instead of all of them.