### PR TITLE
Removed hard coded root password values and added Docker storage on second partition

### DIFF
--- a/fusor-ember-cli/app/models/deployment.js
+++ b/fusor-ember-cli/app/models/deployment.js
@@ -76,6 +76,7 @@ export default DS.Model.extend({
   openshift_storage_size: DS.attr('number'),
   openshift_username: DS.attr('string'),
   openshift_user_password: DS.attr('string'),
+  openshift_root_password: DS.attr('string'),
   openshift_master_vcpu: DS.attr('number'),
   openshift_master_ram: DS.attr('number'),
   openshift_master_disk: DS.attr('number'),

--- a/fusor-ember-cli/app/routes/deployment.js
+++ b/fusor-ember-cli/app/routes/deployment.js
@@ -94,7 +94,7 @@ export default Ember.Route.extend(DeploymentRouteMixin, {
         }
       });
 
-      // set default values 1 Master, 1 Worker, 20GB storage for OSE
+      // set default values 1 Master, 1 Worker, 30GB storage for OSE
       if (!(model.get('openshift_number_master_nodes') > 0)) {
         model.set('openshift_number_master_nodes', 1);
       }
@@ -102,7 +102,7 @@ export default Ember.Route.extend(DeploymentRouteMixin, {
         model.set('openshift_number_worker_nodes', 1);
       }
       if (!(model.get('openshift_storage_size') > 0)) {
-        model.set('openshift_storage_size', 20);
+        model.set('openshift_storage_size', 30);
       }
 
     }

--- a/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
@@ -36,9 +36,7 @@ module Actions
             hostgroup = find_hostgroup(deployment, hostgroup_name)
             os = Operatingsystem.find(hostgroup.operatingsystem_id)
 
-            ::Fusor.log.info '====== Generating randomized password for root access ======'
-            deployment.openshift_root_password = SecureRandom.hex(10)
-            deployment.save!
+            generate_root_password(deployment)
 
             ensure_vda_only_ptable(ptable_name)
             update_ptable_for_os(ptable_name, os.title)
@@ -182,6 +180,12 @@ module Actions
                 where(:ancestry => ancestry).
                 joins(:organizations).
                 where("taxonomies.id in (?)", [deployment.organization.id]).first
+          end
+
+          def generate_root_password(deployment)
+            ::Fusor.log.info '====== Generating randomized password for root access ======'
+            deployment.openshift_root_password = SecureRandom.hex(10)
+            deployment.save!
           end
 
           def ensure_vda_only_ptable(ptable_name)

--- a/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
@@ -11,6 +11,7 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 require 'net/http'
 require 'net/ssh'
+require 'securerandom'
 
 module Actions
   module Fusor
@@ -34,6 +35,10 @@ module Actions
             ptable_name = "#{hostgroup_name} Ptable"
             hostgroup = find_hostgroup(deployment, hostgroup_name)
             os = Operatingsystem.find(hostgroup.operatingsystem_id)
+
+            ::Fusor.log.info '====== Generating randomized password for root access ======'
+            deployment.openshift_root_password = SecureRandom.hex(10)
+            deployment.save!
 
             ensure_vda_only_ptable(ptable_name)
             update_ptable_for_os(ptable_name, os.title)
@@ -99,11 +104,8 @@ module Actions
               end
             end
 
-            #TODO: Need to revisit and remove these hardcoded values.
-            # https://trello.com/c/sSVPuP8b
-
             username = 'root'
-            password = 'dog8code'
+            password = deployment.openshift_root_password
 
             # wait for all the master nodes to fully boot with sshd available
             deployment.ose_master_hosts.each do |host|

--- a/server/app/lib/utils/fusor/ose_ssh_key_utils.rb
+++ b/server/app/lib/utils/fusor/ose_ssh_key_utils.rb
@@ -8,10 +8,7 @@ module Utils
         @key_from_path = File.join(Rails.root, 'ssh-keys', 'openshift', "#{@deployment.label}-#{@deployment.id}")
         @key_to_path   = ".ssh"
         @key_base_name = "id_#{@key_type}"
-
-        #TODO need to read this from deployment set from WebUI
-        # https://trello.com/c/sSVPuP8b
-        @root_password = 'dog8code'
+        @root_password = @deployment.openshift_root_password
       end
 
       def get_ssh_private_key_path

--- a/server/app/lib/utils/fusor/vm_launcher.rb
+++ b/server/app/lib/utils/fusor/vm_launcher.rb
@@ -208,7 +208,7 @@ module Utils
                        "architecture_id" => Architecture.find_by_name(@architecture)['id'],
                        "operatingsystem_id" => Operatingsystem.find_by_title(@operatingsystem)['id'],
                        "domain_id" => 1,
-                       "root_pass" => "dog8code",
+                       "root_pass" => @deployment.openshift_root_password,
                        "mac" => "admin"
                       }.with_indifferent_access
       end

