### PR TITLE
fix ember-power-select bug on rhev-options

### DIFF
--- a/fusor-ember-cli/app/templates/rhev-options.hbs
+++ b/fusor-ember-cli/app/templates/rhev-options.hbs
@@ -30,6 +30,7 @@
                         content=cpuTypes
                         value=rhevCpuType
                         prompt="Autodetect CPU family"
+                        renderInPlace=true
                         cssId="rhev-cpu-type"
                         disabled=isStarted
                         action="setSelectValue"


### PR DESCRIPTION
this was not needed when running using `ember server` but for some reason is needed when running inside Sat6.