### PR TITLE
Refactor deprecations for Ember 2.x

### DIFF
--- a/fusor-ember-cli/app/adapters/application.js
+++ b/fusor-ember-cli/app/adapters/application.js
@@ -11,6 +11,9 @@ export default ActiveModelAdapter.extend({
     shouldReloadRecord(store, ticketSnapshot) {
       return true;
     },
+    shouldReloadAll() {
+      return true;
+    },
     handleResponse(status /*, headers, payload */) {
         if(status === 401) {
             this.eventBus.trigger('displayErrorModal', {

--- a/fusor-ember-cli/app/adapters/application.js
+++ b/fusor-ember-cli/app/adapters/application.js
@@ -1,8 +1,9 @@
 import DS from 'ember-data';
 import Ember from 'ember';
+import ActiveModelAdapter from 'active-model-adapter';
 
 var token = Ember.$('meta[name="csrf-token"]').attr('content');
-export default DS.ActiveModelAdapter.extend({
+export default ActiveModelAdapter.extend({
     namespace: 'api/v21',
     headers: {
         "X-CSRF-Token": token

--- a/fusor-ember-cli/app/adapters/session-portal.js
+++ b/fusor-ember-cli/app/adapters/session-portal.js
@@ -1,6 +1,6 @@
-import DS from 'ember-data';
+import LSAdapter from 'ember-localstorage-adapter';
 
-export default DS.LSAdapter.extend({
+export default LSAdapter.extend({
   namespace: 'rhci',
   shouldReloadAll() {
     return true;

--- a/fusor-ember-cli/app/adapters/session-portal.js
+++ b/fusor-ember-cli/app/adapters/session-portal.js
@@ -1,5 +1,8 @@
 import DS from 'ember-data';
 
 export default DS.LSAdapter.extend({
-  namespace: 'rhci'
+  namespace: 'rhci',
+  shouldReloadAll() {
+    return true;
+  }
 });

--- a/fusor-ember-cli/app/components/wizard-item.js
+++ b/fusor-ember-cli/app/components/wizard-item.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
+import ActiveLinkMixin from 'ember-cli-active-link-wrapper/mixins/active-link';
 
-export default Ember.Component.extend({
+export default Ember.Component.extend(ActiveLinkMixin, {
   tagName: 'li',
 
-  classNameBindings: ['active', 'completed'],
+  classNameBindings: ['completed'],
 
   attributeBindings: ['dataToggle:data-toggle', 'dataPlacement:data-placement', 'title'],
 
@@ -17,24 +18,24 @@ export default Ember.Component.extend({
     return (!this.get('isDisabled') && !this.get('active'));
   }),
 
-  // code borrowed addon ember-cli-active-link-wrapper
-  // github.com/alexspeller/ember-cli-active-link-wrapper/blob/master/addon/components/active-link.js
-  childLinkViews: [],
+  // // code borrowed addon ember-cli-active-link-wrapper
+  // // github.com/alexspeller/ember-cli-active-link-wrapper/blob/master/addon/components/active-link.js
+  // childLinkViews: [],
 
-  active: Ember.computed('childLinkViews.@each.active', function() {
-    return Ember.A(this.get('childLinkViews')).isAny('active');
-  }),
+  // active: Ember.computed('childLinkViews.@each.active', function() {
+  //   return Ember.A(this.get('childLinkViews')).isAny('active');
+  // }),
 
-  didRender: function() {
-    Ember.run.schedule('afterRender', this, function() {
-      var childLinkElements = this.$('a.ember-view');
+  // didRender: function() {
+  //   Ember.run.schedule('afterRender', this, function() {
+  //     var childLinkElements = this.$('a.ember-view');
 
-      var childLinkViews = childLinkElements.toArray().map(view =>
-        this._viewRegistry[view.id]
-      );
+  //     var childLinkViews = childLinkElements.toArray().map(view =>
+  //       this._viewRegistry[view.id]
+  //     );
 
-      this.set('childLinkViews', childLinkViews);
-    });
-  },
+  //     this.set('childLinkViews', childLinkViews);
+  //   });
+  // },
 
 });

--- a/fusor-ember-cli/app/controllers/hypervisor/discovered-host.js
+++ b/fusor-ember-cli/app/controllers/hypervisor/discovered-host.js
@@ -112,7 +112,7 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
       }
 
       let vState = this.get('hostnameValidity').get('state');
-      let trackedHostIds = Ember.keys(vState);
+      let trackedHostIds = Object.keys(vState);
       return trackedHostIds.length === 0 ||
         !trackedHostIds
           .filter((hostId) => this.get('hypervisorModelIds').contains(hostId))

--- a/fusor-ember-cli/app/serializers/deployment.js
+++ b/fusor-ember-cli/app/serializers/deployment.js
@@ -1,6 +1,7 @@
 import DS from 'ember-data';
+import { ActiveModelSerializer } from 'active-model-adapter';
 
-export default DS.ActiveModelSerializer.extend({
+export default ActiveModelSerializer.extend({
   isNewSerializerAPI: true,
 
   attrs: {

--- a/fusor-ember-cli/app/serializers/foreman-task.js
+++ b/fusor-ember-cli/app/serializers/foreman-task.js
@@ -1,6 +1,7 @@
 import DS from 'ember-data';
+import { ActiveModelSerializer } from 'active-model-adapter';
 
-export default DS.ActiveModelSerializer.extend({
+export default ActiveModelSerializer.extend({
   isNewSerializerAPI: true,
   attrs: {
     humanized: { embedded: 'always' }

--- a/fusor-ember-cli/app/serializers/session-portal.js
+++ b/fusor-ember-cli/app/serializers/session-portal.js
@@ -1,0 +1,3 @@
+import { LSSerializer } from 'ember-localstorage-adapter';
+
+export default LSSerializer.extend();

--- a/fusor-ember-cli/app/styles/wizard.scss
+++ b/fusor-ember-cli/app/styles/wizard.scss
@@ -49,10 +49,13 @@
   width: 50%;
 }
 .rhci-steps li.active {
-  color: #0099d3;
+  color: #0099d3 !important;
 }
 .rhci-steps li.active:after {
-  background-color: #0099d3;
+  background-color: #0099d3 !important;
+}
+.rhci-steps li.active a {
+  color: #0099d3 !important;
 }
 .rhci-steps li.completed {
   color: #555555;

--- a/fusor-ember-cli/package.json
+++ b/fusor-ember-cli/package.json
@@ -22,6 +22,7 @@
     "active-model-adapter": "2.1.1",
     "broccoli-asset-rev": "^2.1.2",
     "ember-cli": "1.13.12",
+    "ember-cli-active-link-wrapper": "0.2.0",
     "ember-cli-app-version": "0.5.0",
     "ember-cli-babel": "^5.1.3",
     "ember-cli-blanket": "0.6.2",

--- a/fusor-ember-cli/package.json
+++ b/fusor-ember-cli/package.json
@@ -19,6 +19,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "active-model-adapter": "2.1.1",
     "broccoli-asset-rev": "^2.1.2",
     "ember-cli": "1.13.12",
     "ember-cli-app-version": "0.5.0",

--- a/fusor-ember-cli/package.json
+++ b/fusor-ember-cli/package.json
@@ -49,7 +49,7 @@
     "ember-idx-button": "~0.1.3",
     "ember-idx-forms": "0.5.1",
     "ember-idx-modal": "~0.1.4",
-    "ember-localstorage-adapter": "0.5.3",
+    "ember-localstorage-adapter": "1.0.0-rc.1",
     "ember-moment": "1.1.1",
     "ember-radio-button": "~1.0.1",
     "ember-watson": "~0.7.0",


### PR DESCRIPTION
Here are five fixes deprecation notices. There are still several that involve ember-data serializers, but I prefer to handle these when moving to AMS-0.10 and the standard JSONAPIAdapter for Ember 2.x