--- a/server/app/serializers/fusor/deployment_serializer.rb
+++ b/server/app/serializers/fusor/deployment_serializer.rb
@@ -34,6 +34,7 @@ module Fusor
                :openshift_storage_size,
                :openshift_username,
                :openshift_user_password,
+               :openshift_root_password,
                :openshift_master_vcpu,
                :openshift_master_ram,
                :openshift_master_disk,

--- a/server/db/migrate/20160419111944_add_openshift_root_password.rb
+++ b/server/db/migrate/20160419111944_add_openshift_root_password.rb
@@ -1,0 +1,5 @@
+class AddOpenshiftRootPassword < ActiveRecord::Migration
+  def change
+    add_column :fusor_deployments, :openshift_root_password, :string
+  end
+end

--- a/server/lib/modules/ose_installer/files/docker-storage-setup
+++ b/server/lib/modules/ose_installer/files/docker-storage-setup
@@ -4,6 +4,6 @@
 # For more details refer to "man docker-storage-setup"
 
 # Workaround for https://trello.com/c/1fhpNoVQ, use loopback
-#DEVS=/dev/vdb
-#VG=docker-vg
+DEVS=/dev/vdb
+VG=docker-vg
 

--- a/server/lib/modules/ose_installer/playbooks/setup.yml
+++ b/server/lib/modules/ose_installer/playbooks/setup.yml
@@ -8,23 +8,16 @@
       with_items:
         - docker
 
-    #- name: temporarily downgrade docker
-    #  shell: sudo yum downgrade -y docker
+    - name: scp docker storage configuration
+      action: copy src="../files/docker-storage-setup" dest="/etc/sysconfig/docker-storage-setup" owner=root mode=0775
 
-    #- name: scp docker storage configuration
-    #  action: copy src="../files/docker-storage-setup" dest="/etc/sysconfig/docker-storage-setup" owner=root mode=0775
+    - name: check if docker volume already exists
+      stat: path=/dev/{{docker_volume}}
+      register: p
 
-    #- name: check if docker volume already exists
-    #  stat: path=/dev/{{docker_volume}}
-    #  register: p
-
-    #- name: Setup docker storage
-    #  command: docker-storage-setup
-    #  when: p.stat.isdir is not defined
-
-    #- name: Add external route temporarily for docker registry
-    #  shell: route add default gw 192.168.52.1
-    #  ignore_errors: yes
+    - name: Setup docker storage
+      command: docker-storage-setup
+      when: p.stat.isdir is not defined
 
     - name: Start docker services
       service: name=docker state=started


### PR DESCRIPTION
There are two associated changes with this PR. The first is to remove all hardcoded password values used for the root account on the OSE VMs. This was changed to a randomly generated 10 digit hexadecimal string. The second change is to uncomment the code which will set up docker-storage on the second partition now that the second partition is being created properly. This also includes changing the default storage size from 20 to 30 Gb.