### PR TITLE
Register Nodes OSP Validations

### DIFF
--- a/fusor-ember-cli/app/components/select-req-f.js
+++ b/fusor-ember-cli/app/components/select-req-f.js
@@ -1,0 +1,65 @@
+import Ember from 'ember';
+
+Ember.SelectOption.reopen({
+  attributeBindings: ['value', 'disabled'],
+  disabled: function() {
+    let content = this.get('content');
+    return content.disabled || false;
+  }.property('content')
+});
+
+export default Ember.Component.extend({
+  // Requires: optionLabelPath, optionValuePath, prompt
+  // Expects showValidationError to be bound to external property
+  _content: Ember.computed('content', 'prompt', function() {
+    let promptObj = Ember.Object.create({
+      disabled: true,
+      isPrompt: true
+    });
+
+    if(this.get('optValueIsOptLabel')) {
+      promptObj.set(this.get('valueKey'), this.get('prompt'));
+    } else {
+      promptObj.set(this.get('labelKey'), this.get('prompt'));
+      promptObj.set(this.get('valueKey'), null);
+    }
+
+    let wrappedContent = Ember.A([promptObj]);
+    wrappedContent.pushObjects(this.get('content'));
+    return wrappedContent;
+  }),
+
+  valueKey: Ember.computed('content', function() {
+    let split = this.get('optionValuePath').split('.');
+    return split[split.length-1];
+  }),
+
+  labelKey: Ember.computed('content', function() {
+    let split = this.get('optionLabelPath').split('.');
+    return split[split.length-1];
+  }),
+
+  optValueIsOptLabel: Ember.computed(
+    'optionValuePath', 'optionLabelPath', function() {
+      return this.get('optionValuePath') === this.get('optionLabelPath');
+  }),
+
+  valueIsPrompt: Ember.computed('value', function() {
+    return this.get('value') === null || this.get('value.isPrompt');
+  }),
+  valueIsNotPrompt: Ember.computed.not('valueIsPrompt'),
+
+  isInvalid: Ember.computed.not('isValid'),
+
+  validationMessages: Ember.computed('value', function() {
+    return [ 'must select an option' ];
+  }),
+
+  hasError: Ember.computed('showValidationError', 'errors.name', 'isInvalid',
+    function() {
+      return this.get('showValidationError') && this.get('isInvalid');
+  }),
+
+  showValidationError: false // Sane default if not bound to external property
+});
+

--- a/fusor-ember-cli/app/components/text-f.js
+++ b/fusor-ember-cli/app/components/text-f.js
@@ -2,6 +2,20 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
 
+  didInsertElement: function () {
+    let resetErrorsMessageKey = this.get('resetErrorsMessageKey');
+    if(resetErrorsMessageKey) {
+      this.eventBus.on(resetErrorsMessageKey,
+                       () => this.send('showValidationErrors'));
+    }
+  },
+  willClearRender: function () {
+    let resetErrorsMessageKey = this.get('resetErrorsMessageKey');
+    if(resetErrorsMessageKey) {
+      this.eventBus.off(resetErrorsMessageKey);
+    }
+  },
+
   typeInput: Ember.computed('type', function() {
     return (this.get('type') ? this.get('type') : 'text');
   }),

