### PR TITLE
Change the default public iface to nic2

### DIFF
--- a/fusor-ember-cli/app/routes/deployment.js
+++ b/fusor-ember-cli/app/routes/deployment.js
@@ -84,8 +84,8 @@ export default Ember.Route.extend(DeploymentRouteMixin, {
 
       if (id === 'Controller-1::NeutronPublicInterface' &&
         (!value || value === 'nic1')) {
-        param.set('value', 'eth1');
-        newParams.push({name: id, value: 'eth1'});
+        param.set('value', 'nic2');
+        newParams.push({name: id, value: 'nic2'});
       }
 
       if (id === 'Compute-1::NovaComputeLibvirtType' &&


### PR DESCRIPTION
Learned something new at the hackathon yesterday; nic1, nic2, etc. has special meaning. nic2 will for instance intelligently use the second nic whether it's eth1, em2, p1p2, or whatever.