### PR TITLE
1298890 - Validate RHEV Engine/Hypervisor on selection changes

### DIFF
--- a/fusor-ember-cli/app/components/tr-engine.js
+++ b/fusor-ember-cli/app/components/tr-engine.js
@@ -4,19 +4,18 @@ import TrEngineHypervisorMixin from "../mixins/tr-engine-hypervisor-mixin";
 export default Ember.Component.extend(TrEngineHypervisorMixin, {
 
   isSelectedAsEngine: Ember.computed('host', 'selectedRhevEngineHost', function() {
-      if (this.get('selectedRhevEngineHost')) {
-          return (this.get('selectedRhevEngineHost.id') === this.get('host.id'));
-      }
+    if (this.get('selectedRhevEngineHost')) {
+      return (this.get('selectedRhevEngineHost.id') === this.get('host.id'));
+    }
   }),
 
   isChecked: Ember.computed('isSelectedAsEngine', function () {
-      return this.get('isSelectedAsEngine');
+    return this.get('isSelectedAsEngine');
   }),
 
   actions: {
     engineHostChanged(host) {
-      return this.sendAction("action", host);
+      return this.sendAction("action", host, this.get('isInvalidHostname'));
     }
   }
-
 });

--- a/fusor-ember-cli/app/controllers/engine/discovered-host.js
+++ b/fusor-ember-cli/app/controllers/engine/discovered-host.js
@@ -3,8 +3,6 @@ import NeedsDeploymentMixin from "../../mixins/needs-deployment-mixin";
 
 export default Ember.Controller.extend(NeedsDeploymentMixin, {
 
-  //todo - delete hypervisorDiscoveredHostController, not used?
-  //hypervisorDiscoveredHostController: Ember.inject.controller('hypervisor/discovered-host'),
   rhevController: Ember.inject.controller('rhev'),
 
   selectedRhevEngineHost: Ember.computed.alias("model"),
@@ -30,15 +28,12 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
      if (this.get('allDiscoveredHosts')) {
         return allDiscoveredHosts.filter(function(item) {
           if (self.get('hypervisorModelIds')) {
-            //console.log(item.get('id'));
-            //console.log(self.get('hypervisorModelIds'));
             return !(self.get('hypervisorModelIds').contains(item.get('id')));
           }
         });
       }
   }),
 
-  // same as Engine. TODO. put it mixin
   filteredHosts: Ember.computed('availableHosts.[]', 'searchString', 'isStarted', function(){
     var searchString = this.get('searchString');
     var rx = new RegExp(searchString, 'gi');
@@ -62,22 +57,25 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
     return (this.get('model.id')) ? 1 : 0;
   }),
 
-  isHostnameInvalid: false, //can overwritten by action setToInvalidHostname() triggered from tr-engine-hypervisor-mixin.js
-  disableNextOnEngine: Ember.computed('isHostnameInvalid', 'deploymentController.hasNoEngine', function() {
-    return (this.get('isHostnameInvalid') || this.get('deploymentController.hasNoEngine'));
+  isSelectedEngineHostnameInvalid: false,
+
+  disableNextOnEngine: Ember.computed(
+    'isSelectedEngineHostnameInvalid',
+    'deploymentController.hasNoEngine',
+    function()
+  {
+    return this.get('depoymentController.hasNoEngine') ||
+      this.get('isSelectedEngineHostnameInvalid');
   }),
 
   actions: {
-    setEngine(host, isInvalidHostname) {
-      var deployment = this.get('deploymentController');
-      if (!isInvalidHostname) {
-        deployment.set('model.discovered_host', host);
-      }
+    onEngineChanged(newlySelectedHost, isInvalidHostname) {
+      this.set('isSelectedEngineHostnameInvalid', isInvalidHostname);
+      this.set('deploymentController.model.discovered_host', newlySelectedHost);
     },
-
     setIfHostnameInvalid(bool) {
-      this.set('isHostnameInvalid', bool);
+      // Triggered on hostname value changes, *not* when the selected host changes
+      this.set('isSelectedEngineHostnameInvalid', bool);
     }
   }
-
 });

--- a/fusor-ember-cli/app/mixins/tr-engine-hypervisor-mixin.js
+++ b/fusor-ember-cli/app/mixins/tr-engine-hypervisor-mixin.js
@@ -33,7 +33,7 @@ export default Ember.Mixin.create({
         var hostnameRegex = new RegExp(/^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$/);
         var invalidHostname = Ember.isEmpty(this.get('host.name').match(hostnameRegex));
 
-        this.sendAction('setIfHostnameInvalid', invalidHostname);
+        this.sendAction('setIfHostnameInvalid', invalidHostname, this.get('host.id'));
 
         return invalidHostname;
   }),

--- a/fusor-ember-cli/app/templates/components/tr-engine.hbs
+++ b/fusor-ember-cli/app/templates/components/tr-engine.hbs
@@ -1,5 +1,5 @@
 <td>
-    {{radio-button value=host groupValue=selectedRhevEngineHost changed="engineHostChanged" id=cssIdHostId disabled=disabled}}
+  {{radio-button value=host groupValue=selectedRhevEngineHost changed="engineHostChanged" id=cssIdHostId disabled=disabled}}
 </td>
 <td class="{{if isSelectedAsEngine 'white-font' 'not-selected'}}">
     {{#if isSelectedAsEngine}}

--- a/fusor-ember-cli/app/templates/engine/discovered-host.hbs
+++ b/fusor-ember-cli/app/templates/engine/discovered-host.hbs
@@ -53,7 +53,7 @@
              {{tr-engine host=host
                          selectedRhevEngineHost=selectedRhevEngineHost
                          disabled=isStarted
-                         action="setEngine"
+                         action="onEngineChanged"
                          setIfHostnameInvalid='setIfHostnameInvalid'}}
           {{/each}}
         </tbody>


### PR DESCRIPTION
- As previously implemented, validations were only run
on hostname change events, and not also on selection changes
- During Hypervisor selection, need to track hostname validation
on a per host basis rather than just on the most recently changed
hostname.