### PR TITLE
Locked jquery version to 1.11.3

### DIFF
--- a/fusor-ember-cli/bower.json
+++ b/fusor-ember-cli/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.3",
+    "jquery": "~1.11.3",
     "jquery-csv": "google-code-export/jquery-csv#*",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0",


### PR DESCRIPTION
Until Ember introduces a fix for the latest Jquery update, we will use Jquery 1.11.3.