### PR TITLE
Updated copy ui asset script so by default it will only copy assets, need to run with 'commit' for it to commit

### DIFF
--- a/fusor-ember-cli/copy-fusor-ember-cli-to-ui-assets
+++ b/fusor-ember-cli/copy-fusor-ember-cli-to-ui-assets
@@ -1,4 +1,14 @@
- #!/bin/bash
+#!/bin/bash
+
+COMMIT_ASSETS=0
+
+if [ "$#" -ge "1" ]
+then
+    if [ "$1" == "commit" ] 
+    then
+        COMMIT_ASSETS=1
+    fi
+fi
 
 if [ -f ./dist/assets/fusor-ember-cli.css ]
 then
@@ -43,6 +53,12 @@ cp ./dist/assets/r/blue-i.png        ../ui/app/assets/images/r/;
 
 cp ./dist/fonts/*.*  ../ui/public/fonts/;
 
-cd ..
-git add .;
-git commit -m "copy minified assets from fusor-ember-cli/dist to FusorUI gem at fusor/ui/app/assets";
+if [ "${COMMIT_ASSETS}" -eq "1" ]
+then
+    cd ..
+    git add .;
+    git commit -m "copy minified assets from fusor-ember-cli/dist to FusorUI gem at fusor/ui/app/assets";
+else
+    echo "UI Assets have been copied"
+    echo "If you want to commit, re-run with: $0 commit"
+fi


### PR DESCRIPTION
Intent is script can be reused to copy ui assets over for development testing.
To git commit the assets, run with 'commit'