### PR TITLE
Added new log files to the review/log page of a deployment.

### DIFF
--- a/fusor-ember-cli/app/controllers/review/progress/log.js
+++ b/fusor-ember-cli/app/controllers/review/progress/log.js
@@ -82,21 +82,21 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
   },
 
   navSearchResult(idxChange) {
-    var numSearchResults = this.get('numSearchResults'),
+    var searchResults = this.get('searchResults'),
       searchResultIdx = this.get('searchResultIdx'),
       isSearchActive = this.get('isSearchActive');
 
-    if (!isSearchActive || numSearchResults === 0) {
+    if (!isSearchActive || searchResults.length === 0) {
       return;
     }
 
     searchResultIdx += idxChange;
-    if (searchResultIdx > numSearchResults) {
+    if (searchResultIdx > searchResults.length) {
       searchResultIdx = 1;
     }
 
     if (searchResultIdx < 1) {
-      searchResultIdx = numSearchResults;
+      searchResultIdx = searchResults.length;
     }
 
     this.set('searchResultIdx', searchResultIdx);
@@ -104,13 +104,20 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
   },
 
   markAndScrollToSearchResult(showAtTop) {
-    var searchResultIdx = this.get('searchResultIdx'),
-     currentlySelected = Ember.$('.log-entry-search-selected'),
-     searchResult = Ember.$(`.log-entry-search-result-${searchResultIdx}`);
+    var searchResults = this.get('searchResults'),
+     searchResultIdx = this.get('searchResultIdx'),
+      currentlySelected, searchResult, searchTag;
+
+     searchTag = searchResults[searchResultIdx - 1];
+     currentlySelected = Ember.$('.log-entry-search-selected');
+     searchResult = Ember.$(`.${searchTag.cssClass}`);
 
     this.set('scrollToEndChecked', false);
     currentlySelected.removeClass('log-entry-search-selected');
-    searchResult.addClass('log-entry-search-selected');
-    searchResult[0].scrollIntoView(showAtTop);
+
+    if (searchResult && searchResult[0]) {
+      searchResult.addClass('log-entry-search-selected');
+      searchResult[0].scrollIntoView(showAtTop);
+    }
   }
 });

--- a/fusor-ember-cli/app/controllers/review/progress/log.js
+++ b/fusor-ember-cli/app/controllers/review/progress/log.js
@@ -25,12 +25,6 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
     return !this.get('errorMessage') && !this.get('isLoading') && this.get('deploymentInProgress');
   }),
 
-  showLogTruncated: Ember.computed('errorMessage', 'isLoading', 'displayedLogEntries.[]', function () {
-    var displayedLogEntries = this.get('displayedLogEntries');
-    return !this.get('errorMessage') && !this.get('isLoading') &&
-      displayedLogEntries && displayedLogEntries[0] && displayedLogEntries[0].get('line_number') !== 1;
-  }),
-
   showLogEmpty: Ember.computed('errorMessage', 'isLoading', 'logType',
     'model.fusor_log.entries.[]',  'model.foreman_log.entries.[]', 'model.foreman_proxy_log.entries.[]',
     'model.candlepin_log.entries.[]', 'model.messages_log.entries.[]',
@@ -50,9 +44,10 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
   }),
 
   logTypeChanged: function() {
-    var self = this;
-    self.set('displayedLogEntries', []);
-    self.send('changeLogType');
+    this.set('displayedLogHtml', '');
+    this.set('newEntries', []);
+    // run later to allow the dropdown to close and log to clear before doing the real work
+    Ember.run.later(this, () => { this.send('changeLogType'); });
   }.observes('logType'),
 
   actions: {
@@ -83,13 +78,6 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
 
     navNextSearchResult() {
       this.navSearchResult(1);
-    }
-  },
-
-  formatLog: function() {
-    this.send('formatLog');
-    if (this.get('isSearchActive')) {
-      Ember.run.later(this, () => this.send('navNextSearchResult'));
     }
   },
 

--- a/fusor-ember-cli/app/styles/custom.scss
+++ b/fusor-ember-cli/app/styles/custom.scss
@@ -216,19 +216,19 @@ label.env_path_disabled:after {
   margin-bottom: 1px;
 }
 
