### PR TITLE
Fix initialization of deployment-params on assign-nodes setupController

### DIFF
--- a/fusor-ember-cli/app/routes/openstack/assign-nodes.js
+++ b/fusor-ember-cli/app/routes/openstack/assign-nodes.js
@@ -61,10 +61,11 @@ export default Ember.Route.extend({
     let roles = this.get('controller.roles');
     let plan = this.get('controller.plan');
     let params = this.get('controller.plan.parameters');
-    let globalParams = this.get('controller.globalPlanParameters');
+    let globalParams = [];
     let uneditableParams = {};
 
     roles.forEach(role => {
+      role.set('parameters', []);
       role.set('image', plan.getParamValue(role.get('imageParameterName')));
       uneditableParams[role.get('countParameterName')] = true;
       uneditableParams[role.get('flavorParameterName')] = true;
@@ -97,6 +98,8 @@ export default Ember.Route.extend({
         }
       }
     }
+
+    this.set('controller.globalPlanParameters', globalParams);
   },
 
   findRoleForParamKey(paramKey) {


### PR DESCRIPTION
I noticed that deployment-plan parameters were multiplying on every visit to the page.  For some reason it's saving the state of the page in between transitions, so I cleared the arrays on each visit.