--- a/fusor-ember-cli/app/templates/components/select-req-f.hbs
+++ b/fusor-ember-cli/app/templates/components/select-req-f.hbs
@@ -1,0 +1,23 @@
+{{#base-f label=label labelSize=labelSize inputSize=inputSize unitsSize=unitsSize unitsLabel=unitsLabel isRequired=isRequired helpText=helpText errors=errors hasError=hasError}}
+
+  {{view "select"
+    id=cssId
+    content=_content
+    value=value
+    optionLabelPath=optionLabelPath
+    optionValuePath=optionValuePath
+    selection=selection
+    class="form-control"
+    disabled=disabled}}
+
+  {{#if showValidationError}}
+    {{#if hasError}}
+      {{#each validationMessages as |message|}}
+        <p class="error errorForValidation">{{message}}</p>
+      {{/each}}
+    {{/if}}
+  {{/if}}
+
+  {{yield}}
+
+{{/base-f}}

--- a/fusor-ember-cli/app/templates/new-node-registration.hbs
+++ b/fusor-ember-cli/app/templates/new-node-registration.hbs
@@ -50,45 +50,56 @@
                               <div class="form-horizontal">
                                   <fieldset>
                                       <legend>Management</legend>
-                                      {{select-simple-f label="Driver"
-                                                        labelSize='col-xs-4'
-                                                        inputSize='col-xs-6'
-                                                        content=drivers
-                                                        value=selectedNode.driver
-                                                        selection=selectedNode.driver prompt='unspecified'
-                                                        isRequired=true}}
+                                      {{select-req-f label="Driver"
+                                        labelSize='col-xs-4'
+                                        inputSize='col-xs-6'
+                                        prompt='Select a driver'
+                                        content=drivers
+                                        value=selectedNode.driver
+                                        selection=selectedNode.driverObj
+                                        optionLabelPath='content.driver'
+                                        optionValuePath='content.driver'
+                                        isValid=selectedNode.isDriverValid
+                                        showValidationError=showDriverValidationError
+                                        isRequired=true}}
 
                                       {{text-f label="IP Address"
-                                               type='text'
-                                               labelSize='col-xs-4'
-                                               inputSize='col-xs-6'
-                                               value=selectedNode.ipAddress
-                                               isRequired=true}}
+                                        type='text'
+                                        labelSize='col-xs-4'
+                                        inputSize='col-xs-6'
+                                        value=selectedNode.ipAddress
+                                        validator=ipAddressValidator
+                                        resetErrorsMessageKey=resetErrorsMessageKey
+                                        isRequired=true}}
 
                                       {{text-f label="IPMI User"
-                                               type='text'
-                                               labelSize='col-xs-4'
-                                               inputSize='col-xs-6'
-                                               value=selectedNode.ipmiUsername
-                                               isRequired=false}}
+                                        type='text'
+                                        labelSize='col-xs-4'
+                                        inputSize='col-xs-6'
+                                        value=selectedNode.ipmiUsername
+                                        resetErrorsMessageKey=resetErrorsMessageKey
+                                        isRequired=false}}
 
                                       {{text-f label="IPMI Password"
-                                               type='password'
-                                               labelSize='form-label-nowrap col-xs-4'
-                                               inputSize='col-xs-6'
-                                               value=selectedNode.ipmiPassword
-                                               isRequired=false}}
+                                        type='password'
+                                        labelSize='form-label-nowrap col-xs-4'
+                                        inputSize='col-xs-6'
+                                        value=selectedNode.ipmiPassword
+                                        resetErrorsMessageKey=resetErrorsMessageKey
+                                        isRequired=false}}
 
                                   </fieldset>
                                   <fieldset>
                                       <legend>Networking</legend>
-                                      {{textarea-f label="NIC MAC Address"
-                                                   labelSize='form-label-nowrap col-xs-4' inputSize='col-xs-6'
-                                                   value=selectedNode.nicMacAddress
-                                                   cols="40"
-                                                   placeholder="unspecified"
-                                                   rows="2"
-                                                   isRequired=true}}
+                                      {{text-f label="NIC MAC Address"
+                                        type='text'
+                                        labelSize='form-label-nowrap col-xs-4'
+                                        inputSize='col-xs-6'
+                                        value=selectedNode.nicMacAddress
+                                        placeholder="unspecified"
+                                        validator=macAddressValidator
+                                        resetErrorsMessageKey=resetErrorsMessageKey
+                                        isRequired=true}}
                                   </fieldset>
                               </div>
                           </div>
@@ -100,7 +111,7 @@
 
     {{#em-modal-footer}}
         <button type="cancel" class="btn btn-default" disabled={{async}} {{action "cancelRegisterNodes"}}>Cancel</button>
-        <button type="submit" class="btn btn-primary" disabled={{async}} {{action "registerNodes"}}>Register Nodes</button>
+        <button type="submit" class="btn btn-primary" disabled={{disableModalRegisterNodes}} {{action "registerNodes"}}>Register Nodes</button>
     {{/em-modal-footer}}
 
 {{/em-modal}}

--- a/fusor-ember-cli/app/utils/validators.js
+++ b/fusor-ember-cli/app/utils/validators.js
@@ -138,6 +138,15 @@ const IpRangeValidator = RegExpValidator.extend({
     ].join(''), ''),
   message: 'invalid network range'
 });
+const IpAddressValidator = IpRangeValidator.extend({
+  regExp: new RegExp([
+      '^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)',
+      '\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)',
+      '\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)',
+      '\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
+    ].join(''), ''),
+  message: 'invalid ip address'
+});
 
 const CidrValidator = AggregateValidator.extend({
   validators: [
@@ -157,6 +166,12 @@ const HostnameValidator = RegExpValidator.extend({
   message: 'invalid hostname'
 });
 
+function validateZipper(zipper){
+  return zipper
+    .map((pair) => pair[0].isValid(pair[1]))
+    .reduce((lhs, rhs) => lhs && rhs);
+}
+
 export {
   Validator,
   AggregateValidator,
@@ -168,7 +183,9 @@ export {
   RegExpValidator,
   AlphaNumericDashUnderscoreValidator,
   IpRangeValidator,
+  IpAddressValidator,
   CidrValidator,
   MacAddressValidator,
-  HostnameValidator
+  HostnameValidator,
+  validateZipper
 };


### PR DESCRIPTION
-> Makes OSP registration modal a bit more strict, preventing registration until validated data has been entered

-> Introduced a validation aware select-req-f

-> Added `resetErrorsMessageKey` attr to text-f. If provided, component
  will listen for specified message on the eventBus, telling it to
  stop rendering errors. Useful for resetting an entire form.