### PR TITLE
Check for duplicate subdomain entries

### DIFF
--- a/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
@@ -57,10 +57,10 @@ module Actions
                                                :proxy => Domain.find(1).proxy
                                              })
             if subdomain.valid?
+              ::Fusor.log.debug "====== OSE wildcard subdomain is not valid, it might conflict with a previous entry. Skipping. ======"
+            else
               subdomain.create
               ::Fusor.log.debug "====== OSE wildcard subdomain created successfully ======"
-            else
-              ::Fusor.log.debug "====== OSE wildcard subdomain is not valid, it might conflict with a previous entry. Skipping. ======"
             end
 
             # launch worker nodes


### PR DESCRIPTION
This succeeded previously because I had already created duplicate entries. The check for subdomain.valid? returns true if the entry already exists.