### PR TITLE
1300812 - Ensure subscrpition math uses ints

### DIFF
--- a/fusor-ember-cli/app/models/subscription.js
+++ b/fusor-ember-cli/app/models/subscription.js
@@ -13,7 +13,8 @@ export default DS.Model.extend({
   deployment: DS.belongsTo('deployment', {inverse: 'subscriptions', async: true}),
 
   qtySumAttached: Ember.computed('quantity_to_add', 'quantity_attached', function() {
-    return (this.get('quantity_to_add') + this.get('quantity_attached'));
+    return (parseInt(this.get('quantity_to_add')) +
+            parseInt(this.get('quantity_attached')));
   })
 
 });


### PR DESCRIPTION
- This should only affect the mocked environment. When backed by a
  real server, the data pushed to the front end correctly typed and
  it clobbers anything bad in the client store. Nonetheless, guards
  are good to have.