### PR TITLE
Changed default disk size to 30 Gb for Docker storage

### DIFF
--- a/fusor-ember-cli/app/routes/deployment.js
+++ b/fusor-ember-cli/app/routes/deployment.js
@@ -94,7 +94,7 @@ export default Ember.Route.extend(DeploymentRouteMixin, {
         }
       });
 
-      // set default values 1 Master, 1 Worker, 20GB storage for OSE
+      // set default values 1 Master, 1 Worker, 30GB storage for OSE
       if (!(model.get('openshift_number_master_nodes') > 0)) {
         model.set('openshift_number_master_nodes', 1);
       }
@@ -102,7 +102,7 @@ export default Ember.Route.extend(DeploymentRouteMixin, {
         model.set('openshift_number_worker_nodes', 1);
       }
       if (!(model.get('openshift_storage_size') > 0)) {
-        model.set('openshift_storage_size', 20);
+        model.set('openshift_storage_size', 30);
       }
 
     }


### PR DESCRIPTION
Default storage size is now set to 30 Gb.