-.log-entry-level-d {
+.log-entry-level-debug {
   color: $debug-color
 }
 
-.log-entry-level-i {
+.log-entry-level-info {
   color: $info-color
 }
 
-.log-entry-level-w {
+.log-entry-level-warn {
   color: $warning-color;
 }
 
-.log-entry-level-e {
+.log-entry-level-error {
   color: $error-color;
 }
 
@@ -255,6 +255,10 @@ label.env_path_disabled:after {
 
 .log-warning-icon {
   color: $warning-color;
+}
+
+.log-error-icon {
+  color: $error-color;
 }
 
 .log-updating-spinner {

--- a/fusor-ember-cli/app/templates/review/progress/log.hbs
+++ b/fusor-ember-cli/app/templates/review/progress/log.hbs
@@ -1,16 +1,16 @@
 <div class="row log-selection-row">
   <div class="col-sm-12 col-lg-9">
     <form role="form-inline" class="log-file-form">
-      <select class="selectpicker log-file-select">
-        <option>Deployment Log</option>
-      </select>
-      <span class="log-file-path">Viewing {{model.log.path}}</span>
+      {{view "select" id="log-file-select" class="selectpicker log-file-select"
+                      content=logTypes value=logType selection=logTypeSelection
+                      optionLabelPath="content.label" optionValuePath="content.value"}}
+      <span class="log-file-path">Viewing {{logPath}}</span>
     </form>
   </div>
 </div>
 
 <div class="row">
-  <div class="col-sm-6 col-lg-4">
+  <div class="col-sm-5 col-lg-4">
     <div class="row log-search-row">
       <div class="col-sm-12">
         <form role="form-inline" class="search-pf has-button log-search-form">
@@ -34,20 +34,23 @@
     </div>
   </div>
 
-  <div class="col-sm-6 col-lg-5">
+  <div class="col-sm-7 col-lg-5">
     <form class="pull-right log-level-form form-inline">
-      <div class="checkbox">
-        <label>{{input type="checkbox" name="error" checked=errorChecked}} Error</label>
-      </div>
-      <div class="checkbox">
-        <label>{{input type="checkbox" name="warn" checked=warnChecked}} Warning</label>
-      </div>
-      <div class="checkbox">
-        <label>{{input type="checkbox" name="info" checked=infoChecked}} Informational</label>
-      </div>
-      <div class="checkbox">
-        <label>{{input type="checkbox" name="debug" checked=debugChecked}} Debug</label>
-      </div>
+        <div class="checkbox">
+          <label>Show:</label>
+        </div>
+         <div class="checkbox">
+          <label>{{input type="checkbox" name="error" checked=errorChecked}} Error</label>
+        </div>
+        <div class="checkbox">
+          <label>{{input type="checkbox" name="warn" checked=warnChecked}} Warning</label>
+        </div>
+        <div class="checkbox">
+          <label>{{input type="checkbox" name="info" checked=infoChecked}} Informational</label>
+        </div>
+        <div class="checkbox">
+          <label>{{input type="checkbox" name="debug" checked=debugChecked}} Debug</label>
+        </div>
     </form>
   </div>
 </div>
@@ -55,19 +58,22 @@
 <div class="row">
   <div class="col-sm-12 col-lg-9">
     <div class="log-output">
-      {{#if isLoading}}
+      {{#if showLogLoading}}
         <p class="log-top-message"><span class="spinner spinner-md spinner-inline log-updating-spinner"></span> Loading...</p>
       {{/if}}
-      {{#if isLogEmpty}}
+      {{#if showLogEmpty}}
         <p class="log-top-message">No data in the log file yet, there should be something to see in a few minutes.</p>
       {{/if}}
-      {{#if isLogTooLarge}}
-        <p class="log-top-message"><i class="fa fa-2x fa-exclamation-triangle log-warning-icon"></i> Log too large.  Only last 5000 filtered lines displayed</p>
+      {{#if showLogTruncated}}
+        <p class="log-top-message"><i class="fa fa-2x fa-exclamation-triangle log-warning-icon"></i> Very large log file.  Only the last {{processedLogEntries.length}} lines shown</p>
       {{/if}}
       {{#each processedLogEntries as |entry|}}
-        {{log-entry entry=entry}}
+        {{{entry.formattedText}}}
       {{/each}}
-      {{#if deploymentInProgress}}
+      {{#if errorMessage}}
+        <p class="log-bottom-message"><i class="fa fa-2x fa-exclamation-triangle log-error-icon"></i> {{errorMessage}}</p>
+      {{/if}}
+      {{#if showLogUpdating}}
         <p class="log-bottom-message"><span class="spinner spinner-md spinner-inline log-updating-spinner"></span> Deployment in progress, log file updating.</p>
       {{/if}}
       <div class="log-output-bottom"></div>

--- a/fusor-ember-cli/app/templates/review/progress/log.hbs
+++ b/fusor-ember-cli/app/templates/review/progress/log.hbs
@@ -65,9 +65,9 @@
         <p class="log-top-message">No data in the log file yet, there should be something to see in a few minutes.</p>
       {{/if}}
       {{#if showLogTruncated}}
-        <p class="log-top-message"><i class="fa fa-2x fa-exclamation-triangle log-warning-icon"></i> Very large log file.  Only the last {{processedLogEntries.length}} lines shown</p>
+        <p class="log-top-message"><i class="fa fa-2x fa-exclamation-triangle log-warning-icon"></i> Very large log file.  Only the last {{displayedLog.entries.length}} lines shown</p>
       {{/if}}
-      {{#each processedLogEntries as |entry|}}
+      {{#each displayedLogEntries as |entry|}}
         {{{entry.formattedText}}}
       {{/each}}
       {{#if errorMessage}}

--- a/fusor-ember-cli/app/templates/review/progress/log.hbs
+++ b/fusor-ember-cli/app/templates/review/progress/log.hbs
@@ -67,9 +67,12 @@
       {{#if showLogTruncated}}
         <p class="log-top-message"><i class="fa fa-2x fa-exclamation-triangle log-warning-icon"></i> Very large log file.  Only the last {{displayedLog.entries.length}} lines shown</p>
       {{/if}}
-      {{#each displayedLogEntries as |entry|}}
-        {{{entry.formattedText}}}
+
+      {{{displayedLogHtml}}}
+      {{#each newEntries as |newEntry|}}
+        {{{newEntry}}}
       {{/each}}
+
       {{#if errorMessage}}
         <p class="log-bottom-message"><i class="fa fa-2x fa-exclamation-triangle log-error-icon"></i> {{errorMessage}}</p>
       {{/if}}

--- a/fusor-ember-cli/app/templates/review/progress/log.hbs
+++ b/fusor-ember-cli/app/templates/review/progress/log.hbs
@@ -19,7 +19,7 @@
               <label for="log-search-input" class="sr-only">Search Log Input</label>
               {{input id="log-search-input" type="text" class="form-control log-search-input" placeholder="Search" value=searchLogInputValue}}
               {{#if isSearchActive}}
-                <span class="log-search-result-counter inside-log-search-input">{{searchResultIdx}} of {{numSearchResults}}</span>
+                <span class="log-search-result-counter inside-log-search-input">{{searchResultIdx}} of {{searchResults.length}}</span>
                 <button type="button" class="clear btn btn-log-result-up" aria-hidden="true" {{action 'navPreviousSearchResult'}}><span class="fa fa-angle-up inside-log-search-input"></span></button>
                 <button type="button" class="clear btn btn-log-result-down" aria-hidden="true" {{action 'navNextSearchResult'}}><span class="fa fa-angle-down inside-log-search-input"></span></button>
                 <button type="button" class="clear btn" aria-hidden="true" {{action 'clearSearch'}}><span class="pficon pficon-close"></span></button>

--- a/server/app/models/fusor/logging/java_log_reader.rb
+++ b/server/app/models/fusor/logging/java_log_reader.rb
@@ -1,0 +1,13 @@
+module Fusor
+  module Logging
+    class JavaLogReader < LogReader
+      def parse_log_level(raw_text)
+        return :error if /\sERROR\s|^Caused by:|^\s*at\s\w*\./.match(raw_text)
+        return :warn if /\sWARN\s/.match(raw_text)
+        return :info if /\sINFO\s/.match(raw_text)
+        return :debug if /\sDEBUG\s|\sFINE\s|\sFINER\s|\sFINEST\s|\sTRACE\s/.match(raw_text)
+        nil
+      end
+    end
+  end
+end

--- a/server/app/models/fusor/logging/log_entry.rb
+++ b/server/app/models/fusor/logging/log_entry.rb
@@ -13,7 +13,7 @@
 module Fusor
   module Logging
     class LogEntry
-      attr_accessor :date_time, :level, :text
+      attr_accessor :line_number, :level, :text
     end
   end
 end

--- a/server/app/models/fusor/logging/log_reader.rb
+++ b/server/app/models/fusor/logging/log_reader.rb
@@ -14,7 +14,7 @@ module Fusor
   module Logging
     class LogReader
 
-      MAX_NUM_LINES = 10_000
+      MAX_NUM_LINES = 40_000
 
       def read_full_log(path)
         num_lines = get_num_lines(path)

--- a/server/app/models/fusor/logging/log_reader.rb
+++ b/server/app/models/fusor/logging/log_reader.rb
@@ -13,86 +13,51 @@
 module Fusor
   module Logging
     class LogReader
+
+      MAX_NUM_LINES = 10_000
+
       def read_full_log(path)
+        num_lines = get_num_lines(path)
+        return tail_log(path, num_lines - MAX_NUM_LINES, MAX_NUM_LINES) if num_lines > MAX_NUM_LINES
+
         log = Fusor::Logging::Log.new
         log.path = path
-        log.entries = []
-        File.open(log.path).each { |line| log.entries.push(parse_entry(line)) }
+        line_number = 0
+        File.open(log.path).each { |line| log.entries.push(parse_entry(line, line_number += 1)) }
         log
       end
 
-      def parse_entry(raw_text)
+      def parse_entry(raw_text, line_number)
         entry = Fusor::Logging::LogEntry.new
-        entry.date_time = parse_date raw_text
+        entry.line_number = line_number
         entry.level = parse_log_level raw_text
         entry.text = raw_text[-1] == "\n" ? raw_text[0..-2] : raw_text
         entry
       end
 
-      def parse_date(raw_text)
-        date_str = /\d+-\d+-\d+\s\d+:\d+:\d+/.match(raw_text).to_s
-        begin
-          DateTime.strptime(date_str, '%Y-%m-%d %H:%M:%S')
-        rescue ArgumentError
-          return nil
-        end
+      def parse_log_level(_raw_text)
+        nil
       end
 
-      def parse_log_level(raw_text)
-        level_str = /\[[A-Z]\]/.match(raw_text).to_s
-        return nil unless level_str && level_str.size > 2
-        level_str[1..-2]
+      def tail_log_since(path, lower_boundary)
+        tail_log(path, lower_boundary, get_num_lines(path) - lower_boundary)
       end
 
-      def tail_log_since(path, date_time, num_lines = 1000, num_lines_limit = 16_000)
-        # TODO - implement File.reverse_each then we could do something like:
-        # File.open(log.path).reverse_each{|line| entry = parse(line); break if entry.date_time < date_time}
-        # to read the file backwards and parse it line by line
-
+      # on a 4gb file with 4.4mil lines, wc -l and tail ~= 1s, awk ~= 11s, ruby file.readlines ~= 100s
+      def tail_log(path, lower_boundary, num_lines)
         log = Fusor::Logging::Log.new
         log.path = path
-        tail_n = [num_lines, num_lines_limit].min
-        enough_lines = false
+        return log if num_lines <= 0
 
-        # unfortunately, file.readlines[-200..-1] would read the whole file
-        # so instead, grab enough tail of the log to parse
-        until enough_lines
-          entry_text = `tail -n #{tail_n} #{log.path}`
-          lines = entry_text.split("\n")
-
-          # check to see if we grabbed enough of the log
-          first_date = nil
-          lines.each do |line|
-            d = parse_date line
-            unless d.nil?
-              first_date = d
-              break
-            end
-          end
-
-          if first_date < date_time || tail_n >= num_lines_limit
-            enough_lines = true
-          end
-
-          # get 4x more of the log up to the limit on the next iteration
-          tail_n = [tail_n * 4, num_lines_limit].min
-        end
-
-        # Add lines from the bottom of the log until
-        # we reach one from earlier than the requested date_time
-        log.entries = []
-        lines.reverse_each do |text|
-          entry = parse_entry text
-          break if !entry.date_time.nil? && entry.date_time < date_time
-          log.entries.unshift entry
-        end
-
-        # Pop off any lines at the beginning with no date.
-        # They were part of a log line with a date earlier than we want.
-        while log.entries.length > 0 && log.entries[0].date_time.nil?
-          log.entries.shift
-        end
+        line_number = lower_boundary
+        entry_text = `tail -n #{num_lines} #{log.path}`
+        lines = entry_text.split("\n")
+        lines.each { |line| log.entries.push(parse_entry(line, line_number += 1)) }
         log
+      end
+
+      def get_num_lines(path)
+        `wc -l "#{path}"`.strip.split(' ')[0].to_i
       end
     end
   end

--- a/server/app/models/fusor/logging/proxy_log_reader.rb
+++ b/server/app/models/fusor/logging/proxy_log_reader.rb
@@ -1,0 +1,11 @@
+module Fusor
+  module Logging
+    class ProxyLogReader < LogReader
+      def parse_log_level(raw_text)
+        return :error if /\sERROR\s/.match(raw_text)
+        return nil if raw_text.strip.empty?
+        :info
+      end
+    end
+  end
+end

--- a/server/app/models/fusor/logging/rails_log_reader.rb
+++ b/server/app/models/fusor/logging/rails_log_reader.rb
@@ -1,0 +1,21 @@
+module Fusor
+  module Logging
+    class RailsLogReader < LogReader
+      def parse_log_level(raw_text)
+        level_str = /\[[A-Z]\]/.match(raw_text).to_s
+        return nil unless level_str && level_str.size > 2
+        case level_str[1..-2]
+          when 'D'
+            return :debug
+          when 'I'
+            return :info
+          when 'W'
+            return :warn
+          when 'E'
+            return :error
+        end
+        nil
+      end
+    end
+  end
+end

--- a/server/test/fixtures/log_reader_test_file.log
+++ b/server/test/fixtures/log_reader_test_file.log
@@ -1,9 +1,7 @@
-line 0
-2015-01-02 03:04:01 [E] line 1
+line 1
 line 2
 line 3
 line 4
-2015-01-02 03:04:05 [W] line 5
-2015-01-02 03:04:06 [I] line 6
-2015-01-02 03:04:06 [I] line 7
-line 8 no newline
+line 5
+line 6
+line 7

--- a/server/test/models/java_log_reader_test.rb
+++ b/server/test/models/java_log_reader_test.rb
@@ -1,0 +1,60 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'test_helper'
+
+class JavaLogReaderTest < ActiveSupport::TestCase
+  def setup
+    @reader = Fusor::Logging::JavaLogReader.new
+  end
+
+  # parse_log_level
+  test 'parse_log_level should return :debug log level for debug' do
+    assert_equal :debug, @reader.parse_log_level('should match DEBUG to :debug')
+    assert_equal :debug, @reader.parse_log_level('should match FINE to :debug')
+    assert_equal :debug, @reader.parse_log_level('should match FINER to :debug')
+    assert_equal :debug, @reader.parse_log_level('should match FINEST to :debug')
+    assert_equal :debug, @reader.parse_log_level('should match TRACE to :debug')
+  end
+
+  test 'parse_log_level should return :info log level for info lines' do
+    assert_equal :info, @reader.parse_log_level('should match INFO to :info')
+  end
+
+  test 'parse_log_level should return :warn log level for warnings' do
+    assert_equal :warn, @reader.parse_log_level('should match WARN to :warn')
+  end
+
+  test 'parse_log_level should return :error log level for errors' do
+    assert_equal :error, @reader.parse_log_level('should match ERROR to :error')
+  end
+
+  test 'parse_log_level should return :error log level for stacktrace lines' do
+    assert_equal :error, @reader.parse_log_level('Caused by: a previous error and should match to :error')
+    assert_nil @reader.parse_log_level('should not match caused by since it\'s not at the beginning')
+    assert_equal :error, @reader.parse_log_level('             at com.hello.world')
+    assert_nil @reader.parse_log_level('should not match at com.hello.world since it\'s not at the beginning')
+  end
+
+  test 'parse_log_level should return nil for no log level matched' do
+    assert_nil @reader.parse_log_level ''
+    assert_nil @reader.parse_log_level '       '
+    assert_nil @reader.parse_log_level "\n"
+    assert_nil @reader.parse_log_level 'lowercase error no match'
+  end
+
+  #parse entry
+  test 'parse_entry should set the entry log_level' do
+    entry = @reader.parse_entry('2016-01-05 17:00:00,099 [job=blah] INFO log stuff', 123)
+    assert_equal :info, entry.level
+  end
+end

--- a/server/test/models/proxy_log_reader_test.rb
+++ b/server/test/models/proxy_log_reader_test.rb
@@ -1,0 +1,40 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'test_helper'
+
+class ProxyLogReaderTest < ActiveSupport::TestCase
+  def setup
+    @reader = Fusor::Logging::ProxyLogReader.new
+  end
+
+  # parse_log_level
+  test 'parse_log_level should return :error log level for errors' do
+    assert_equal :error, @reader.parse_log_level('should match ERROR to :error')
+  end
+
+  test 'parse_log_level should return :info for no log level matched' do
+    assert_equal :info, @reader.parse_log_level('lowercase error no match')
+  end
+
+  test 'parse_log_level should return nil for blank lines' do
+    assert_nil @reader.parse_log_level ''
+    assert_nil @reader.parse_log_level '       '
+    assert_nil @reader.parse_log_level "\n"
+  end
+
+  #parse entry uses parse_level
+  test 'parse_entry should set the entry log_level' do
+    entry = @reader.parse_entry('E, [2015-12-21T11:46:58.928214 #26913] ERROR -- : A', 123)
+    assert_equal :error, entry.level
+  end
+end

--- a/server/test/models/rails_log_reader_test.rb
+++ b/server/test/models/rails_log_reader_test.rb
@@ -1,0 +1,56 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+require 'test_helper'
+
+class RailsLogReaderTest < ActiveSupport::TestCase
+  def setup
+    @reader = Fusor::Logging::RailsLogReader.new
+  end
+
+  # parse_log_level
+  test 'parse_log_level should return :debug log level for debug' do
+    assert_equal :debug, @reader.parse_log_level('should match [D] to :debug')
+  end
+
+  test 'parse_log_level should return :info log level for info lines' do
+    assert_equal :info, @reader.parse_log_level('should match [I] to :info')
+  end
+
+  test 'parse_log_level should return :warn log level for warnings' do
+    assert_equal :warn, @reader.parse_log_level('should match [W] to :warn')
+  end
+
+  test 'parse_log_level should return :error log level for errors' do
+    assert_equal :error, @reader.parse_log_level('should match [E] to :error')
+  end
+
+  test 'parse_log_level should return the first valid warning level for multiple matches' do
+    assert_equal :info, @reader.parse_log_level('[I][W][E] should only return I')
+  end
+
+  test 'parse_log_level should return nil for no log level matched' do
+    assert_nil @reader.parse_log_level ''
+    assert_nil @reader.parse_log_level '       '
+    assert_nil @reader.parse_log_level "\n"
+    assert_nil @reader.parse_log_level 'I'
+    assert_nil @reader.parse_log_level '[i]'
+    assert_nil @reader.parse_log_level '[]'
+    assert_nil @reader.parse_log_level '[9]'
+  end
+
+  #parse entry uses parse_level
+  test 'parse_entry should set the entry log_level' do
+    entry = @reader.parse_entry('2015-01-02 03:04:05 [I] some log stuff', 123)
+    assert_equal :info, entry.level
+  end
+end


### PR DESCRIPTION
I've added the new logs and the ability to switch between them.  


Unfortunately, I'm running into performance issues in the UI loading large log files.  In a future PR I'd like to:

1. push the search logic down into the log-entry component 
2. break up the large loops into chunked promise based ones
3. use ember data instead of ajax calls to eliminate the object creation code