### PR TITLE
Added driver selection to be saved when registering new nodes

### DIFF
--- a/fusor-ember-cli/app/templates/new-node-registration.hbs
+++ b/fusor-ember-cli/app/templates/new-node-registration.hbs
@@ -54,6 +54,7 @@
                                                         labelSize='col-xs-4'
                                                         inputSize='col-xs-6'
                                                         content=drivers
+                                                        value=selectedNode.driver
                                                         selection=selectedNode.driver prompt='unspecified'
                                                         isRequired=true}}
 


### PR DESCRIPTION
All other fields before were being populated so now populated driver based on previous entry to be consistent.