### PR TITLE
Small fix for OSP controller cleanup, return path and not a closed file

### DIFF
--- a/server/app/lib/actions/fusor/deployment/open_stack/controller_cleanup.rb
+++ b/server/app/lib/actions/fusor/deployment/open_stack/controller_cleanup.rb
@@ -53,7 +53,7 @@ module Actions
             keyfile << client.exec!('cat /home/stack/.ssh/id_rsa')
             keyfile.close
             client.close
-            return keyfile
+            return keyfile.path
           end
 
           def fix_controller_services(deployment, keyfile_path)


### PR DESCRIPTION
Small change, even though the code was working, realized I was returning a File which I had already closed.  My intent was not that, but to return just the path from the File.

I've since run through a clean deployment of OSP with this single change and was successful.

