### PR TITLE
Fixed deployment label not being updated on PUT.

### DIFF
--- a/server/app/models/fusor/deployment.rb
+++ b/server/app/models/fusor/deployment.rb
@@ -44,7 +44,8 @@ module Fusor
     belongs_to :foreman_task, :class_name => "::ForemanTasks::Task", :foreign_key => :foreman_task_uuid
 
     after_initialize :setup_warnings
-    before_validation :update_label
+    before_validation :update_label, on: :create  # we validate on create, so we need to do it before those validations
+    before_save :update_label, on: :update        # but we don't validate on update, so we need to call before_save
 
     scoped_search :on => [:id, :name], :complete_value => true
 


### PR DESCRIPTION
We're skipping validations on PUT ([here](https://github.com/fusor/fusor/blob/master/server/app/controllers/fusor/api/v21/deployments_controller.rb#L49)) so the before_validation callback wasn't being called on update.