### PR TITLE
Always retry if we couldn't make the connection.

### DIFF
--- a/server/app/lib/actions/fusor/deployment/cloud_forms/update_root_password.rb
+++ b/server/app/lib/actions/fusor/deployment/cloud_forms/update_root_password.rb
@@ -96,7 +96,7 @@ module Actions
           def update_root_password_failed
             ::Fusor.log.debug "=========== failed entered ============="
             @retries -= 1
-            if !@success && @retries >= 0 && recoverable_error?
+            if !@success && @retries >= 0
               @retry = true
             else
               @retry = false
@@ -105,11 +105,6 @@ module Actions
               ::Fusor.log.error "Probable error. Will we retry? #{@retry}. Error message: #{@io.string}"
             end
             ::Fusor.log.debug "=========== failed exited ============="
-          end
-
-          def recoverable_error?
-            recoverable_msgs = ["execution expired", "Connection refused"]
-            recoverable_msgs.any? { |msg| @io.string.include?(msg) }
           end
         end
       end


### PR DESCRIPTION
There are some errors that are truly recoverable, others are not for example no
route to host. But some of these "non recoverable" errors happen because of
timing issues i.e. dns record not updated, ssh daemon not up yet, etc. So if
we always retry, the hope is we'll be able to connect before we exhaust our
retry counter.