### PR TITLE
Fixed check that NFS share is empty and display warning if it does not

### DIFF
--- a/server/app/lib/fusor/validators/deployment_validator.rb
+++ b/server/app/lib/fusor/validators/deployment_validator.rb
@@ -167,7 +167,7 @@ module Fusor
           return
         end
 
-        files = Dir["#{output}/*"] # this may return [] if it can't read the share
+        files = Dir["/tmp/fusor-test-mount-#{deployment.id}/*"] # this may return [] if it can't read the share
         Utils::Fusor::CommandUtils.run_command("sudo safe-umount.sh #{deployment.id}")
 
         if files.length > 0


### PR DESCRIPTION
#{output} was the mount location as a text string with '\n' at the end. files was always being set to [] which would render this validation useless.