### PR TITLE
fix WARNING: Binding style attributes may introduce cross-site scripting vulnerabilities

### DIFF
--- a/fusor-ember-cli/app/components/ose-summary-needed-available.js
+++ b/fusor-ember-cli/app/components/ose-summary-needed-available.js
@@ -15,7 +15,7 @@ export default Ember.Component.extend({
   }),
 
   styleWidth: Ember.computed('percentProgressMax', function () {
-    return new Ember.Handlebars.SafeString(this.get('percentProgressMax') + '%');
+    return Ember.String.htmlSafe('width: ' + this.get('percentProgressMax') + '%;');
   }),
 
   progressBarClass: Ember.computed('percentProgress', function() {

--- a/fusor-ember-cli/app/components/osp-node.js
+++ b/fusor-ember-cli/app/components/osp-node.js
@@ -61,7 +61,7 @@ export default Ember.Component.extend({
 
   progressWidth: Ember.computed('foremanTask.progress', function() {
     let progressPercent = Math.floor((parseFloat(this.get('foremanTask.progress')) || 0) * 100);
-    return `${progressPercent}%`;
+    return Ember.String.htmlSafe(`width: ${progressPercent}%;`);
   }),
 
   progressBarClass: Ember.computed('isNodeError', function() {

--- a/fusor-ember-cli/app/components/progress-bar.js
+++ b/fusor-ember-cli/app/components/progress-bar.js
@@ -24,7 +24,7 @@ export default Ember.Component.extend({
   }),
 
   styleWidth: Ember.computed('percentProgressInt', function () {
-    return new Ember.Handlebars.SafeString(this.get('percentProgressInt') + '%');
+    return Ember.String.htmlSafe('width: ' + this.get('percentProgressInt') + '%;');
   }),
 
   progressBarClass: Ember.computed('model.result', function() {

--- a/fusor-ember-cli/app/components/wizard-step.js
+++ b/fusor-ember-cli/app/components/wizard-step.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Component.extend({
 
   minHeightStyle: Ember.computed('minHeight', function() {
-    return new Ember.Handlebars.SafeString('min-height: ' + this.get('minHeight') + 'px;');
+    return Ember.String.htmlSafe('min-height: ' + this.get('minHeight') + 'px;');
   }),
 
   resizeWizard: Ember.on('didInsertElement', function() {

--- a/fusor-ember-cli/app/templates/components/ose-summary-needed-available.hbs
+++ b/fusor-ember-cli/app/templates/components/ose-summary-needed-available.hbs
@@ -8,7 +8,7 @@
     <div class='light-gray-background'>
       &nbsp;
     </div>
-    <div class="needed-available-bar {{progressBarClass}}" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow={{percentProgressInt}} style="width: {{styleWidth}};">
+    <div class="needed-available-bar {{progressBarClass}}" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow={{percentProgressInt}} style={{styleWidth}}>
       &nbsp;{{helpText}}
     </div>
     <div class="amt-needed {{fontColorClass}}">

--- a/fusor-ember-cli/app/templates/components/osp-node.hbs
+++ b/fusor-ember-cli/app/templates/components/osp-node.hbs
@@ -12,7 +12,7 @@
 </div>
 <div class="col-xs-9 osp-node-progress-column">
   <div class="progress osp-node-progress">
-    <div class="{{progressBarClass}}" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: {{progressWidth}};">
+    <div class="{{progressBarClass}}" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style={{progressWidth}}>
       <span class="osp-node-progress-bar-label">{{label}}</span>
     </div>
   </div>

--- a/fusor-ember-cli/app/templates/components/progress-bar.hbs
+++ b/fusor-ember-cli/app/templates/components/progress-bar.hbs
@@ -38,7 +38,7 @@
   </div>
 
   <div class="progress">
-    <div class={{progressBarClass}} role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow={{percentProgressInt}} style="width: {{styleWidth}};">
+    <div class={{progressBarClass}} role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow={{percentProgressInt}} style={{styleWidth}}>
     </div>
   </div>
 </div>

--- a/fusor-ember-cli/app/templates/components/wizard-step.hbs
+++ b/fusor-ember-cli/app/templates/components/wizard-step.hbs
@@ -1,8 +1,8 @@
-<div class="col-xs-8 col-sm-8 col-md-9 col-lg-10 col-xs-push-4 col-sm-push-4 col-md-push-3 col-lg-push-2 sidebar-pf-right" style="{{minHeightStyle}}">
+<div class="col-xs-8 col-sm-8 col-md-9 col-lg-10 col-xs-push-4 col-sm-push-4 col-md-push-3 col-lg-push-2 sidebar-pf-right" style={{minHeightStyle}}>
     {{outlet}}
 </div>
 
-<div class="col-xs-4 col-sm-4 col-md-3 col-lg-2 col-xs-pull-8 col-sm-pull-8 col-md-pull-9 col-lg-pull-10 sidebar-pf sidebar-pf-left" style="{{minHeightStyle}}">
+<div class="col-xs-4 col-sm-4 col-md-3 col-lg-2 col-xs-pull-8 col-sm-pull-8 col-md-pull-9 col-lg-pull-10 sidebar-pf sidebar-pf-left" style={{minHeightStyle}}>
   <ul class="nav nav-pills nav-stacked">
        {{yield}}
   </ul>


### PR DESCRIPTION
@rwjblue writes in http://discuss.emberjs.com/t/binding-style-attributes-warning-still-popping-up-with-safe-string/7798

```
<div class="progress" style="{{barWidth}}">
Change that to:
<div class="progress" style={{barWidth}}>
```
The reason the initial version still triggers the warning is that quoting an attribute automatically calls concat on the parameters (even though in this case there is only one). We can likely make the internal HTMLBars concat utility smart enough to return the first param if there is only one (as in this example).

