### PR TITLE
Bugfix to ensure cloudforms is disabled when it should be during new deployment

### DIFF
--- a/fusor-ember-cli/app/components/rhci-start.js
+++ b/fusor-ember-cli/app/components/rhci-start.js
@@ -2,6 +2,8 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
 
+  isDisabledCfme: true,
+
   setIsDisabledCfme: Ember.observer('isRhev', 'isOpenStack', function() {
     if (this.get('isRhev') || this.get('isOpenStack')) {
       return this.set('isDisabledCfme', false);

--- a/fusor-ember-cli/tests/acceptance/rhci-start-test.js
+++ b/fusor-ember-cli/tests/acceptance/rhci-start-test.js
@@ -1,0 +1,95 @@
+/* jslint node: true */
+import { test } from 'qunit';
+import moduleForAcceptance from '../helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | rhci start');
+
+test('Cloudforms button should be disabled on starting new deployment',
+  function(assert)
+{
+  expect(1);
+  visit('/deployments/new/start');
+
+  andThen(function() {
+    assert.ok($('span#is_cloudforms').find('img').hasClass('disabledImage'));
+  });
+});
+
+test('Selecting rhev should enable ability to select cloudforms',
+  function(assert)
+{
+  expect(1);
+  visit('/deployments/new/start');
+
+  click('.rhci-item #is_rhev');
+
+  andThen(function() {
+    let isDisabled = $('span#is_cloudforms')
+      .find('img')
+      .hasClass('disabledImage');
+
+    assert.notOk(isDisabled);
+  });
+});
+
+test('Selecting osp should enable ability to select cloudforms',
+  function(assert)
+{
+  expect(1);
+  visit('/deployments/new/start');
+
+  click('.rhci-item #is_openstack');
+
+  andThen(function() {
+    let isDisabled = $('span#is_cloudforms')
+      .find('img')
+      .hasClass('disabledImage');
+
+    assert.notOk(isDisabled);
+  });
+});
+
+test('Selecting rhev and osp should enable ability to select cloudforms',
+  function(assert)
+{
+  expect(1);
+  visit('/deployments/new/start');
+
+  click('.rhci-item #is_rhev');
+  click('.rhci-item #is_openstack');
+
+  andThen(function() {
+    let isDisabled = $('span#is_cloudforms')
+      .find('img')
+      .hasClass('disabledImage');
+
+    assert.notOk(isDisabled);
+  });
+});
+
+test('Deselecting a previously active rhev should disable cloudforms',
+  function(assert)
+{
+  expect(2);
+  visit('/deployments/new/start');
+
+  click('.rhci-item #is_rhev');
+
+  andThen(function() {
+    let isDisabled = $('span#is_cloudforms')
+      .find('img')
+      .hasClass('disabledImage');
+
+    assert.notOk(isDisabled);
+  });
+
+  click('.rhci-item #is_rhev');
+
+  andThen(function() {
+    let isDisabled = $('span#is_cloudforms')
+      .find('img')
+      .hasClass('disabledImage');
+
+    assert.ok(isDisabled);
+  });
+});

--- a/fusor-ember-cli/tests/helpers/destroy-app.js
+++ b/fusor-ember-cli/tests/helpers/destroy-app.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default function destroyApp(application) {
+  Ember.run(application, 'destroy');
+}

--- a/fusor-ember-cli/tests/helpers/module-for-acceptance.js
+++ b/fusor-ember-cli/tests/helpers/module-for-acceptance.js
@@ -1,0 +1,23 @@
+import { module } from 'qunit';
+import startApp from './start-app';
+import destroyApp from './destroy-app';
+
+export default function(name, options = {}) {
+  module(name, {
+    beforeEach() {
+      this.application = startApp();
+
+      if (options.beforeEach) {
+        options.beforeEach.apply(this, arguments);
+      }
+    },
+
+    afterEach() {
+      destroyApp(this.application);
+
+      if (options.afterEach) {
+        options.afterEach.apply(this, arguments);
+      }
+    }
+  });
+}


### PR DESCRIPTION
The cloudforms option at `/deployments/start/new` is initially enabled regardless of the selection state of rhev and osp. `setIsDisabledCfme` is configured as an observer, and does not fire on initial page load. Default value fixes this.

Also introduced some initial UI acceptance testing and associated helpers.