### PR TITLE
1306421 - Remove unused branding entries

### DIFF
--- a/server/app/controllers/fusor/api/v21/subscriptions_controller.rb
+++ b/server/app/controllers/fusor/api/v21/subscriptions_controller.rb
@@ -87,7 +87,6 @@ module Fusor
         @subscription.deployment_id = deployment.id
         @subscription.contract_number = entitlement['pool']['contractNumber']
         @subscription.product_name = entitlement['pool']['productName']
-        #@subscription.product_name = entitlement['pool']['branding'].first['name']
         @subscription.start_date = entitlement['startDate']
         @subscription.end_date = entitlement['endDate']
         @subscription.quantity_attached = entitlement['quantity']

--- a/server/app/lib/fusor/manifest/manifest_importer.rb
+++ b/server/app/lib/fusor/manifest/manifest_importer.rb
@@ -25,7 +25,6 @@ module Fusor
 
         ::Fusor.log.debug "------------------------------------"
         ::Fusor.log.debug "Subscription Name: #{entitlement['pool']['productName']}"
-        ::Fusor.log.debug "Subscription Name2: #{entitlement['pool']['branding'].first['name']}"
         ::Fusor.log.debug "Contract Number: #{entitlement['pool']['contractNumber']}"
         ::Fusor.log.debug "System Type: N/A"
         ::Fusor.log.debug "Start Date: #{entitlement['startDate']}"


### PR DESCRIPTION
The manifest importer was printing out the optional branding entry as debug. If
this is blank it causes the import to fail and throws a 500 error.

We aren't using this value today, so I'm just removing it.