### PR TITLE
disable CFME configure tab if no location is selected

### DIFF
--- a/fusor-ember-cli/app/controllers/cloudforms.js
+++ b/fusor-ember-cli/app/controllers/cloudforms.js
@@ -11,6 +11,7 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
   isValidCfmeInstallLocation: Ember.computed.notEmpty('deploymentController.model.cfme_install_loc'),
 
   isInvalidCfmeInstallLocation: Ember.computed.not("isValidCfmeInstallLocation"),
+  disableTabCFConfiguration: Ember.computed.alias("isInvalidCfmeInstallLocation"),
 
   validCloudforms: Ember.computed('isValidCfmeInstallLocation', 'isValidCfmeConfiguration', function() {
       return this.get('isValidCfmeInstallLocation') && this.get('isValidCfmeConfiguration');


### PR DESCRIPTION
No CFME location only happens if both RHEV and OSP are selected. Otherwise, CFME location is automatically filled in. The bug was caused since the "Configuration" tab was enabled even though no location was selected.