### PR TITLE
Fix operating system validation, use 7.2 for kickstarts

### DIFF
--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -63,7 +63,7 @@
         :repository_set_id: "2455"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server (Kickstart)"
         :basearch: "x86_64"
-        :releasever: "7.1"
+        :releasever: "7.2"
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"
@@ -96,8 +96,8 @@
         :repository_set_id: "2455"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server (Kickstart)"
         :basearch: "x86_64"
-        :releasever: "7.1"
-        #Need Red Hat 7.1 Operating Sysetem setup including Media, architecture, and other associations.
+        :releasever: "7.2"
+        #Need Red Hat 7.2 Operating Sysetem setup including Media, architecture, and other associations.
 
     :openshift:
       - :product_name: "Red Hat OpenShift Enterprise"
@@ -118,7 +118,7 @@
         :repository_set_id: "2455"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server (Kickstart)"
         :basearch: "x86_64"
-        :releasever: "7.1"
+        :releasever: "7.2"
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"
@@ -154,7 +154,7 @@
         :repository_set_id: "2455"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server (Kickstart)"
         :basearch: "x86_64"
-        :releasever: "7.1"
+        :releasever: "7.2"
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"
@@ -244,7 +244,7 @@
        - :name: "RHEV-Hypervisor"
          :os: "RedHat"
          :major: "7"
-         :minor: "1"
+         :minor: "2"
          :parent: :root_deployment
          :puppet_classes:
            - :name: "ovirt"
@@ -266,7 +266,7 @@
        - :name: "OpenShift"
          :os: "RedHat"
          :major: "7"
-         :minor: "1"
+         :minor: "2"
          :parent: :root_deployment
          :activation_key:
            :name: "OpenShift"
@@ -274,7 +274,7 @@
            :subscription_descriptions:
              - "Red Hat Cloud Infrastructure"
              - "OpenShift Enterprise"
-             
+
     :openstack:
      :root_name: "Fusor Base" # seeded by the fusor-installer
      :host_groups:
@@ -284,7 +284,7 @@
          :parent: :root_deployment
          :os: "RedHat"
          :major: "7"
-         :minor: "1"
+         :minor: "2"
          :activation_key:
            :name: "OpenStack-Undercloud"
            :content: :openstack


### PR DESCRIPTION
Updated fusor.yaml to use 7.2 for kickstarts since the 7Server content will always pull in the latest (today it is 7.2). Also updated the hostgroups to match.

The problem usually manifests itself as the following:

```
Validation failed: Medium Default_Organization/Library/Red_Hat_Server/Red_Hat_Enterprise_Linux_7_Server_Kickstart_x86_64_7_1 does not belong to RedHat 7.2 operating system (ActiveRecord::RecordInvalid)
```
