### PR TITLE
Small fix ups to get rid of ember build errors.

### DIFF
--- a/fusor-ember-cli/app/controllers/hypervisor/discovered-host.js
+++ b/fusor-ember-cli/app/controllers/hypervisor/discovered-host.js
@@ -107,13 +107,13 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
     'hypervisorModelIds',
     'hostnameValidity.updated',
     function() {
-      if(this.get('hypervisorModelIds') == 0) {
-        return true
+      if(this.get('hypervisorModelIds') === 0) {
+        return true;
       }
 
       let vState = this.get('hostnameValidity').get('state');
       let trackedHostIds = Ember.keys(vState);
-      return trackedHostIds.length == 0 ||
+      return trackedHostIds.length === 0 ||
         !trackedHostIds
           .filter((hostId) => this.get('hypervisorModelIds').contains(hostId))
           .map((k) => vState.get(k))


### PR DESCRIPTION
Errors from ember build: 

controllers/hypervisor/discovered-host.js: line 110, col 41, Use '===' to compare with '0'.
controllers/hypervisor/discovered-host.js: line 111, col 20, Missing semicolon.
controllers/hypervisor/discovered-host.js: line 116, col 36, Use '===' to compare with '0'.