### PR TITLE
Override foreman adding 30px padding-right to all .form-control fields.

### DIFF
--- a/fusor-ember-cli/app/styles/custom.scss
+++ b/fusor-ember-cli/app/styles/custom.scss
@@ -8,9 +8,14 @@ $error-color: #cc0000;
 // ******************************
 // Foreman style overrides - begin
 
-// overriding foreman .spinner {float: left;}
+// overriding foreman patternfly_and_overrides.scss .spinner {float: left;}
 .spinner {
   float: none;
+}
+
+// overriding foreman patternfly_and_overrides.scss .form-control {padding-right: 30px;}
+.form-control {
+  padding-right: 6px;
 }
 
 //overriding foreman padding so gray goes to the left/right edges
@@ -26,6 +31,8 @@ $error-color: #cc0000;
 #content > .row:first-child {
   display: none;
 }
+
+
 
 // ******************************
 


### PR DESCRIPTION
the right part of our text entry fields are being hidden by https://github.com/theforeman/foreman/blob/develop/app/assets/stylesheets/patternfly_and_overrides.scss#L206-L208