### PR TITLE
Remove dead symlinks

### DIFF
--- a/ui/app/assets/javascripts/fusor_ui/ember-data.js.map
+++ b/ui/app/assets/javascripts/fusor_ui/ember-data.js.map
@@ -1,1 +1,0 @@
-/git/RHCI/fusor/fusor-ember-cli/dist/assets/ember-data.js.map

--- a/ui/app/assets/javascripts/fusor_ui/test-loader.js
+++ b/ui/app/assets/javascripts/fusor_ui/test-loader.js
@@ -1,1 +1,0 @@
-/git/RHCI/fusor/fusor-ember-cli/dist/assets/test-loader.js

--- a/ui/app/assets/javascripts/fusor_ui/test-support.js
+++ b/ui/app/assets/javascripts/fusor_ui/test-support.js
@@ -1,1 +1,0 @@
-/git/RHCI/fusor/fusor-ember-cli/dist/assets/test-support.js

--- a/ui/app/assets/javascripts/fusor_ui/test-support.map
+++ b/ui/app/assets/javascripts/fusor_ui/test-support.map
@@ -1,1 +1,0 @@
-/git/RHCI/fusor/fusor-ember-cli/dist/assets/test-support.map

--- a/ui/app/assets/stylesheets/fusor_ui/test-support.css
+++ b/ui/app/assets/stylesheets/fusor_ui/test-support.css
@@ -1,1 +1,0 @@
-/git/RHCI/fusor/fusor-ember-cli/dist/assets/test-support.css

--- a/ui/app/assets/stylesheets/fusor_ui/vendor.css
+++ b/ui/app/assets/stylesheets/fusor_ui/vendor.css
@@ -1,1 +1,0 @@
-/git/RHCI/fusor/fusor-ember-cli/dist/assets/vendor.css


### PR DESCRIPTION
Was trying to rsync the fusor directory onto another box and got the following errors:

```
symlink has no referent: "/home/dadavis/Projects/fusor/ui/app/assets/javascripts/fusor_ui/ember-data.js.map"
symlink has no referent: "/home/dadavis/Projects/fusor/ui/app/assets/javascripts/fusor_ui/test-loader.js"
symlink has no referent: "/home/dadavis/Projects/fusor/ui/app/assets/javascripts/fusor_ui/test-support.js"
symlink has no referent: "/home/dadavis/Projects/fusor/ui/app/assets/javascripts/fusor_ui/test-support.map"
symlink has no referent: "/home/dadavis/Projects/fusor/ui/app/assets/stylesheets/fusor_ui/test-support.css"
symlink has no referent: "/home/dadavis/Projects/fusor/ui/app/assets/stylesheets/fusor_ui/vendor.css"
```