### PR TITLE
1298890 - Fix race condition breaking engine selection validation

### DIFF
--- a/fusor-ember-cli/app/controllers/engine/discovered-host.js
+++ b/fusor-ember-cli/app/controllers/engine/discovered-host.js
@@ -64,7 +64,7 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
     'deploymentController.hasNoEngine',
     function()
   {
-    return this.get('depoymentController.hasNoEngine') ||
+    return this.get('deploymentController.hasNoEngine') ||
       this.get('isSelectedEngineHostnameInvalid');
   }),
 
@@ -73,9 +73,11 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
       this.set('isSelectedEngineHostnameInvalid', isInvalidHostname);
       this.set('deploymentController.model.discovered_host', newlySelectedHost);
     },
-    setIfHostnameInvalid(bool) {
-      // Triggered on hostname value changes, *not* when the selected host changes
-      this.set('isSelectedEngineHostnameInvalid', bool);
+    setIfHostnameInvalid(bool, hostId) {
+      let discoveredHost = this.get('deploymentController.model.discovered_host');
+      if(discoveredHost && discoveredHost.get('id') === hostId) {
+        this.set('isSelectedEngineHostnameInvalid', bool);
+      }
     }
   }
 });

--- a/fusor-ember-cli/app/controllers/hypervisor/discovered-host.js
+++ b/fusor-ember-cli/app/controllers/hypervisor/discovered-host.js
@@ -107,7 +107,7 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
     'hypervisorModelIds',
     'hostnameValidity.updated',
     function() {
-      if(this.get('hypervisorModelIds') === 0) {
+      if(this.get('hypervisorModelIds').get('length') === 0) {
         return true;
       }
 

--- a/fusor-ember-cli/app/mixins/tr-engine-hypervisor-mixin.js
+++ b/fusor-ember-cli/app/mixins/tr-engine-hypervisor-mixin.js
@@ -56,13 +56,13 @@ export default Ember.Mixin.create({
                     "Authorization": "Basic " + self.get('session.basicAuthToken')
                 }
               }).then(function(response) {
-                  self.sendAction('setIfHostnameInvalid', false);
+                  self.sendAction('setIfHostnameInvalid', false, host.get('id'));
                 }, function(error) {
                   console.log(error);
                 }
               );
       } else {
-        this.sendAction('setIfHostnameInvalid', true);
+        this.sendAction('setIfHostnameInvalid', true, host.get('id'));
       }
     }
   }


### PR DESCRIPTION
- Second patch to address this bug. Outstanding server validation
  requests were clobbering currently selected engine invalidation
  state. Patch will only set the invalidation state if the request
  matches the currently selected host.