### PR TITLE
fix exception handlin in cfme add credentials

### DIFF
--- a/server/app/lib/utils/cloud_forms/add_credentials_for_hosts.rb
+++ b/server/app/lib/utils/cloud_forms/add_credentials_for_hosts.rb
@@ -57,7 +57,7 @@ module Utils
           # close the stringio at the end
           @io.close unless @io.closed?
 
-        rescue
+        rescue Exception => e
           @io.close if @io && !@io.closed?
           fail _("Failed to add host credentials. Error message: #{e.message}")
         end


### PR DESCRIPTION
NameError: undefined local variable or method `e' for Utils::CloudForms::AddCredentialsForHosts:Class

vs.

RuntimeError: Failed to add host credentials. Error message: No such file or directory @ rb_file_s_stat - /usr/share/fusor_ovirt/bin/add_host_credentials.rb