### PR TITLE
Automatically copy compiled js/css during ember server/build

### DIFF
--- a/fusor-ember-cli/lib/copy-assets/index.js
+++ b/fusor-ember-cli/lib/copy-assets/index.js
@@ -1,0 +1,30 @@
+var fs = require('fs');
+var path = require('path');
+
+module.exports = {
+  name: 'copy-assets',
+
+  outputReady: function(result) {
+    const BUILT_CSS_FILES = [
+        './dist/assets/fusor-ember-cli.css',
+        './dist/assets/fusor-ember-cli.css.map'
+      ],
+      CSS_DESTINATION_DIR = '../ui/app/assets/stylesheets/fusor_ui/',
+      BUILT_JS_FILES = ['./dist/assets/vendor.js',
+        './dist/assets/vendor.map',
+        './dist/assets/fusor-ember-cli.js',
+        './dist/assets/fusor-ember-cli.map'
+      ],
+      JS_DESTINATION_DIR = '../ui/app/assets/javascripts/fusor_ui/';
+
+    BUILT_CSS_FILES.forEach(function (src) {
+      var dst = path.join(CSS_DESTINATION_DIR, path.basename(src));
+      fs.createReadStream(src).pipe(fs.createWriteStream(dst));
+    });
+
+    BUILT_JS_FILES.forEach(function (src) {
+      var dst = path.join(JS_DESTINATION_DIR, path.basename(src));
+      fs.createReadStream(src).pipe(fs.createWriteStream(dst));
+    });
+  }
+};

--- a/fusor-ember-cli/lib/copy-assets/package.json
+++ b/fusor-ember-cli/lib/copy-assets/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "copy-assets",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/fusor-ember-cli/package.json
+++ b/fusor-ember-cli/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.1.2",
-    "ember-cli": "1.13.8",
+    "ember-cli": "1.13.12",
     "ember-cli-app-version": "0.5.0",
     "ember-cli-babel": "^5.1.3",
     "ember-cli-blanket": "0.6.2",
@@ -55,5 +55,10 @@
     "glob": "^4.5.3",
     "morgan": "^1.6.0",
     "phantomjs": "~1.9.18"
+  },
+  "ember-addon": {
+    "paths": [
+      "lib/copy-assets"
+    ]
   }
 }


### PR DESCRIPTION
Automatically copy compiled js/css from fusor-ember-cli dist to ui/assets while running ember server/build.  Does not included static assets such as pngs, etc.