### PR TITLE
Create wildcard subdomain entry for OSE installation

### DIFF
--- a/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
@@ -54,7 +54,12 @@ module Actions
                                                :hostname => "*.#{deployment.openshift_subdomain_name}.#{Domain.find(host.domain_id)}",
                                                :proxy => Domain.find(1).proxy
                                              })
-            subdomain.create
+            if subdomain.valid?
+              subdomain.create
+              ::Fusor.log.debug "====== OSE wildcard subdomain created successfully ======"
+            else
+              ::Fusor.log.debug "====== OSE wildcard subdomain is not valid, it might conflict with a previous entry. Skipping. ======"
+            end
 
             # launch worker nodes
             for i in 1..deployment.openshift_number_worker_nodes do

--- a/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
@@ -50,6 +50,11 @@ module Actions
                 ::Fusor.log.debug "====== OSE Launched VM IP   : #{host.ip}   ======"
               end
             end
+            subdomain = Net::DNS::ARecord.new({:ip => host.ip,
+                                               :hostname => "*.#{deployment.openshift_subdomain_name}.#{Domain.find(host.domain_id)}",
+                                               :proxy => Domain.find(1).proxy
+                                             })
+            subdomain.create
 
             # launch worker nodes
             for i in 1..deployment.openshift_number_worker_nodes do


### PR DESCRIPTION
This creates a subdomain entry to point to the OSE master host. This will be used to host OSE applications by redirecting through the OSE router.