### PR TITLE
rubocop: whitespace, indentation.

### DIFF
--- a/server/app/lib/actions/fusor/deployment/open_shift/deploy.rb
+++ b/server/app/lib/actions/fusor/deployment/open_shift/deploy.rb
@@ -26,13 +26,13 @@ module Actions
             sequence do
               plan_action(::Actions::Fusor::Deployment::Rhev::OseLaunch, deployment)
 
-              #TODO wait for all master and node VMs to finish booting
-#              concurrence do
-#                list_of_all_openshift_vms.each do |host|
-#                  plan_action(::Actions::Fusor::Host::WaitUntilProvisioned,
-#                              host.name)
-#                end
-#              end
+              # TODO wait for all master and node VMs to finish booting
+              # concurrence do
+              #   list_of_all_openshift_vms.each do |host|
+              #     plan_action(::Actions::Fusor::Host::WaitUntilProvisioned,
+              #                 host.name)
+              #   end
+              # end
             end
           end
         end

--- a/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
@@ -31,13 +31,13 @@ module Actions
 
             # launch master nodes
             for i in 1..deployment.openshift_number_master_nodes do
-              vmlauncher = Utils::Fusor::VMLauncher.new(deployment, 
-                                                        'ose', 
+              vmlauncher = Utils::Fusor::VMLauncher.new(deployment,
+                                                        'ose',
                                                         deployment.openshift_install_loc,
                                                         'RedHat 7.1',
                                                         'x86_64')
               vmlauncher.set_hostname("#{deployment.label.tr('_', '-')}-ose-master#{i}")
-              
+
               host = vmlauncher.launch_openshift_vm(deployment.openshift_master_vcpu,
                                                     deployment.openshift_master_ram,
                                                     deployment.openshift_master_disk,
@@ -53,13 +53,13 @@ module Actions
 
             # launch worker nodes
             for i in 1..deployment.openshift_number_worker_nodes do
-              vmlauncher = Utils::Fusor::VMLauncher.new(deployment, 
-                                                        'ose', 
+              vmlauncher = Utils::Fusor::VMLauncher.new(deployment,
+                                                        'ose',
                                                         deployment.openshift_install_loc,
                                                         'RedHat 7.1',
                                                         'x86_64')
               vmlauncher.set_hostname("#{deployment.label.tr('_', '-')}-ose-node#{i}")
-              
+
               host = vmlauncher.launch_openshift_vm(deployment.openshift_node_vcpu,
                                                     deployment.openshift_node_ram,
                                                     deployment.openshift_node_disk,

--- a/server/app/lib/actions/fusor/deployment/rhev/upload_image.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/upload_image.rb
@@ -45,7 +45,7 @@ module Actions
             username = "admin@internal"
             imported_template_name = "#{deployment.label}-#{input[:appliance]}-template"
             export_domain_name = deployment.rhev_export_domain_name
-            image_path = "/root/#{input[:image_file_name]}" 
+            image_path = "/root/#{input[:image_file_name]}"
 
             # NOTE: the image file found locally is DIFFERENT than the one on
             # the rhev engine host. Also note this uses /usr/bin/ because it is on

--- a/server/app/models/setting/cloudforms.rb
+++ b/server/app/models/setting/cloudforms.rb
@@ -9,7 +9,7 @@ module Fusor
           self.set('cloudforms_vm_disk_size', N_("Size of Storage (GB) for VM for CloudForms"), 40),
           self.set('cloudforms_db_disk_size', N_("Size of Storage (GB) for DB for CloudForms"), 40),
           self.set('cloudforms_ram', N_("Amount of RAM (GB) for CloudForms"), 6),
-          self.set('cloudforms_vcpu', N_("Number of vCPU's for CloudForms"), 4),
+          self.set('cloudforms_vcpu', N_("Number of vCPU's for CloudForms"), 4)
         ].each { |s| self.create! s.update(:category => "Setting::Cloudforms") }
 
       end

--- a/server/app/models/setting/openshift.rb
+++ b/server/app/models/setting/openshift.rb
@@ -11,7 +11,7 @@ module Fusor
           self.set('openshift_master_disk', N_("Amount of Storage (GB) for each OSE Master Node"), 30),
           self.set('openshift_node_vcpu', N_("Number of vCPU's for each OSE Worker Node"), 1),
           self.set('openshift_node_ram', N_("Amount of RAM (GB) for each OSE Worker Node"), 8),
-          self.set('openshift_node_disk', N_("Amount of Storage (GB) for each OSE Worker Node"), 15),
+          self.set('openshift_node_disk', N_("Amount of Storage (GB) for each OSE Worker Node"), 15)
         ].each { |s| self.create! s.update(:category => "Setting::Openshift") }
       end
       true


### PR DESCRIPTION
rubocop: Avoid comma after the last item of an array
rubocop: Trailing whitespace detected.
rubocop: Surrounding space missing in default value assignment.
rubocop: Use 2 (not 6) spaces for indentation.
rubocop: Align the elements of a hash literal
rubocop: Incorrect indentation detected
rubocop: ignore class length for now

Added a trello card to refactor it:

https://trello.com/c/CbLbQ7aa/979-refactor-vm-launcher-rb-the-class-is-too-long