### PR TITLE
Moved NFS validation check outside of safe-mount.sh

### DIFF
--- a/server/app/lib/fusor/validators/deployment_validator.rb
+++ b/server/app/lib/fusor/validators/deployment_validator.rb
@@ -142,6 +142,19 @@ module Fusor
           return
         end
 
+        # 36 is the expected UID and GID of the share
+        if File.stat("/tmp/fusor-test-mount-#{deployment.id}").uid != 36
+          add_warning(deployment, _("NFS share has an invalid UID. The expected UID is 36. " \
+                                    "Please check NFS share permissions."))
+          return
+        end
+
+        if File.stat("/tmp/fusor-test-mount-#{deployment.id}").gid != 36
+          add_warning(deployment, _("NFS share has an invalid GID. The expected GID is 36. " \
+                                    "Please check NFS share permissions."))
+          return
+        end
+
         files = Dir["#{output}/*"] # this may return [] if it can't read the share
         Utils::Fusor::CommandUtils.run_command("sudo safe-umount.sh #{deployment.id}")
 


### PR DESCRIPTION
With the validation occurring in deployment_validator.rb, we now print the UID and GID errors to the screen as a warning.