### PR TITLE
print only the unique repos in a sorted manner.

### DIFF
--- a/scripts/disconnected/gen_kd_repos
+++ b/scripts/disconnected/gen_kd_repos
@@ -33,6 +33,7 @@ class GenerateKDRepos(object):
     def __init__(self):
         self.doc = None
         self.content_lists = []
+        self.unique_repos = {}
 
     def parse_product_json(self, product_path):
         """
@@ -105,7 +106,11 @@ class GenerateKDRepos(object):
                 product_json = self.parse_product_json(product_path)
                 for p in product_json['productContent']:
                     if c.repository_set_id == p['content']['id']:
-                        print self.format_repo_string(p['content'], c)
+                        form_repo = self.format_repo_string(p['content'], c)
+                        self.unique_repos[form_repo] = form_repo
+
+        for key in sorted(self.unique_repos):
+            print key
 
         # cleanup
         shutil.rmtree(dest)


### PR DESCRIPTION
This script is used to print out the list of repos defined in fusor.yaml and passed to katello-disconnected to sync the content. Prior to this patch, we printed all of the repos causing duplicates to print out. Now we print them out sorted and unique.

### BEFORE:
```
rhel-7-server-ose-3_1-rpms--x86_64
rhel-7-server-rpms-7Server-x86_64
rhel-7-server-kickstart-7_2-x86_64
rhel-7-server-rh-common-rpms-7Server-x86_64
rhel-7-server-extras-rpms--x86_64
rhel-7-server-optional-rpms-7Server-x86_64
rhel-7-server-rpms-7Server-x86_64
rhel-7-server-kickstart-7_2-x86_64
rhel-7-server-satellite-tools-6_1-rpms--x86_64
rhel-7-server-rhev-mgmt-agent-rpms-7Server-x86_64
rhel-6-server-rpms-6Server-x86_64
rhel-6-server-kickstart-6_7-x86_64
rhel-6-server-satellite-tools-6_1-rpms--x86_64
rhel-6-server-supplementary-rpms-6Server-x86_64
rhel-6-server-rhevm-3_6-rpms--x86_64
jb-eap-6-for-rhel-6-server-rpms-6Server-x86_64
rhel-7-server-rpms-7Server-x86_64
rhel-7-server-kickstart-7_2-x86_64
rhel-7-server-extras-rpms--x86_64
rhel-7-server-optional-rpms-7Server-x86_64
rhel-7-server-rh-common-rpms-7Server-x86_64
rhel-7-server-openstack-7_0-rpms-7Server-x86_64
rhel-7-server-openstack-7_0-director-rpms-7Server-x86_64
rhel-7-server-openstack-7_0-files-7Server-x86_64
rhel-server-rhscl-7-rpms-7Server-x86_64
cf-me-5_5-for-rhel-7-files--x86_64
rhel-7-server-kickstart-7_2-x86_64
```

### AFTER:
```
cf-me-5_5-for-rhel-7-files--x86_64
jb-eap-6-for-rhel-6-server-rpms-6Server-x86_64
rhel-6-server-kickstart-6_7-x86_64
rhel-6-server-rhevm-3_6-rpms--x86_64
rhel-6-server-rpms-6Server-x86_64
rhel-6-server-satellite-tools-6_1-rpms--x86_64
rhel-6-server-supplementary-rpms-6Server-x86_64
rhel-7-server-extras-rpms--x86_64
rhel-7-server-kickstart-7_2-x86_64
rhel-7-server-openstack-7_0-director-rpms-7Server-x86_64
rhel-7-server-openstack-7_0-files-7Server-x86_64
rhel-7-server-openstack-7_0-rpms-7Server-x86_64
rhel-7-server-optional-rpms-7Server-x86_64
rhel-7-server-ose-3_1-rpms--x86_64
rhel-7-server-rh-common-rpms-7Server-x86_64
rhel-7-server-rhev-mgmt-agent-rpms-7Server-x86_64
rhel-7-server-rpms-7Server-x86_64
rhel-7-server-satellite-tools-6_1-rpms--x86_64
rhel-server-rhscl-7-rpms-7Server-x86_64
```