### PR TITLE
Disable deploy if no manifest_file is set

### DIFF
--- a/fusor-ember-cli/app/controllers/review/installation.js
+++ b/fusor-ember-cli/app/controllers/review/installation.js
@@ -15,6 +15,10 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
   isNotDisconnected: Ember.computed.not("isDisconnected"),
   cdnUrl: Ember.computed.alias("model.cdn_url"),
 
+  manifestFile: Ember.computed.alias('deploymentController.model.manifest_file'),
+  hasManifestFile: Ember.computed.notEmpty('manifestFile'),
+  hasNoManifestFile: Ember.computed.not('hasManifestFile'),
+
   buttonDeployTitle: Ember.computed('isStarted', function() {
     if (this.get('isStarted')) {
       return 'Next';
@@ -31,10 +35,16 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
            (!this.get('hasSessionPortal') || !this.get('hasSubscriptionPools')));
   }),
 
-  buttonDeployDisabled: Ember.computed('deploymentController.isDisabledReview',
-                                       'isMissingSubscriptions', function() {
-    return this.get('deploymentController.isDisabledReview(') ||
+  buttonDeployDisabled: Ember.computed(
+    'deploymentController.isDisabledReview',
+    'isMissingSubscriptions',
+    'isDisconnected',
+    'hasNoManifestFile',
+    function()
+  {
+    return this.get('deploymentController.isDisabledReview') ||
            this.get('isMissingSubscriptions') ||
+           (this.get('isDisconnected') && this.get('hasNoManifestFile')) ||
            this.get('validationErrors.length') > 0;
   }),
 


### PR DESCRIPTION
tr796: If backing up and choosing disconnected *after* making it
to the review page, and not uploading a manifest, it's possible
to arrive at the review page and initiate a deployemnt without
a manifest. This causes a deployment to blowup.

This patch prevents you from being able to actually deploy without
a manifest and allows you to backup and set one in order to proceed.