### PR TITLE
upgrade to RHEV 3.6

### DIFF
--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -39,8 +39,8 @@
 
       - :product_name: "Red Hat Enterprise Virtualization"
         :product_id: "150"
-        :repository_set_id: "3790"
-        :repository_set_name: "Red Hat Enterprise Virtualization Manager 3.5 (RPMs)"
+        :repository_set_id: "1121"
+        :repository_set_name: "Red Hat Enterprise Virtualization Manager 3 Beta (RPMs)"
         :basearch: "x86_64"
         :releasever: "6Server"
 
@@ -54,30 +54,29 @@
     :rhevh:
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"
-        :repository_set_id: "168"
-        :repository_set_name: "Red Hat Enterprise Linux 6 Server (RPMs)"
+        :repository_set_id: "2456"
+        :repository_set_name: "Red Hat Enterprise Linux 7 Server (RPMs)"
         :basearch: "x86_64"
-        :releasever: "6Server"
+        :releasever: "7Server"
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"
-        :repository_set_id: "1952"
-        :repository_set_name: "Red Hat Enterprise Linux 6 Server (Kickstart)"
+        :repository_set_id: "2455"
+        :repository_set_name: "Red Hat Enterprise Linux 7 Server (Kickstart)"
         :basearch: "x86_64"
-        :releasever: "6.7"
+        :releasever: "7.1"
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"
-        :repository_set_id: "4185"
-        :repository_set_name: "Red Hat Satellite Tools 6.1 (for RHEL 6 Server) (RPMs)"
+        :repository_set_id: "4188"
+        :repository_set_name: "Red Hat Satellite Tools 6.1 (for RHEL 7 Server) (RPMs)"
         :basearch: "x86_64"
 
       - :product_name: "Red Hat Enterprise Virtualization"
         :product_id: "150"
-        :repository_set_id: "1099"
-        :repository_set_name: "Red Hat Enterprise Virtualization Management Agents (RPMs)"
+        :repository_set_id: "3112"
+        :repository_set_name: "Red Hat Enterprise Virtualization Management Agents Beta for RHEL 7 (RPMs)"
         :basearch: "x86_64"
-        :releasever: "6Server"
 
     :cloudforms:
       - :product_name: "Red Hat CloudForms"
@@ -197,8 +196,8 @@
 
        - :name: "RHEV-Hypervisor"
          :os: "RedHat"
-         :major: "6"
-         :minor: "7"
+         :major: "7"
+         :minor: "1"
          :parent: :root_deployment
          :puppet_classes:
            - :name: "ovirt"


### PR DESCRIPTION
Updates for deploying RHEV 3.6. This PR depends on an update to puppet-ovirt in gitlab.