### PR TITLE
Changed from using .clone to .dup on ActiveRecord objects

### DIFF
--- a/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
@@ -159,7 +159,7 @@ module Actions
             end
 
             defaultptable = Ptable.find_by_name(default_name)
-            oseptable = defaultptable.clone
+            oseptable = defaultptable.dup
 
             layoutstring = oseptable.layout.clone
             layoutstring.sub! default_name, ptable_name

--- a/server/app/lib/utils/fusor/config_template_utils.rb
+++ b/server/app/lib/utils/fusor/config_template_utils.rb
@@ -47,14 +47,15 @@ module Utils
         default_template_name = 'Satellite Kickstart Default'
         default_template = ProvisioningTemplate.find_by_name(default_template_name)
         if default_template.nil?
-          ::Fusor.log.error "====== Template '#{default_template_name}' does not exist! Cannot clone from default! ======"
+          ::Fusor.log.error "====== Template '#{default_template_name}' does not exist! Cannot dup from default! ======"
           return nil
         end
-        new_template = default_template.clone
+        new_template = default_template.dup
         new_template.name = name
         str = new_template.template.clone
         str.sub! "name: #{default_template_name}", "name: #{name}"
         new_template.template = str
+        new_template.locked = false
         new_template.save!
       end
 


### PR DESCRIPTION
Fixes issue with renaming default kickstart ptable

Without this, OSE deployments are broken after first deployment.

Trello: https://trello.com/c/J5LE2lCF