### PR TITLE
Add additional validation ensuring the the cluster and datacenter name are valid

### DIFF
--- a/fusor-ember-cli/app/controllers/rhev-options.js
+++ b/fusor-ember-cli/app/controllers/rhev-options.js
@@ -72,9 +72,11 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
   isClusterNeedRenaming: false,
 
   showMsgToChangeCluster: Ember.observer('rhevClusterName', 'rhevDatabaseName', function() {
-    if (this.get('isDirtyRhevDatabaseName') &&
+    if ((this.get('isDirtyRhevDatabaseName') &&
         this.get('rhevClusterName') &&
-        this.get('isNotDirtyRhevClusterName')) {
+        this.get('isNotDirtyRhevClusterName')) ||
+        (this.get('rhevDatabaseName') !== 'Default') &&
+        this.get('rhevClusterName') === 'Default') {
             return this.set('isClusterNeedRenaming', true);
     }
   }),


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1262387
Prevents invalid Datacenter/Cluster name combinations.

Changes
=======
- Adds a check to make sure that if the datacenter's name is not default, the cluster name cannot be default

Side-effects
==========
None