### PR TITLE
1299888 - Show ajax errors on failing to deploy.

### DIFF
--- a/fusor-ember-cli/app/controllers/assign-nodes.js
+++ b/fusor-ember-cli/app/controllers/assign-nodes.js
@@ -143,7 +143,7 @@ export default Ember.Controller.extend(DeploymentControllerMixin, NeedsDeploymen
     }).catch(function (error) {
         console.log('ERROR');
         console.log(error.jqXHR);
-        return self.send('error', error);
+        return self.send('error', error.jqXHR);
       }
     );
   },

--- a/fusor-ember-cli/app/controllers/review/installation.js
+++ b/fusor-ember-cli/app/controllers/review/installation.js
@@ -33,14 +33,21 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
 
   buttonDeployDisabled: Ember.computed('deploymentController.isDisabledReview',
                                        'isMissingSubscriptions', function() {
-    return this.get('deploymentController.isDisabledReview') ||
-           this.get('isMissingSubscriptions');
+    return this.get('deploymentController.isDisabledReview(') ||
+           this.get('isMissingSubscriptions') ||
+           this.get('validationErrors.length') > 0;
   }),
 
-  showErrorMessage: false,
-  errorMsg: null,
-  showWarningMessage: false,
-  warningMsg: null,
+  validationWarnings: [],
+  showValidationWarnings: Ember.computed('validationWarnings', function () {
+    return this.get('validationWarnings.length') > 0;
+  }),
+
+  validationErrors: [],
+  showValidationErrors: Ember.computed('validationErrors', function () {
+    return this.get('validationErrors.length') > 0;
+  }),
+
   foremanTasksURL: null,
   skipContent: Ember.computed.alias("deploymentController.skipContent"),
 

--- a/fusor-ember-cli/app/routes/review/installation.js
+++ b/fusor-ember-cli/app/routes/review/installation.js
@@ -36,6 +36,11 @@ export default Ember.Route.extend({
         var deployment = self.modelFor('deployment');
         var token = Ember.$('meta[name="csrf-token"]').attr('content');
 
+        var validationErrors = controller.get('validationErrors');
+
+        controller.set('validationErrors', []);
+        controller.set('validationWarnings', []);
+
         controller.set('showSpinner', true);
         controller.set('spinnerTextMessage', "Validating deployment...");
 
@@ -47,19 +52,15 @@ export default Ember.Route.extend({
                 "Content-Type": "application/json",
                 "X-CSRF-Token": token
             }
-        }).then(function(response) {
-            controller.set('showSpinner', false);
-
-            controller.set('showErrorMessage', response.errors.length > 0);
-            controller.set('errorMsg', response.errors.join("\n"));
-
-            controller.set('showWarningMessage', response.warnings.length > 0);
-            controller.set('warningMsg', response.warnings.join("\n"));
-        }, function(response){
-            controller.set('showSpinner', false);
-            console.log(response);
-            var errorMsg = response.responseText;
-            controller.set('errorMsg', errorMsg);
+        }).then(function (response) {
+          controller.set('showSpinner', false);
+          controller.set('validationErrors', response.validation.errors);
+          controller.set('validationWarnings', response.validation.warnings);
+        }, function(error){
+          console.log('error', error);
+          controller.set('showSpinner', false);
+          controller.set('errorMsg', error.jqXHR.responseText);
+          controller.set('showErrorMessage', true);
         });
     }
   }

--- a/fusor-ember-cli/app/styles/custom.scss
+++ b/fusor-ember-cli/app/styles/custom.scss
@@ -133,6 +133,14 @@ label.env_path_disabled:after {
   color: #a94442;
 }
 
+.validation-alert-icon {
+  float: left;
+}
+
+.validation-alert-message {
+  margin-left: 24px;
+}
+
 .warningForValidation, .warningForValidation a {
   color: $warning-color;
 }

--- a/fusor-ember-cli/app/templates/deployments.hbs
+++ b/fusor-ember-cli/app/templates/deployments.hbs
@@ -30,7 +30,7 @@
       <th> Status </th>
       <th> </th>
     </tr>
-    </thead>
+  </thead>
 
   <tbody>
   {{#each filteredDeployments as |deployment|}}

--- a/fusor-ember-cli/app/templates/review/installation.hbs
+++ b/fusor-ember-cli/app/templates/review/installation.hbs
@@ -4,21 +4,39 @@
     <div class="row">
       <div class='col-md-9'>
         <div class='alert alert-danger rhci-alert'>
-            <i class="fa fa-2x fa-exclamation-triangle errorForValidation"></i>
-            &nbsp;
-            {{errorMsg}}
+          <i class="fa fa-2x fa-exclamation-triangle errorForValidation"></i>
+          &nbsp;
+          {{errorMsg}}
         </div>
       </div>
     </div>
   {{/if}}
 
-  {{#if showWarningMessage}}
+  {{#if showValidationErrors}}
+    <div class="row">
+      <div class='col-md-9'>
+        <div class='alert alert-danger rhci-alert'>
+          <i class="fa fa-2x fa-exclamation-triangle errorForValidation validation-alert-icon"></i>
+          <ul class="validation-alert-message">
+            {{#each validationErrors as |errorMsg|}}
+              <li>{{errorMsg}}</li>
+            {{/each}}
+          </ul>
+        </div>
+      </div>
+    </div>
+  {{/if}}
+
+  {{#if showValidationWarnings}}
     <div class="row">
       <div class='col-md-9'>
         <div class='alert alert-warning rhci-alert'>
-            <i class="fa fa-2x fa-exclamation-triangle warningForValidation"></i>
-            &nbsp;
-            {{warningMsg}}
+            <i class="fa fa-2x fa-exclamation-triangle warningForValidation validation-alert-icon"></i>
+            <ul class="validation-alert-message">
+              {{#each validationWarnings as |warningMsg|}}
+                <li>{{warningMsg}}</li>
+              {{/each}}
+            </ul>
         </div>
       </div>
     </div>

--- a/server/app/controllers/fusor/api/v21/deployments_controller.rb
+++ b/server/app/controllers/fusor/api/v21/deployments_controller.rb
@@ -65,11 +65,13 @@ module Fusor
     end
 
     def validate
-      status = @deployment.valid? ? 200 : 422
-
-      render status: status, json: {
-        :errors => @deployment.errors.full_messages,
-        :warnings => @deployment.warnings
+      @deployment.valid?
+      render json: {
+          :validation => {
+              :deployment_id => @deployment.id,
+              :errors => @deployment.errors.full_messages,
+              :warnings => @deployment.warnings
+          }
       }
     end
 


### PR DESCRIPTION
Deployment validations weren't being displayed.  Using a 422 ias the response status was sending it through the error code path on the UI side which wasn't handling the errors/warnings.  Modified the request to respond with a validation object and a 200 response.

Displayed validation errors/warnings as a list at validation time and at deploy time.  

Error was also assuming we'd have a json response, so modified it to display other responses if they were returned. (ie 404 was returning responseText only).

Turned off spinner after building task list is complete.