### PR TITLE
1280423 - Invalid hostnames disable user's ability to continue

### DIFF
--- a/fusor-ember-cli/app/controllers/engine/discovered-host.js
+++ b/fusor-ember-cli/app/controllers/engine/discovered-host.js
@@ -75,7 +75,7 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
       }
     },
 
-    setIfHostnameValid(bool) {
+    setIfHostnameInvalid(bool) {
       this.set('isHostnameInvalid', bool);
     }
   }

--- a/fusor-ember-cli/app/controllers/hypervisor/discovered-host.js
+++ b/fusor-ember-cli/app/controllers/hypervisor/discovered-host.js
@@ -139,7 +139,7 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
       this.get('deploymentController.model').save();
     },
 
-    setIfHostnameValid(bool) {
+    setIfHostnameInvalid(bool) {
       this.set('isHostnameInvalid', bool);
     }
 

--- a/fusor-ember-cli/app/mixins/tr-engine-hypervisor-mixin.js
+++ b/fusor-ember-cli/app/mixins/tr-engine-hypervisor-mixin.js
@@ -31,7 +31,11 @@ export default Ember.Mixin.create({
         // HOST_REGEXP taken from Foreman code HOST_REGEXP in file /lib/net/validations.rb
         // But replaced /A with ^ and /z with $
         var hostnameRegex = new RegExp(/^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$/);
-        return Ember.isEmpty(this.get('host.name').match(hostnameRegex));
+        var invalidHostname = Ember.isEmpty(this.get('host.name').match(hostnameRegex));
+
+        this.sendAction('setIfHostnameInvalid', invalidHostname);
+
+        return invalidHostname;
   }),
   isValidHostname: Ember.computed.not('isInvalidHostname'),
 
@@ -52,13 +56,13 @@ export default Ember.Mixin.create({
                     "Authorization": "Basic " + self.get('session.basicAuthToken')
                 }
               }).then(function(response) {
-                  self.sendAction('setIfHostnameValid', false);
+                  self.sendAction('setIfHostnameInvalid', false);
                 }, function(error) {
                   console.log(error);
                 }
               );
       } else {
-        this.sendAction('setIfHostnameValid', true);
+        this.sendAction('setIfHostnameInvalid', true);
       }
     }
   }

--- a/fusor-ember-cli/app/templates/engine/discovered-host.hbs
+++ b/fusor-ember-cli/app/templates/engine/discovered-host.hbs
@@ -54,7 +54,7 @@
                          selectedRhevEngineHost=selectedRhevEngineHost
                          disabled=isStarted
                          action="setEngine"
-                         setIfHostnameValid='setIfHostnameValid'}}
+                         setIfHostnameInvalid='setIfHostnameInvalid'}}
           {{/each}}
         </tbody>
       </table>

--- a/fusor-ember-cli/app/templates/hypervisor/discovered-host.hbs
+++ b/fusor-ember-cli/app/templates/hypervisor/discovered-host.hbs
@@ -77,7 +77,7 @@
                            num=host.id
                            disabled=isStarted
                            filteredHosts=filteredHosts
-                           setIfHostnameValid='setIfHostnameValid'
+                           setIfHostnameInvalid='setIfHostnameInvalid'
                            checkAll=checkAll
                            uncheckAll=uncheckAll
                            }}


### PR DESCRIPTION
When the host name for the engine or hypervisor is changed, the 'next' button and associated tab it will go to is grayed out whenever the host name is invalid.