### PR TITLE
world clock update

### DIFF
--- a/server/app/lib/actions/fusor/host/wait_until_ose_provisioned.rb
+++ b/server/app/lib/actions/fusor/host/wait_until_ose_provisioned.rb
@@ -68,6 +68,7 @@ module Actions
 
             unless outstanding_host_ids.length == 0
               suspend do |suspended_action|
+                world.clock.ping suspended_action, input[:timeout], "timeout"
                 outstanding_host_ids.each{|host_id| set_host_trigger(suspended_action, host_id)}
               end
             end


### PR DESCRIPTION
Reset timeout trigger on subsequent suspensions.

NOTE: This resets time already burned back to zero, so you'll wait the full timeout amount again
before actually timing out. Improved version would schedule the timeout to be

`TIMEOUT - (now - initial_suspension_time)`