### PR TITLE
fix rhev cr creation on sat 6.2

### DIFF
--- a/server/app/controllers/fusor/api/v21/deployments_controller.rb
+++ b/server/app/controllers/fusor/api/v21/deployments_controller.rb
@@ -190,7 +190,7 @@ module Fusor
     def deployment_params
       params.require(:deployment).permit(:name, :description, :deploy_rhev, :deploy_cfme,
                                          :deploy_openstack, :is_disconnected, :rhev_is_self_hosted,
-                                         :rhev_engine_admin_password, :rhev_database_name,
+                                         :rhev_engine_admin_password, :rhev_data_center_name,
                                          :rhev_cluster_name, :rhev_storage_name, :rhev_storage_type,
                                          :rhev_storage_address, :rhev_cpu_type, :rhev_share_path,
                                          :cfme_install_loc, :rhev_root_password, :cfme_root_password,


### PR DESCRIPTION
Two issues:
1.) Foreman now appears to verify the ssl cert so we need to load it now. This is different from when I tested.
2.) The data center name used to be saved in rhev_database_name; this was updated to rhev_data_center_name. The sat 6.2 PR still had rhev_data_center_name in the list of protected parameters that could be updated so it was coming up nil when trying to create the CR.