### PR TITLE
Content Sync Failure Recovery

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -40,6 +40,7 @@ if [ $1 == "install" ]; then
   echo "gem 'coveralls', require: false" >> bundler.d/local.rb
   echo "gem 'foreman_docker', '< 2.0.0'" >> bundler.d/local.rb
   echo "gem 'jwt', '< 1.5.3'" >> bundler.d/local.rb
+  echo "gem 'rake', '< 11'" >> bundler.d/local.rb
 
   # TODO: use the latest version of foreman once this PR is merged
   # https://github.com/theforeman/foreman/pull/3034

--- a/fusor-ember-cli/app/controllers/review/progress.js
+++ b/fusor-ember-cli/app/controllers/review/progress.js
@@ -24,5 +24,4 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
         return 'Deploying ...';
     }
   })
-
 });

--- a/fusor-ember-cli/app/models/deployment.js
+++ b/fusor-ember-cli/app/models/deployment.js
@@ -13,6 +13,7 @@ export default DS.Model.extend({
   deploy_openstack: DS.attr('boolean'),
 
   is_disconnected: DS.attr('boolean'),
+  has_content_error: DS.attr('boolean'),
   rhev_is_self_hosted: DS.attr('boolean'),
 
   rhev_engine_admin_password: DS.attr('string'),

--- a/fusor-ember-cli/app/models/foreman-task.js
+++ b/fusor-ember-cli/app/models/foreman-task.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import DS from 'ember-data';
+import ForemanTaskUtil from '../utils/foreman-task-util';
 
 export default DS.Model.extend({
   label: DS.attr('string'),
@@ -18,5 +19,10 @@ export default DS.Model.extend({
   repository: DS.attr('string'),
   taskUrl: Ember.computed('id', function() {
     return '/foreman_tasks/tasks/' + this.get('id');
-  })
+  }),
+  resume() {
+    const csrfToken = Ember.$('meta[name="csrf-token"]').attr('content');
+    const taskUtil = new ForemanTaskUtil(csrfToken);
+    return taskUtil.resume(this.get('id'));
+  }
 });

--- a/fusor-ember-cli/app/routes/review/progress/overview.js
+++ b/fusor-ember-cli/app/routes/review/progress/overview.js
@@ -37,7 +37,7 @@ export default Ember.Route.extend({
     controller.stopPolling();
 
     ////////////////////////////////////////////////////////////
-    // NOTE: If an error during a pulp sync occurs, the Katelo::Sync
+    // NOTE: If an error during a pulp sync occurs, the Katello::Sync
     // task scheduled in the Fusor Deploy task tree will throw itself
     // into a skipped/warning state. This ultimately bubbles, sending
     // Fusor::Actions::ManageContent into a paused/error state due to

--- a/fusor-ember-cli/app/templates/abandon-deployment-modal.hbs
+++ b/fusor-ember-cli/app/templates/abandon-deployment-modal.hbs
@@ -1,0 +1,20 @@
+{{#em-modal configName="bs" id="abandonDeploymentModal" open-if=isAbandonModalOpen close-if=isCloseModal}}
+    {{#em-modal-title}}
+        {{#em-modal-toggler class="close"}}
+            <span aria-hidden="true">×</span><span class="sr-only">Close</span>
+        {{/em-modal-toggler}}
+        <h4 class="modal-title">Abandon QCI Deployment</h4>
+    {{/em-modal-title}}
+
+    {{#em-modal-body}}
+        Are you sure that you want to abandon this deployment?
+    {{/em-modal-body}}
+
+    {{#em-modal-footer}}
+        {{#em-modal-toggler class="btn btn-default"}}
+          No
+        {{/em-modal-toggler}}
+        <button {{action 'executeAbandonment'}} class="btn btn-danger">Yes, Abandon Deployment</button>
+
+    {{/em-modal-footer}}
+{{/em-modal}}

--- a/fusor-ember-cli/app/templates/review/progress.hbs
+++ b/fusor-ember-cli/app/templates/review/progress.hbs
@@ -31,16 +31,18 @@
   </div>
 </div>
 
-{{#cancel-back-next backRouteName='review.installation'
-                    disableBack=false
-                    disableCancel=isStarted}}
-  {{#if deployTaskIsFinished}}
-    {{#link-to 'review.summary' role="button" class='btn btn-primary'}}
-        Next <i class="fa fa-angle-right"></i>
-    {{/link-to}}
-  {{else}}
-    <button class='btn btn-primary' disabled=true>
-        {{deployButtonTitle}} <i class="fa fa-angle-right"></i>
-    </button>
-  {{/if}}
-{{/cancel-back-next}}
+{{#unless deploymentController.model.has_content_error}}
+  {{#cancel-back-next backRouteName='review.installation'
+                      disableBack=false
+                      disableCancel=isStarted}}
+    {{#if deployTaskIsFinished}}
+      {{#link-to 'review.summary' role="button" class='btn btn-primary'}}
+          Next <i class="fa fa-angle-right"></i>
+      {{/link-to}}
+    {{else}}
+      <button class='btn btn-primary' disabled=true>
+          {{deployButtonTitle}} <i class="fa fa-angle-right"></i>
+      </button>
+    {{/if}}
+  {{/cancel-back-next}}
+{{/unless}}

--- a/fusor-ember-cli/app/templates/review/progress.hbs
+++ b/fusor-ember-cli/app/templates/review/progress.hbs
@@ -31,6 +31,7 @@
   </div>
 </div>
 
+{{! Hide buttons if the deployment has_content_error }}
 {{#unless deploymentController.model.has_content_error}}
   {{#cancel-back-next backRouteName='review.installation'
                       disableBack=false

--- a/fusor-ember-cli/app/templates/review/progress/overview.hbs
+++ b/fusor-ember-cli/app/templates/review/progress/overview.hbs
@@ -6,8 +6,8 @@
     <div style="float: left; margin-top: 2px" class="spinner spinner-md spinner-inline"></div>
   {{else}}
     <h1>Content Error Occurred</h1>
-    <button {{action 'abandon'}}>Abandon Deployment</button>
-    <button {{action 'redeploy'}}>Redeploy</button>
+    <button class="btn btn-default" {{action 'abandon'}}>Abandon Deployment</button>
+    <button class="btn btn-primary" {{action 'redeploy'}}>Redeploy</button>
   {{/if}}
 {{else}}
 

--- a/fusor-ember-cli/app/templates/review/progress/overview.hbs
+++ b/fusor-ember-cli/app/templates/review/progress/overview.hbs
@@ -1,19 +1,34 @@
 <br />
 
-{{progress-bar model=manageContentTask name=nameSatellite isSatelliteProgressBar=true}}
+{{#if deployment.has_content_error}}
+  {{#if loadingRedeployment}}
+    <h1 style="float: left; margin: 0 15px 0 0">Content Error Occurred</h1>
+    <div style="float: left; margin-top: 2px" class="spinner spinner-md spinner-inline"></div>
+  {{else}}
+    <h1>Content Error Occurred</h1>
+    <button {{action 'abandon'}}>Abandon Deployment</button>
+    <button {{action 'redeploy'}}>Redeploy</button>
+  {{/if}}
+{{else}}
 
-{{#if isRhev}}
-  {{progress-bar model=rhevTask name=nameRhev isSatelliteProgressBar=false}}
+  {{progress-bar model=manageContentTask name=nameSatellite isSatelliteProgressBar=true}}
+
+  {{#if isRhev}}
+    {{progress-bar model=rhevTask name=nameRhev isSatelliteProgressBar=false}}
+  {{/if}}
+
+  {{#if isOpenStack}}
+    {{progress-bar model=openstackTask name=nameOpenStack isSatelliteProgressBar=false}}
+  {{/if}}
+
+  {{#if isCloudForms}}
+    {{progress-bar model=cfmeTask name=nameCloudForms isSatelliteProgressBar=false}}
+  {{/if}}
+
+  {{#if showDeployTaskProgressBar}}
+    {{progress-bar model=deployTask name='Total Deployment' isSatelliteProgressBar=false}}
+  {{/if}}
+
 {{/if}}
 
-{{#if isOpenStack}}
-  {{progress-bar model=openstackTask name=nameOpenStack isSatelliteProgressBar=false}}
-{{/if}}
-
-{{#if isCloudForms}}
-  {{progress-bar model=cfmeTask name=nameCloudForms isSatelliteProgressBar=false}}
-{{/if}}
-
-{{#if showDeployTaskProgressBar}}
-  {{progress-bar model=deployTask name='Total Deployment' isSatelliteProgressBar=false}}
-{{/if}}
+{{partial 'abandon-deployment-modal'}}

--- a/fusor-ember-cli/app/utils/foreman-task-util.js
+++ b/fusor-ember-cli/app/utils/foreman-task-util.js
@@ -1,0 +1,30 @@
+// ForemanTaskUtil: Wrappers around driving foreman tasks
+
+import Ember from 'ember';
+import request from 'ic-ajax';
+let Promise = Ember.RSVP.Promise;
+
+class ForemanTaskUtil {
+  constructor(csrfToken) {
+    this._csrfToken = csrfToken;
+    this._uriRoot = `${window.location.protocol}//${window.location.host}`;
+    this._foremanApiPath = '/foreman_tasks/api';
+    this._foremanApiUri = `${this._uriRoot}${this._foremanApiPath}`;
+    this._resumePath = `/tasks/bulk_resume`;
+    this._resumeUri = `${this._foremanApiUri}${this._resumePath}`;
+  }
+  resume(taskId) {
+    return request({
+      url: this._resumeUri,
+      type: 'POST',
+      headers: {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "X-CSRF-Token": this._csrfToken,
+      },
+      data: JSON.stringify({ 'search': taskId })
+    });
+  }
+}
+
+export default ForemanTaskUtil;

--- a/server/app/serializers/fusor/deployment_serializer.rb
+++ b/server/app/serializers/fusor/deployment_serializer.rb
@@ -30,6 +30,7 @@ module Fusor
                :openstack_overcloud_hostname,
                :cfme_hostname,
                :is_disconnected,
+               :has_content_error,
                :cdn_url, :manifest_file,
                :created_at, :updated_at
 

--- a/server/config/routes/api/v21.rb
+++ b/server/config/routes/api/v21.rb
@@ -5,6 +5,7 @@ Fusor::Engine.routes.draw do
         resources :deployments do
           member do
             put :deploy
+            put :redeploy
             get :validate
             get :log
           end

--- a/server/db/migrate/20160305171005_add_has_content_error.rb
+++ b/server/db/migrate/20160305171005_add_has_content_error.rb
@@ -1,0 +1,5 @@
+class AddHasContentError < ActiveRecord::Migration
+  def change
+    add_column :fusor_deployments, :has_content_error, :boolean
+  end
+end


### PR DESCRIPTION
```
-> Upon an error thrown during content sync, ManageContent task will
be auto-resumed to ensure locks are dropped.

-> During progress overview, will monitor for ManageContent error.
 If this occurs, will mark the deployment with a content error
`has_content_error` in the fusor database and prompt the user
with recovery options.

-> Deployment can be abandoned (deleted), or the user can attempt a
redeployment. In practice, this means fusor server kicks off a new
Deploy task using the existing deployment object, and the front
end re-associates the new task with the deployment.
```
**Known Issue**: This patch relies on the front end to resume a bad ManageContent task.
As such, resume won't occur unless the progress overview page is opened/already open.
The logic needs to be moved serverside with some kind of a task monitor or polling task,
but I think our TP3 requirements should be met with this PR as is. I'm intending to
submit the serverside resume as a separate PR this week.