### PR TITLE
Restore ability to use a specific CFME image file name from fusor.yaml.

### DIFF
--- a/server/app/lib/actions/fusor/deployment/cloud_forms/deploy.rb
+++ b/server/app/lib/actions/fusor/deployment/cloud_forms/deploy.rb
@@ -45,7 +45,7 @@ module Actions
               if deployment.cfme_install_loc == 'RHEV'
                 transfer_action = plan_action(::Actions::Fusor::Deployment::Rhev::TransferImage,
                                               deployment, file_repositories(repositories).first,
-                                              image_file_name(SETTINGS[:fusor][:content][:cloudforms]))
+                                              image_file_name(SETTINGS[:fusor][:content][:cloudforms], :rhev_image_file_name))
 
                 upload_action = plan_action(::Actions::Fusor::Deployment::Rhev::UploadImage,
                                             deployment, transfer_action.output[:image_file_name])
@@ -57,7 +57,7 @@ module Actions
               elsif deployment.cfme_install_loc == 'OpenStack'
                 plan_action(::Actions::Fusor::Deployment::OpenStack::CfmeUpload, deployment,
                             file_repositories(repositories).first,
-                            image_file_name(SETTINGS[:fusor][:content][:cloudforms]))
+                            image_file_name(SETTINGS[:fusor][:content][:cloudforms], :rhos_image_file_name))
                 plan_action(::Actions::Fusor::Deployment::OpenStack::CfmeSecgroup, deployment)
                 plan_action(::Actions::Fusor::Deployment::OpenStack::CfmeLaunch, deployment)
               end
@@ -93,9 +93,9 @@ module Actions
             repos
           end
 
-          def image_file_name(product_content)
-            product = product_content.find { |content| !content[:image_file_name].nil? }
-            product[:image_file_name] if product
+          def image_file_name(product_content, key_name)
+            product = product_content.find { |content| !content[key_name].nil? }
+            product[key_name] if product
           end
 
           def file_repositories(repositories)

--- a/server/app/lib/actions/fusor/deployment/rhev/transfer_image.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/transfer_image.rb
@@ -38,7 +38,7 @@ module Actions
             deployment = ::Fusor::Deployment.find(input[:deployment_id])
             repository = ::Katello::Repository.find(input[:repository_id])
 
-            image_full_path, image_file_name = find_image_details(repository, input[:image_file_name])
+            image_full_path, image_file_name = Utils::CloudForms::ImageLookup.find_image_details(repository, input[:image_file_name], 'cfme-rhev')
             scp_image_file(deployment, image_full_path)
 
             output[:image_full_path] = image_full_path
@@ -59,22 +59,6 @@ module Actions
               scp.upload!(image_file, "/root")
             end
           end
-
-          def find_image_details(repository, image_file_name)
-            images = ::Katello.pulp_server.extensions.repository.unit_search(repository.pulp_id)
-
-            if image_file_name
-              image_name = images.find { |image| image[:metadata][:name] == image_file_name }
-              image_path = image_file[:metadata][:_storage_path] if image_name
-            else
-              images = images.find_all { |image| image[:metadata][:name].starts_with?("cfme-rhevm") }
-              image_name = images.compact.sort_by { |k| k[:name] }.last[:metadata][:name]
-              image_path = images.compact.sort_by { |k| k[:name] }.last[:metadata][:_storage_path]
-            end
-
-            return image_path, image_name
-          end
-
         end
       end
     end

--- a/server/app/lib/utils/cloud_forms/image_lookup.rb
+++ b/server/app/lib/utils/cloud_forms/image_lookup.rb
@@ -1,0 +1,38 @@
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Utils
+  module CloudForms
+    class ImageLookup
+      def self.find_image_details(repository, image_file_name, image_prefix)
+        ## Expecting image_prefix to be one of 'cfme-rhevm' or 'cfme-rhos'
+
+        images = ::Katello.pulp_server.extensions.repository.unit_search(repository.pulp_id)
+
+        if image_file_name
+          image_file = images.find { |image| image[:metadata][:name] == image_file_name }
+          if !image_file
+            fail _("Unable to find image '%{image_file_name}'") % { :image_file_name => image_file_name}
+          end
+          image_name = image_file[:metadata][:name]
+          image_path = image_file[:metadata][:_storage_path]
+        else
+          images = images.find_all { |image| image[:metadata][:name].starts_with?(image_prefix) }
+          image_name = images.compact.sort_by { |k| k[:name] }.last[:metadata][:name]
+          image_path = images.compact.sort_by { |k| k[:name] }.last[:metadata][:_storage_path]
+        end
+
+        return image_path, image_name
+      end
+    end
+  end
+end

--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -84,7 +84,12 @@
         :repository_set_id: "4631"
         :repository_set_name: "Red Hat CloudForms Management Engine 5.5 (Files)"
         :basearch: "x86_64"
-        #:image_file_name: "cfme-rhevm-5.3-54.x86_64.rhevm.ova" # Default behavior uses the 'latest' image file.
+        # Default behavior is to use the latest available image found
+        # in the repository if either :rhos_image_file_name or :rhev_image_file_name
+        # are commented out.
+        #
+        #:rhos_image_file_name: "cfme-rhos-5.5.2.4-1.x86_64.qcow2"
+        #:rhev_image_file_name: "cfme-rhevm-5.5.2.4-1.x86_64.rhevm.ova"
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"


### PR DESCRIPTION
Intent is to merge this into Master, then cherrypick to TP3.

During investigation of locking down CFME to a specific version for TP3 I ran into the below error.
This PR is to fix this problem and allow us to specify 'image_file_name' in fusor.yaml

2016-04-05 13:51:55 [E] undefined local variable or method `image_file' for #<Actions::Fusor::Deployment::Rhev::TransferImage:0x007f2f0892f070> (NameError)
/git/RHCI/fusor/server/app/lib/actions/fusor/deployment/rhev/transfer_image.rb:68:in `find_image_details'
/git/RHCI/fusor/server/app/lib/actions/fusor/deployment/rhev/transfer_image.rb:41:in `run'
/git/RHCI/dynflow/lib/dynflow/action.rb:487:in `block (3 levels) in execute_run'