### PR TITLE
Subscription workflow update

### DIFF
--- a/fusor-ember-cli/app/components/tr-subscription-manifest.js
+++ b/fusor-ember-cli/app/components/tr-subscription-manifest.js
@@ -9,10 +9,7 @@ export default Ember.Component.extend({
     'subscription.quantity_attached',
     'subscription.qtySumAttached',
     function() {
-      if (this.get('isDisconnected')) {
-        return this.get('subscription.quantity_attached');
-
-      } else if (this.get('subscription.quantity_to_add') > 0) {
+      if (this.get('subscription.quantity_to_add') > 0) {
         return this.get('subscription.quantity_attached') + ' + ' +
           this.get('subscription.quantity_to_add') + ' = ' +
           this.get('subscription.qtySumAttached');

--- a/fusor-ember-cli/app/controllers/configure-environment.js
+++ b/fusor-ember-cli/app/controllers/configure-environment.js
@@ -30,7 +30,7 @@ export default Ember.Controller.extend(ConfigureEnvironmentMixin, NeedsDeploymen
     selectEnvironment(environment) {
       this.set('showAlertMessage', false);
       this.set('selectedEnvironment', environment);
-      return this.get('deploymentController.model').set('lifecycle_environment', environment);
+      this.get('deploymentController.model').set('lifecycle_environment', environment);
     },
 
     createEnvironment(fields_env) {
@@ -38,7 +38,7 @@ export default Ember.Controller.extend(ConfigureEnvironmentMixin, NeedsDeploymen
 
       var nameAlreadyExists =  self.get('lifecycleEnvironments').findBy('name', fields_env.name);
       if (nameAlreadyExists) {
-        return self.get('deploymentController').set('errorMsg', fields_env.name + ' is not a unique name. Environment not saved.');
+        self.get('deploymentController').set('errorMsg', envName + ' is not a unique name. Environment not saved.');
       }
 
       var selectedOrganization = this.get('selectedOrganization');
@@ -55,7 +55,7 @@ export default Ember.Controller.extend(ConfigureEnvironmentMixin, NeedsDeploymen
         self.set('selectedEnvironment', environment);
         self.get('deploymentController.model').set('lifecycle_environment', environment);
         self.get('deploymentController').set('errorMsg', null);
-        return self.set('showAlertMessage', true);
+        self.set('showAlertMessage', true);
       }, function(error) {
         self.get('deploymentController').set('errorMsg', 'error saving environment' + error);
       });

--- a/fusor-ember-cli/app/controllers/configure-environment.js
+++ b/fusor-ember-cli/app/controllers/configure-environment.js
@@ -38,7 +38,7 @@ export default Ember.Controller.extend(ConfigureEnvironmentMixin, NeedsDeploymen
 
       var nameAlreadyExists =  self.get('lifecycleEnvironments').findBy('name', fields_env.name);
       if (nameAlreadyExists) {
-        self.get('deploymentController').set('errorMsg', envName + ' is not a unique name. Environment not saved.');
+        self.get('deploymentController').set('errorMsg', fields_env.name + ' is not a unique name. Environment not saved.');
       }
 
       var selectedOrganization = this.get('selectedOrganization');

--- a/fusor-ember-cli/app/controllers/deployment.js
+++ b/fusor-ember-cli/app/controllers/deployment.js
@@ -88,12 +88,9 @@ export default Ember.Controller.extend(DeploymentControllerMixin, DisableTabMixi
   ),
 
   hasSubscriptionUUID: Ember.computed(
-    'organizationUpstreamConsumerUUID',
     'model.upstream_consumer_uuid',
     function() {
-      return (Ember.isPresent(this.get('organizationUpstreamConsumerUUID')) ||
-              Ember.isPresent(this.get('model.upstream_consumer_uuid'))
-             );
+      return Ember.isPresent(this.get('model.upstream_consumer_uuid'));
     }
   ),
 
@@ -103,7 +100,14 @@ export default Ember.Controller.extend(DeploymentControllerMixin, DisableTabMixi
     'hasSubscriptionUUID',
     'disableNextOnSelectSubscriptions',
     function() {
-      return (!this.get('isDisconnected') && (this.get('isDisabledSubscriptions') || !this.get("hasSubscriptionUUID") || this.get('disableNextOnSelectSubscriptions')));
+      const isConnectedSync = !this.get('isDisconnected');
+      const subsNotReady =
+       this.get('isDisabledSubscriptions') ||
+       !this.get("hasSubscriptionUUID") ||
+       this.get('disableNextOnSelectSubscriptions');
+
+      // Disable review if this is a connected sync and subs are not ready
+      return isConnectedSync && subsNotReady;
     }
   ),
 

--- a/fusor-ember-cli/app/controllers/subscriptions.js
+++ b/fusor-ember-cli/app/controllers/subscriptions.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 import NeedsDeploymentMixin from "../mixins/needs-deployment-mixin";
 
 export default Ember.Controller.extend(NeedsDeploymentMixin, {
-
   stepNumberSubscriptions: Ember.computed.alias("deploymentController.stepNumberSubscriptions"),
   isStarted: Ember.computed.alias("deploymentController.isStarted"),
   isDisconnected: Ember.computed.alias("deploymentController.model.is_disconnected"),
@@ -13,10 +12,7 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
 
   disableTabReviewSubsciptions: Ember.computed.empty("deploymentController.model.manifest_file"),
 
-  upstreamConsumerUuid: Ember.computed.alias("deploymentController.model.upstream_consumer_uuid"),
-
   disableTabSelectSubsciptions: Ember.computed('model.isAuthenticated', 'upstreamConsumerUuid', function() {
     return (Ember.isBlank(this.get('upstreamConsumerUuid')) || !this.get('model.isAuthenticated'));
   })
-
 });

--- a/fusor-ember-cli/app/controllers/subscriptions/credentials.js
+++ b/fusor-ember-cli/app/controllers/subscriptions/credentials.js
@@ -11,8 +11,6 @@ const MirrorStatus = {
 export default Ember.Controller.extend(NeedsDeploymentMixin, {
 
   deploymentId: Ember.computed.alias("deploymentController.model.id"),
-  upstreamConsumerUuid: Ember.computed.alias("deploymentController.model.upstream_consumer_uuid"),
-  upstreamConsumerName: Ember.computed.alias("deploymentController.model.upstream_consumer_name"),
   cdnUrl: Ember.computed.alias("deploymentController.model.cdn_url"),
   manifestFile: Ember.computed.alias("deploymentController.model.manifest_file"),
 
@@ -20,10 +18,6 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
   isOpenStack: Ember.computed.alias("deploymentController.model.deploy_openstack"),
   isCloudForms: Ember.computed.alias("deploymentController.model.deploy_cfme"),
   isOpenShift: Ember.computed.alias("deploymentController.model.deploy_openshift"),
-
-  //overwritten by setupController
-  organizationUpstreamConsumerUUID: null,
-  organizationUpstreamConsumerName: null,
 
   validCredentials: Ember.computed('model.identification', 'password', function() {
     // password is not saved in the model
@@ -34,14 +28,6 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
     return this.get('validCredentials') || this.get('model.isAuthenticated');
   }),
   disableCredentialsNext: Ember.computed.not('enableCredentialsNext'),
-
-  hasUpstreamConsumerUuid: Ember.computed('upstreamConsumerUuid', function() {
-    return Ember.isPresent(this.get('upstreamConsumerUuid'));
-  }),
-
-  hasOrganizationUpstreamConsumerUUID: Ember.computed('organizationUpstreamConsumerUUID', function() {
-    return Ember.isPresent(this.get('organizationUpstreamConsumerUUID'));
-  }),
 
   backRouteNameonCredentials: Ember.computed('isRhev', 'isOpenStack', 'isOpenShift', 'isCloudForms', function() {
     if (this.get('isCloudForms')) {

--- a/fusor-ember-cli/app/controllers/subscriptions/management-application.js
+++ b/fusor-ember-cli/app/controllers/subscriptions/management-application.js
@@ -4,15 +4,10 @@ import request from 'ic-ajax';
 import ValidationUtil from '../../utils/validation-util';
 
 export default Ember.Controller.extend(NeedsDeploymentMixin, {
-
   subscriptionsController: Ember.inject.controller('subscriptions'),
 
   showManagementApplications: true,
-
   sessionPortal: Ember.computed.alias('subscriptionsController.model'),
-  upstreamConsumerUuid: Ember.computed.alias("deploymentController.model.upstream_consumer_uuid"),
-  upstreamConsumerName: Ember.computed.alias("deploymentController.model.upstream_consumer_name"),
-
   showAlertMessage: false,
   showWaitingMessage: false,
   showErrorMessage: false,

--- a/fusor-ember-cli/app/mixins/disable-tab-mixin.js
+++ b/fusor-ember-cli/app/mixins/disable-tab-mixin.js
@@ -25,7 +25,7 @@ export default Ember.Mixin.create(ValidatesDeploymentNameMixin, {
   // disable Next on Lifecycle Environment if no lifecycle environment is selected
   // note: hasNoLifecycleEnvironment and hasNoLifecycleEnvironment is defined in /app/controllers/deployment.js
   //       and app/controllers/deployment-new.js rather than in this mixin
-  disableNextOnLifecycleEnvironment: Ember.computed.or('hasNoLifecycleEnvironment', 'model.isSaving'),
+  disableNextOnLifecycleEnvironment: Ember.computed.or('hasNoLifecycleEnvironment', 'disableAll'),
 
   // Satellite Tabs Only
   disableTabDeploymentName: false, // always enable tab for entering deployment name

--- a/fusor-ember-cli/app/mixins/needs-deployment-mixin.js
+++ b/fusor-ember-cli/app/mixins/needs-deployment-mixin.js
@@ -10,5 +10,17 @@ export default Ember.Mixin.create({
 
   isNew: false,
 
-  deploymentName: Ember.computed.alias("deploymentController.model.name")
+  deploymentName: Ember.computed.alias("deploymentController.model.name"),
+
+  ////////////////////////////////////////////////////////////
+  // ALIASES AND COMMONLY USED COMPUTED PROPS
+  // Consolidates these and makes them available for free to any mixee
+  ////////////////////////////////////////////////////////////
+  upstreamConsumerUuid: Ember.computed.alias(
+    'deploymentController.model.upstream_consumer_uuid'),
+  hasUpstreamConsumerUuid: Ember.computed('upstreamConsumerUuid', function() {
+    return Ember.isPresent(this.get('upstreamConsumerUuid'));
+  }),
+  upstreamConsumerName: Ember.computed.alias(
+    'deploymentController.model.upstream_consumer_name')
 });

--- a/fusor-ember-cli/app/mixins/needs-deployment-mixin.js
+++ b/fusor-ember-cli/app/mixins/needs-deployment-mixin.js
@@ -15,6 +15,7 @@ export default Ember.Mixin.create({
   ////////////////////////////////////////////////////////////
   // ALIASES AND COMMONLY USED COMPUTED PROPS
   // Consolidates these and makes them available for free to any mixee
+  // Prevents littering leaf controllers with duplicated aliases
   ////////////////////////////////////////////////////////////
   upstreamConsumerUuid: Ember.computed.alias(
     'deploymentController.model.upstream_consumer_uuid'),

--- a/fusor-ember-cli/app/mixins/needs-existing-manifest-helpers.js
+++ b/fusor-ember-cli/app/mixins/needs-existing-manifest-helpers.js
@@ -1,0 +1,73 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+  shouldUseExistingManifest() {
+    const orgId = this.modelFor('deployment').get('organization.id');
+    const modelUpstreamConsumerUuid = this.modelFor('deployment')
+      .get('upstream_consumer_uuid');
+    const hasModelUpstreamConsumerUuid = Ember.isPresent(modelUpstreamConsumerUuid);
+
+    return new Ember.RSVP.Promise((res, rej) => {
+      const url = `/katello/api/v2/organizations/${orgId}`;
+      Ember.$.getJSON(url).then(results => {
+        const satManifestExists =
+          Ember.isPresent(results.owner_details) &&
+          Ember.isPresent(results.owner_details.upstreamConsumer);
+
+        if(!satManifestExists && hasModelUpstreamConsumerUuid) {
+          // Edge case where an upstream_consumer_uuid has been saved into the
+          // fusor model but not yet uploaded to satellite. Indicates a deployment
+          // in progress, but not one where satellite already has an existing
+          // manifest available for reuse
+          res(false);
+        } else if(satManifestExists && hasModelUpstreamConsumerUuid){
+          if(results.owner_details.upstreamConsumer.uuid !== modelUpstreamConsumerUuid) {
+            // ERROR: Manifest uuid reported by satellite differs from that on the model
+            // something is corrupt. Assert failure.
+            throw 'ERROR: upstreamConsumer.uuid does not match the one found on the' +
+              'fusor deployment model!';
+          } else {
+            // Existing manifest was found in satellite and matches the one set on the
+            // model by the deployment route, continue with streamlined subs
+            res(true);
+          }
+        } else {
+          // Standard new deployment with no manifest in Sat and with no manifest
+          // having ever been uploaded via the Fusor wizard
+          res(false);
+        }
+      }, () => rej(false));
+    });
+  },
+
+  loadSubscriptions() {
+    const orgId = this.modelFor('deployment').get('organization.id');
+    const subsUrl = `/katello/api/v2/organizations/${orgId}/subscriptions`;
+    return new Ember.RSVP.Promise((res, rej) => {
+      Ember.$.getJSON(subsUrl).then(response => {
+        if(Ember.isNone(response.results)) {
+          res(Ember.A());
+        } else {
+          const subs = Ember.A(response.results)
+            .filter(sub => sub.name !== 'Fusor')
+            .map(sub => {
+              return Ember.Object.create({
+                product_name: sub.name,
+                contract_number: sub.contract_number,
+                start_date: sub.start_date,
+                end_date: sub.end_date,
+                quantity_attached: sub.quantity
+              });
+            });
+          res(subs);
+        }
+      },
+      err => {
+        console.log(
+          'ERROR: Something went wrong loading subscription info ' +
+          'during existing manifest load!');
+        rej(err);
+      });
+    });
+  }
+});

--- a/fusor-ember-cli/app/routes/configure-environment.js
+++ b/fusor-ember-cli/app/routes/configure-environment.js
@@ -15,16 +15,15 @@ export default Ember.Route.extend({
       controller.set('lifecycleEnvironments', results);
       // nullify environment if organization has no environments
       if (results.get('length') === 0) {
-        return controller.set('selectedEnvironment', null);
+        controller.set('selectedEnvironment', null);
       } else {
-        return controller.set('selectedEnvironment', model);
+        controller.set('selectedEnvironment', model);
       }
     });
   },
 
   deactivate() {
     this.get('controller').set('showAlertMessage', false);
-    return this.send('saveDeployment', null);
+    this.send('saveDeployment', null);
   }
-
 });

--- a/fusor-ember-cli/app/routes/deployment.js
+++ b/fusor-ember-cli/app/routes/deployment.js
@@ -174,7 +174,7 @@ export default Ember.Route.extend(DeploymentRouteMixin, UsesOseDefaults, {
     attachSubscriptions() {
       var self = this;
       var token = Ember.$('meta[name="csrf-token"]').attr('content');
-      var sessionPortal = this.modelFor('subscriptions');
+      var sessionPortal = this.modelFor('subscriptions').sessionPortal;
       var consumerUUID = sessionPortal.get('consumerUUID');
       var subscriptionPools = this.controllerFor('subscriptions/select-subscriptions').get('subscriptionPools');
 

--- a/fusor-ember-cli/app/routes/review/installation.js
+++ b/fusor-ember-cli/app/routes/review/installation.js
@@ -42,7 +42,7 @@ export default Ember.Route.extend({
       }, false); // initial val
       controller.set('reviewSubscriptions', reviewSubscriptions);
       controller.set('hasSubscriptionsToAttach', hasSubs);
-      controller.set('hasSessionPortal', Ember.isPresent(this.modelFor('subscriptions')));
+      controller.set('hasSessionPortal', Ember.isPresent(this.modelFor('subscriptions').sessionPortal));
       controller.set('hasSubscriptionPools', Ember.isPresent(this.controllerFor('subscriptions/select-subscriptions').get('subscriptionPools')));
     }
 

--- a/fusor-ember-cli/app/routes/review/installation.js
+++ b/fusor-ember-cli/app/routes/review/installation.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
 import request from 'ic-ajax';
+import NeedsExistingManifestHelpers from '../../mixins/needs-existing-manifest-helpers';
 
-export default Ember.Route.extend({
+export default Ember.Route.extend(NeedsExistingManifestHelpers, {
 
   beforeModel() {
     // Ensure the models have been persisted so that we're validating/syncing up to date data.
@@ -18,12 +19,39 @@ export default Ember.Route.extend({
     return Ember.RSVP.hash(promises);
   },
 
-  setupController(controller, model) {
+  model() {
+    const reviewModel = this.modelFor('review');
+    const subModel = this.modelFor('subscriptions');
+    let modelHash = {reviewModel};
+    if(subModel) {
+      // Use subscriptions model if the loading has already been done
+      modelHash.useExistingManifest = subModel.useExistingManifest;
+      if(subModel.subscriptions) {
+        modelHash.subscriptions = subModel.subscriptions;
+      }
+      return modelHash;
+    } else {
+      // subscriptions model isn't available, maybe because of a page refresh
+      // Need to load this data independently
+      return this.shouldUseExistingManifest().then(useExistingManifest => {
+        modelHash.useExistingManifest = useExistingManifest;
+
+        if(useExistingManifest) {
+          modelHash.subscriptions = this.loadSubscriptions();
+        }
+
+        return Ember.RSVP.hash(modelHash);
+      });
+    }
+  },
+
+  setupController(controller, modelHash) {
+    const model = modelHash.reviewModel;
     controller.set('model', model);
     controller.set('showErrorMessage', false);
+    controller.set('useExistingManifest', modelHash.useExistingManifest);
     if (model.get('deploy_rhev')) {
       this.store.findAll('hostgroup').then(function(results) {
-        console.log(results);
         var fusorBaseHostgroup = results.filterBy('name', 'Fusor Base').get('firstObject');
         var fusorBaseDomain = fusorBaseHostgroup.get('domain.name');
         controller.set('engineDomain', fusorBaseDomain);
@@ -31,7 +59,11 @@ export default Ember.Route.extend({
       });
     }
 
-    if (model.get('is_disconnected')) {
+    const subModel = this.controllerFor('subscriptions');
+    if(modelHash.useExistingManifest) {
+      controller.set('useExistingManifest', true);
+      controller.set('reviewSubscriptions', modelHash.subscriptions);
+    } else if (model.get('is_disconnected')) {
       controller.set('reviewSubscriptions', this.modelFor('subscriptions/review-subscriptions'));
     } else {
       var reviewSubscriptions = model.get('subscriptions').filter(function(sub) {
@@ -42,7 +74,7 @@ export default Ember.Route.extend({
       }, false); // initial val
       controller.set('reviewSubscriptions', reviewSubscriptions);
       controller.set('hasSubscriptionsToAttach', hasSubs);
-      controller.set('hasSessionPortal', Ember.isPresent(this.modelFor('subscriptions').sessionPortal));
+      controller.set('hasSessionPortal', subModel ? subModel.sessionPortal : null);
       controller.set('hasSubscriptionPools', Ember.isPresent(this.controllerFor('subscriptions/select-subscriptions').get('subscriptionPools')));
     }
 

--- a/fusor-ember-cli/app/routes/subscriptions.js
+++ b/fusor-ember-cli/app/routes/subscriptions.js
@@ -20,9 +20,8 @@ export default Ember.Route.extend({
   },
 
   actions: {
-    error(reason, transition) {
-      // bubble up this error event:
-      return true;
+    error() {
+      return true; // bubbles error event
     }
   }
 });

--- a/fusor-ember-cli/app/routes/subscriptions.js
+++ b/fusor-ember-cli/app/routes/subscriptions.js
@@ -3,20 +3,38 @@ import Ember from 'ember';
 export default Ember.Route.extend({
 
   model() {
-    var self = this;
-    return this.store.findAll('session-portal').then(function(results) {
+    const sessionPortal = this.store.findAll('session-portal').then(results => {
       if (Ember.isBlank(results)) {
-        return self.store.createRecord('session-portal');
+        return this.store.createRecord('session-portal');
       } else {
         return results.get('firstObject');
       }
     });
+
+    return Ember.RSVP.hash({
+      sessionPortal,
+      useExistingManifest: this.shouldUseExistingManifest()
+    });
   },
 
   setupController(controller, model) {
-    controller.set('model', model);
+    controller.set('model', model.sessionPortal);
+    // Check if there's an existing manifest in satellite that should be used
+    // If so, we want to streamline subscriptions and simply reuse that manifest
+    // Steps A-C in a brand new deployment are no longer needed, so simply display
+    // the review and continue.
+    controller.set('useExistingManifest', model.useExistingManifest);
+    if(model.useExistingManifest) {
+      this.transitionTo('subscriptions.review-subscriptions');
+    }
+
     var stepNumberSubscriptions = this.controllerFor('deployment').get('stepNumberSubscriptions');
     return this.controllerFor('deployment').set('currentStepNumber', stepNumberSubscriptions);
+  },
+
+  shouldUseExistingManifest() {
+    const deplController = this.controllerFor('deployment');
+    return Ember.isPresent(deplController.get('model.upstream_consumer_uuid'));
   },
 
   actions: {

--- a/fusor-ember-cli/app/routes/subscriptions.js
+++ b/fusor-ember-cli/app/routes/subscriptions.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
+import NeedsExistingManifestHelpers from '../mixins/needs-existing-manifest-helpers';
 
-export default Ember.Route.extend({
+export default Ember.Route.extend(NeedsExistingManifestHelpers, {
 
   model() {
     const sessionPortal = this.store.findAll('session-portal').then(results => {
@@ -10,7 +11,6 @@ export default Ember.Route.extend({
         return results.get('firstObject');
       }
     });
-
 
     return this.shouldUseExistingManifest().then(useExistingManifest => {
       const modelHash = {sessionPortal, useExistingManifest};
@@ -34,76 +34,6 @@ export default Ember.Route.extend({
 
     var stepNumberSubscriptions = this.controllerFor('deployment').get('stepNumberSubscriptions');
     return this.controllerFor('deployment').set('currentStepNumber', stepNumberSubscriptions);
-  },
-
-  shouldUseExistingManifest() {
-    const orgId = this.modelFor('deployment').get('organization.id');
-    const modelUpstreamConsumerUuid = this.modelFor('deployment')
-      .get('upstream_consumer_uuid');
-    const hasModelUpstreamConsumerUuid = Ember.isPresent(modelUpstreamConsumerUuid);
-
-    return new Ember.RSVP.Promise((res, rej) => {
-      const url = `/katello/api/v2/organizations/${orgId}`;
-      Ember.$.getJSON(url).then(results => {
-        const satManifestExists =
-          Ember.isPresent(results.owner_details) &&
-          Ember.isPresent(results.owner_details.upstreamConsumer);
-
-        if(!satManifestExists && hasModelUpstreamConsumerUuid) {
-          // Edge case where an upstream_consumer_uuid has been saved into the
-          // fusor model but not yet uploaded to satellite. Indicates a deployment
-          // in progress, but not one where satellite already has an existing
-          // manifest available for reuse
-          res(false);
-        } else if(satManifestExists && hasModelUpstreamConsumerUuid){
-          if(results.owner_details.upstreamConsumer.uuid !== modelUpstreamConsumerUuid) {
-            // ERROR: Manifest uuid reported by satellite differs from that on the model
-            // something is corrupt. Assert failure.
-            throw 'ERROR: upstreamConsumer.uuid does not match the one found on the' +
-              'fusor deployment model!';
-          } else {
-            // Existing manifest was found in satellite and matches the one set on the
-            // model by the deployment route, continue with streamlined subs
-            res(true);
-          }
-        } else {
-          // Standard new deployment with no manifest in Sat and with no manifest
-          // having ever been uploaded via the Fusor wizard
-          res(false);
-        }
-      }, () => rej(false));
-    });
-  },
-
-  loadSubscriptions() {
-    const orgId = this.modelFor('deployment').get('organization.id');
-    const subsUrl = `/katello/api/v2/organizations/${orgId}/subscriptions`;
-    return new Ember.RSVP.Promise((res, rej) => {
-      Ember.$.getJSON(subsUrl).then(response => {
-        if(Ember.isNone(response.results)) {
-          res(Ember.A());
-        } else {
-          const subs = Ember.A(response.results)
-            .filter(sub => sub.name !== 'Fusor')
-            .map(sub => {
-              return Ember.Object.create({
-                product_name: sub.name,
-                contract_number: sub.contract_number,
-                start_date: sub.start_date,
-                end_date: sub.end_date,
-                quantity_attached: sub.quantity
-              });
-            });
-          res(subs);
-        }
-      },
-      err => {
-        console.log(
-          'ERROR: Something went wrong loading subscription info ' +
-          'during existing manifest load!');
-        rej(err);
-      });
-    });
   },
 
   actions: {

--- a/fusor-ember-cli/app/routes/subscriptions.js
+++ b/fusor-ember-cli/app/routes/subscriptions.js
@@ -33,8 +33,44 @@ export default Ember.Route.extend({
   },
 
   shouldUseExistingManifest() {
-    const deplController = this.controllerFor('deployment');
-    return Ember.isPresent(deplController.get('model.upstream_consumer_uuid'));
+    const orgId = this.modelFor('deployment').get('organization.id');
+    const modelUpstreamConsumerUuid = this.controllerFor('deployment')
+      .get('model.upstream_consumer_uuid');
+    const hasModelUpstreamConsumerUuid = Ember.isPresent(modelUpstreamConsumerUuid);
+
+    return new Ember.RSVP.Promise((res, rej) => {
+      const url = `/katello/api/v2/organizations/${orgId}`;
+      Ember.$.getJSON(url).then(results => {
+        const satManifestExists =
+          Ember.isPresent(results.owner_details) &&
+          Ember.isPresent(results.owner_details.upstreamConsumer);
+
+        if(!satManifestExists && hasModelUpstreamConsumerUuid) {
+          // Edge case where an upstream_consumer_uuid has been saved into the
+          // fusor model but not yet uploaded to satellite. Indicates a deployment
+          // in progress, but not one where satellite already has an existing
+          // manifest available for reuse
+          res(false);
+        } else if(satManifestExists && hasModelUpstreamConsumerUuid){
+          if(results.owner_details.upstreamConsumer.uuid !== modelUpstreamConsumerUuid) {
+            // ERROR: Manifest uuid reported by satellite differs from that on the model
+            // something is corrupt. Assert failure.
+            throw 'ERROR: upstreamConsumer.uuid does not match the one found on the' +
+              'fusor deployment model!';
+          } else {
+            // Existing manifest was found in satellite and matches the one set on the
+            // model by the deployment route, continue with streamlined subs
+            res(true);
+          }
+        } else {
+          // Standard new deployment with no manifest in Sat and with no manifest
+          // having ever been uploaded via the Fusor wizard
+          res(false);
+        }
+      }, () => {
+        rej(false);
+      });
+    });
   },
 
   actions: {

--- a/fusor-ember-cli/app/routes/subscriptions.js
+++ b/fusor-ember-cli/app/routes/subscriptions.js
@@ -11,9 +11,13 @@ export default Ember.Route.extend({
       }
     });
 
-    return Ember.RSVP.hash({
-      sessionPortal,
-      useExistingManifest: this.shouldUseExistingManifest()
+
+    return this.shouldUseExistingManifest().then(useExistingManifest => {
+      const modelHash = {sessionPortal, useExistingManifest};
+      if(useExistingManifest) {
+        modelHash.subscriptions = this.loadSubscriptions();
+      }
+      return Ember.RSVP.hash(modelHash);
     });
   },
 
@@ -34,8 +38,8 @@ export default Ember.Route.extend({
 
   shouldUseExistingManifest() {
     const orgId = this.modelFor('deployment').get('organization.id');
-    const modelUpstreamConsumerUuid = this.controllerFor('deployment')
-      .get('model.upstream_consumer_uuid');
+    const modelUpstreamConsumerUuid = this.modelFor('deployment')
+      .get('upstream_consumer_uuid');
     const hasModelUpstreamConsumerUuid = Ember.isPresent(modelUpstreamConsumerUuid);
 
     return new Ember.RSVP.Promise((res, rej) => {
@@ -67,8 +71,37 @@ export default Ember.Route.extend({
           // having ever been uploaded via the Fusor wizard
           res(false);
         }
-      }, () => {
-        rej(false);
+      }, () => rej(false));
+    });
+  },
+
+  loadSubscriptions() {
+    const orgId = this.modelFor('deployment').get('organization.id');
+    const subsUrl = `/katello/api/v2/organizations/${orgId}/subscriptions`;
+    return new Ember.RSVP.Promise((res, rej) => {
+      Ember.$.getJSON(subsUrl).then(response => {
+        if(Ember.isNone(response.results)) {
+          res(Ember.A());
+        } else {
+          const subs = Ember.A(response.results)
+            .filter(sub => sub.name !== 'Fusor')
+            .map(sub => {
+              return Ember.Object.create({
+                product_name: sub.name,
+                contract_number: sub.contract_number,
+                start_date: sub.start_date,
+                end_date: sub.end_date,
+                quantity_attached: sub.quantity
+              });
+            });
+          res(subs);
+        }
+      },
+      err => {
+        console.log(
+          'ERROR: Something went wrong loading subscription info ' +
+          'during existing manifest load!');
+        rej(err);
       });
     });
   },

--- a/fusor-ember-cli/app/routes/subscriptions/credentials.js
+++ b/fusor-ember-cli/app/routes/subscriptions/credentials.js
@@ -5,7 +5,7 @@ export default Ember.Route.extend({
 
   beforeModel() {
     // Verify isAuthenticated: true is accurate, since Satellite session may have changed
-    const model =  this.modelFor('subscriptions');
+    const model =  this.modelFor('subscriptions').sessionPortal;
     if(model.get('isAuthenticated')) {
       const urlVerify =
         `/customer_portal/users/${model.get('identification')}/owners`;
@@ -79,14 +79,15 @@ export default Ember.Route.extend({
           }
         }).then(function(response) {
           //show always be {} empty successful 200 response
-          self.modelFor('subscriptions').setProperties({
+          const sessionPortal = self.modelFor('subscriptions').sessionPortal;
+          sessionPortal.setProperties({
             'isAuthenticated': false,
             'identification': null,
             'ownerKey': null,
             'consumerUUID': null
           });
 
-          self.modelFor('subscriptions').save();
+          sessionPortal.save();
         }, function(error) {
           console.log('error on loginPortal');
           return self.send('error');
@@ -99,7 +100,7 @@ export default Ember.Route.extend({
       var self = this;
       var controller = this.controllerFor('subscriptions/credentials');
       var identification = controller.get('model.identification');
-      var sessionPortal = this.modelFor('subscriptions');
+      var sessionPortal = this.modelFor('subscriptions').sessionPortal;
       if (sessionPortal) {
         sessionPortal.set('identification', identification);
       } else {
@@ -137,7 +138,7 @@ export default Ember.Route.extend({
         }).then(function(response) {
           var ownerKey = response[0]['key'];
           console.log('owner key is ' + ownerKey);
-          var sessionPortal = self.modelFor('subscriptions');
+          var sessionPortal = self.modelFor('subscriptions').sessionPortal;
           sessionPortal.set('ownerKey', ownerKey);
           sessionPortal.set('isAuthenticated', true);
           sessionPortal.save().then(function(result) {

--- a/fusor-ember-cli/app/routes/subscriptions/management-application.js
+++ b/fusor-ember-cli/app/routes/subscriptions/management-application.js
@@ -5,7 +5,7 @@ export default Ember.Route.extend({
   model() {
     var self = this;
     var deployment = this.modelFor('deployment');
-    var sessionPortal = this.modelFor('subscriptions');
+    var sessionPortal = this.modelFor('subscriptions').sessionPortal;
     var ownerKey = sessionPortal.get('ownerKey');
 
     // Use owner key to get consumers (subscription application manangers)
@@ -46,7 +46,7 @@ export default Ember.Route.extend({
     controller.set('model', model);
     controller.set('showManagementApplications', true);
 
-    var sessionPortal = this.modelFor('subscriptions');
+    var sessionPortal = this.modelFor('subscriptions').sessionPortal;
     var deployment = this.modelFor('deployment');
     var upstream_consumer_uuid = deployment.get('upstream_consumer_uuid');
 

--- a/fusor-ember-cli/app/routes/subscriptions/review-subscriptions.js
+++ b/fusor-ember-cli/app/routes/subscriptions/review-subscriptions.js
@@ -1,28 +1,46 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-
+  ////////////////////////////////////////////////////////////
+  // NOTE: Review data can comes from three different sources depending on scenario
+  // 1) Connected -> No existing manifest, uploading manifest as part of the deployment
+  //    by logging into the CDN as part of the deployment. Review info comes from
+  //    customer portal.
+  // 2) Disconnected -> No existing manifest, uploading manifest locally. Entitlement
+  //    data was previously stored in fusor_subscriptions table as part of that upload.
+  //    We ask fusor server for that data via subscription endpoint
+  // 3) useExistingManifest -> Manifest was *not* uploaded as part of current deployment,
+  //    instead we're using an existing manifest that's been uploaded to Sat previously.
+  //    In this case, might not be logged in, and fusor_subscriptions table probably does
+  //    not have the data we need, so neither 1) or 2) approaches can be used. Need to
+  //    hit Sat to retrieve what it knows about the existing manifest.
+  ////////////////////////////////////////////////////////////
   model() {
-    // GET /fusor/subscriptions?source=imported&deployment_id=ID_OF_DEPLOYMENT
-    var self = this;
-    var deploymentId = this.modelFor('deployment').get('id');
-    if (this.modelFor('deployment').get('is_disconnected')) {
+    const useExistingManifest =
+      this.modelFor('subscriptions').useExistingManifest;
+
+    if(useExistingManifest) { // Case 3)
+      return this.loadExistingManifest();
+    }
+
+    const deploymentId = this.modelFor('deployment').get('id');
+    if (this.modelFor('deployment').get('is_disconnected')) { // Case 2)
+      // GET /fusor/subscriptions?source=imported&deployment_id=ID_OF_DEPLOYMENT
       return this.store.query('subscription', {deployment_id: deploymentId, source: 'imported'});
-    } else {
+    } else { // Case 1)
         // if there are no added subscriptions we need to show what is in the manifest instead.
       return this.store.query('subscription', {
         deployment_id: deploymentId,
         source: 'added'
-      }).then(function(results) {
-
-        let noSubsFound = results.get('length') === 0;
+      }).then(results => {
+        const noSubsFound = results.get('length') === 0;
 
         if(noSubsFound) {
 
-          let deployment = self.modelFor('deployment');
-          let consumerUUID = self.modelFor('deployment').get('upstream_consumer_uuid');
+          const deployment = this.modelFor('deployment');
+          const consumerUUID = this.modelFor('deployment').get('upstream_consumer_uuid');
 
-          return self.store.query('entitlement', {uuid: consumerUUID}).then((entitlements) => {
+          return this.store.query('entitlement', {uuid: consumerUUID}).then((entitlements) => {
 
             let pseudoSubs = entitlements.map((pool) => {
               return Ember.Object.create({
@@ -46,8 +64,31 @@ export default Ember.Route.extend({
           });
         }
       });
-
     }
-  }
+  },
 
+  setupController(controller, model) {
+    controller.set('model', model);
+    controller.set(
+      'useExistingManifest',
+      this.modelFor('subscriptions').useExistingManifest);
+  },
+
+  loadExistingManifest() {
+    // TODO: DEBUG:
+    return new Ember.RSVP.Promise((res, rej) => {
+      const subs = Ember.A([]);
+
+      subs.push(Ember.Object.create({
+        product_name: 'MOCKED PRODUCT',
+        contract_number: '10670000',
+        start_date: '2015-03-31T04:00:00.000+0000',
+        end_date: '2016-03-31T03:59:59.000+0000',
+        quantity_attached: 10,
+        total_quantity: 400
+      }));
+
+      res(subs);
+    });
+  }
 });

--- a/fusor-ember-cli/app/routes/subscriptions/review-subscriptions.js
+++ b/fusor-ember-cli/app/routes/subscriptions/review-subscriptions.js
@@ -16,11 +16,12 @@ export default Ember.Route.extend({
   //    hit Sat to retrieve what it knows about the existing manifest.
   ////////////////////////////////////////////////////////////
   model() {
-    const useExistingManifest =
-      this.modelFor('subscriptions').useExistingManifest;
+    const subModel = this.modelFor('subscriptions');
+    const useExistingManifest = subModel.useExistingManifest;
 
     if(useExistingManifest) { // Case 3)
-      return this.loadExistingManifest();
+      // Note: subscriptions will only be available if useExistingManifest is true
+      return subModel.subscriptions;
     }
 
     const deploymentId = this.modelFor('deployment').get('id');
@@ -72,23 +73,5 @@ export default Ember.Route.extend({
     controller.set(
       'useExistingManifest',
       this.modelFor('subscriptions').useExistingManifest);
-  },
-
-  loadExistingManifest() {
-    // TODO: DEBUG:
-    return new Ember.RSVP.Promise((res, rej) => {
-      const subs = Ember.A([]);
-
-      subs.push(Ember.Object.create({
-        product_name: 'MOCKED PRODUCT',
-        contract_number: '10670000',
-        start_date: '2015-03-31T04:00:00.000+0000',
-        end_date: '2016-03-31T03:59:59.000+0000',
-        quantity_attached: 10,
-        total_quantity: 400
-      }));
-
-      res(subs);
-    });
   }
 });

--- a/fusor-ember-cli/app/routes/subscriptions/select-subscriptions.js
+++ b/fusor-ember-cli/app/routes/subscriptions/select-subscriptions.js
@@ -14,6 +14,7 @@ export default Ember.Route.extend({
     var deployment = this.modelFor('deployment');
     var deploymentId = deployment.get('id');
     var isDisconnected = this.controllerFor('deployment').get('isDisconnected');
+    var sessionPortal = self.modelFor('subscriptions').sessionPortal;
 
     if (!(this.controllerFor('deployment').get('isStarted'))) {
       controller.set('isLoading', true);
@@ -35,7 +36,7 @@ export default Ember.Route.extend({
         var subscriptionResults     = results[2];
 
         // in case go to this route from URL
-        self.modelFor('subscriptions').set('isAuthenticated', true);
+        sessionPortal.set('isAuthenticated', true);
         allPoolsResults.forEach(function(pool){
           pool.set('qtyAttached', 0); //default for loop
 
@@ -72,7 +73,7 @@ export default Ember.Route.extend({
         controller.set('subscriptionPools', Ember.A(results[1]));
         return controller.set('isLoading', false);
       }, function(error) {
-        self.modelFor('subscriptions').save().then(function() {
+        sessionPortal.save().then(function() {
           controller.set('errorMsg', error.message);
           return controller.set('isLoading', false);
         });
@@ -80,13 +81,7 @@ export default Ember.Route.extend({
     }
   },
 
-  deactivate() {
-    // uncommeting causes inFlight issues
-    // return this.send('saveSubscriptions', null);
-  },
-
   actions: {
-
     saveSubscription(pool, qty) {
       // get saved subscriptions and update quantity
       var deployment = this.modelFor('deployment');

--- a/fusor-ember-cli/app/templates/components/tr-subscription-manifest.hbs
+++ b/fusor-ember-cli/app/templates/components/tr-subscription-manifest.hbs
@@ -3,4 +3,6 @@
 <td class="text-center"> {{moment subscription.start_date 'll'}} </td>
 <td class="text-center"> {{moment subscription.end_date 'll'}} </td>
 <td class="text-center"> {{qtyColumn}} </td>
-<td class="text-center"> {{subscription.total_quantity}} </td>
+{{#unless useExistingManifest}}
+  <td class="text-center"> {{subscription.total_quantity}} </td>
+{{/unless}}

--- a/fusor-ember-cli/app/templates/subscriptions.hbs
+++ b/fusor-ember-cli/app/templates/subscriptions.hbs
@@ -1,47 +1,57 @@
 {{#wizard-step outlet=outlet}}
 
-      {{#link-to 'subscriptions.credentials' tagName='li' disabled=disableTabCredentials}}
-        <a>
-          <span class="hanging-indent">
-            {{stepNumberSubscriptions}}A. Content Provider
-          </span>
-        </a>
-      {{/link-to}}
+  {{#if useExistingManifest}}
+    {{#link-to 'subscriptions.review-subscriptions' tagName='li'}}
+      <a>
+        <span class="hanging-indent">
+          {{stepNumberSubscriptions}}A. Review Subscriptions
+        </span>
+      </a>
+    {{/link-to}}
+  {{else}}
+    {{#link-to 'subscriptions.credentials' tagName='li' disabled=disableTabCredentials}}
+      <a>
+        <span class="hanging-indent">
+          {{stepNumberSubscriptions}}A. Content Provider
+        </span>
+      </a>
+    {{/link-to}}
 
-      {{#if isDisconnected}}
-          {{#link-to 'subscriptions.review-subscriptions' tagName='li' disabled=disableTabReviewSubsciptions}}
-            <a>
-              <span class="hanging-indent">
-                {{stepNumberSubscriptions}}B. Review Subscriptions
-              </span>
-            </a>
-          {{/link-to}}
+    {{#if isDisconnected}}
+        {{#link-to 'subscriptions.review-subscriptions' tagName='li' disabled=disableTabReviewSubsciptions}}
+          <a>
+            <span class="hanging-indent">
+              {{stepNumberSubscriptions}}B. Review Subscriptions
+            </span>
+          </a>
+        {{/link-to}}
 
-      {{else}}
+    {{else}}
 
-          {{#link-to 'subscriptions.management-application' tagName='li' disabled=disableTabManagementApplication}}
-            <a>
-              <span class="hanging-indent">
-                {{stepNumberSubscriptions}}B. Subscription Management Application
-              </span>
-            </a>
-          {{/link-to}}
+        {{#link-to 'subscriptions.management-application' tagName='li' disabled=disableTabManagementApplication}}
+          <a>
+            <span class="hanging-indent">
+              {{stepNumberSubscriptions}}B. Subscription Management Application
+            </span>
+          </a>
+        {{/link-to}}
 
-          {{#link-to 'subscriptions.select-subscriptions' tagName='li' disabled=disableTabSelectSubsciptions}}
-            <a>
-              <span class="hanging-indent">
-                {{stepNumberSubscriptions}}C. Add Subscriptions
-              </span>
-            </a>
-          {{/link-to}}
+        {{#link-to 'subscriptions.select-subscriptions' tagName='li' disabled=disableTabSelectSubsciptions}}
+          <a>
+            <span class="hanging-indent">
+              {{stepNumberSubscriptions}}C. Add Subscriptions
+            </span>
+          </a>
+        {{/link-to}}
 
-          {{#link-to 'subscriptions.review-subscriptions' tagName='li' disabled=disableTabSelectSubsciptions}}
-            <a>
-              <span class="hanging-indent">
-                {{stepNumberSubscriptions}}D. Review Subscriptions
-              </span>
-            </a>
-          {{/link-to}}
-      {{/if}}
+        {{#link-to 'subscriptions.review-subscriptions' tagName='li' disabled=disableTabSelectSubsciptions}}
+          <a>
+            <span class="hanging-indent">
+              {{stepNumberSubscriptions}}D. Review Subscriptions
+            </span>
+          </a>
+        {{/link-to}}
+    {{/if}}
+  {{/if}}
 
 {{/wizard-step}}

--- a/fusor-ember-cli/app/templates/subscriptions/credentials.hbs
+++ b/fusor-ember-cli/app/templates/subscriptions/credentials.hbs
@@ -1,13 +1,3 @@
-{{#if hasUpstreamConsumerUuid}}
-  <div class="row">
-    <div class='col-md-9'>
-      <div class='alert alert-info rhci-alert'>
-          This deployment already has a subscription management application <strong>{{upstreamConsumerName}}</strong> assigned to it.
-      </div>
-    </div>
-  </div>
-{{/if}}
-
 {{#if showErrorMessage}}
   <div class="row">
     <div class='col-md-9'>

--- a/fusor-ember-cli/app/templates/subscriptions/credentials.hbs
+++ b/fusor-ember-cli/app/templates/subscriptions/credentials.hbs
@@ -6,14 +6,6 @@
       </div>
     </div>
   </div>
-{{else if hasOrganizationUpstreamConsumerUUID}}
-  <div class="row">
-    <div class='col-md-9'>
-      <div class='alert alert-info rhci-alert'>
-          There is already a manifest uploaded for your organization: <strong> {{organizationUpstreamConsumerName}}</strong>
-      </div>
-    </div>
-  </div>
 {{/if}}
 
 {{#if showErrorMessage}}

--- a/fusor-ember-cli/app/templates/subscriptions/review-subscriptions.hbs
+++ b/fusor-ember-cli/app/templates/subscriptions/review-subscriptions.hbs
@@ -1,3 +1,14 @@
+
+{{#if useExistingManifest}}
+  <div class="row">
+    <div class='col-md-9'>
+      <div class='alert alert-info rhci-alert'>
+          This deployment already has a subscription management application <strong>{{upstreamConsumerName}}</strong> assigned to it.
+      </div>
+    </div>
+  </div>
+{{/if}}
+
 <div class="row">
   <div class='col-md-9'>
 

--- a/fusor-ember-cli/app/templates/subscriptions/review-subscriptions.hbs
+++ b/fusor-ember-cli/app/templates/subscriptions/review-subscriptions.hbs
@@ -20,13 +20,15 @@
           <th class="text-center"> Start Date </th>
           <th class="text-center"> End Date </th>
           <th class="text-center"> Quantity Attached </th>
-          <th class="text-center"> Total Quantity </th>
+          {{#unless useExistingManifest}}
+            <th class="text-center"> Total Quantity </th>
+          {{/unless}}
         </tr>
         </thead>
 
       <tbody>
       {{#each sortedModel as |subscription|}}
-          {{tr-subscription-manifest subscription=subscription isDisconnected=isDisconnected}}
+          {{tr-subscription-manifest subscription=subscription isDisconnected=isDisconnected useExistingManifest=useExistingManifest}}
       {{else}}
         <tr>
           <td colspan="8">

--- a/server/app/lib/actions/fusor/subscription/manage_manifest.rb
+++ b/server/app/lib/actions/fusor/subscription/manage_manifest.rb
@@ -39,55 +39,31 @@ module Actions
               # automagically.
               # only download it if we didn't supply our own cdn_url
               if deployment.cdn_url.blank?
+                ::Fusor.log.error("XXX DOWNLOAD manifest 1");
                 plan_action(::Actions::Fusor::Subscription::DownloadManifest,
                             deployment,
                             customer_portal_credentials,
                             download_file_path)
               end
+              ::Fusor.log.error("XXX IMPORT manifest 1");
               plan_action(::Actions::Katello::Provider::ManifestImport,
                           deployment.organization.redhat_provider,
                           download_file_path,
                           nil)
             end
 
-          else
-            # If there is an upstream consumer, a manifest has been previously imported in to the org;
-            # therefore,if the user didn't associate a consumer with the deployment, use the existing upstream
-            # consumer from the organization; otherwise, either refresh it or delete it and import another
-
-            if deployment.upstream_consumer_uuid.nil?
-              deployment.update_attribute(:upstream_consumer_uuid, upstream_consumer['uui'])
-
-            elsif upstream_consumer['uuid'] == deployment.upstream_consumer_uuid
-              plan_action(::Actions::Katello::Provider::ManifestRefresh,
-                          deployment.organization.redhat_provider,
-                          upstream_consumer)
-
-            else
-              download_file_path = File.join("#{Rails.root}/tmp", "import_#{SecureRandom.hex(10)}.zip")
-              if deployment.cdn_url?
-                download_file_path = deployment.manifest_file
-              end
-
-              ::Fusor.log.debug("existing upstream_consumer: #{download_file_path}")
-
-              sequence do
-                if deployment.cdn_url.blank?
-                  plan_action(::Actions::Fusor::Subscription::DownloadManifest,
-                              deployment,
-                              customer_portal_credentials,
-                              download_file_path)
-                end
-
-                plan_action(::Actions::Katello::Provider::ManifestDelete,
-                            deployment.organization.redhat_provider)
-
-                plan_action(::Actions::Katello::Provider::ManifestImport,
-                            deployment.organization.redhat_provider,
-                            download_file_path,
-                            nil)
-              end
-            end
+            #
+            # 2016/05/27 zeus:
+            # we used to have an else condition that would refresh the manifest
+            # if the deployment had an upstream uuid that matched the
+            # organizations. If for some reason the uuid of the deployment did
+            # not match the one from the organization we would download, delete
+            # and import a new manifest.
+            #
+            # We no longer want to do any of this. Once a manifest has been
+            # imported we don't want to allow new imports. Therefore the entire
+            # else clause was wiped out.
+            #
           end
         end
       end

--- a/server/app/lib/actions/fusor/subscription/manage_manifest.rb
+++ b/server/app/lib/actions/fusor/subscription/manage_manifest.rb
@@ -39,13 +39,11 @@ module Actions
               # automagically.
               # only download it if we didn't supply our own cdn_url
               if deployment.cdn_url.blank?
-                ::Fusor.log.error("XXX DOWNLOAD manifest 1");
                 plan_action(::Actions::Fusor::Subscription::DownloadManifest,
                             deployment,
                             customer_portal_credentials,
                             download_file_path)
               end
-              ::Fusor.log.error("XXX IMPORT manifest 1");
               plan_action(::Actions::Katello::Provider::ManifestImport,
                           deployment.organization.redhat_provider,
                           download_file_path,

--- a/server/test/lib/actions/fusor/subscription/manage_manifest_test.rb
+++ b/server/test/lib/actions/fusor/subscription/manage_manifest_test.rb
@@ -21,20 +21,6 @@ module Actions::Fusor::Subscription
       assert_action_planed(@action, ManifestImport)
     end
 
-    test "if org consumer is the same as deployment consumer, schedule refresh" do
-      @deployment.organization.stubs(:owner_details => {'upstreamConsumer' => { 'uuid' => @deployment.upstream_consumer_uuid }})
-      plan_action @action, @deployment, @credentials
-      assert_action_planed(@action, ManifestRefresh)
-    end
-
-    test "if org consumer is the different from deployment consumer, delete old manifest, download new one, and import" do
-      @deployment.organization.stubs(:owner_details => {'upstreamConsumer' => { 'uuid' => 'some other random thing' }})
-      plan_action @action, @deployment, @credentials
-      assert_action_planed(@action, DownloadManifest)
-      assert_action_planed(@action, ManifestDelete)
-      assert_action_planed(@action, ManifestImport)
-    end
-
     test "there is no run method for ManageManifest Actions" do
       @deployment.organization.stubs(:owner_details => {'upstreamConsumer' => ''})
       plan = plan_action @action, @deployment, @credentials


### PR DESCRIPTION
This PR changes the subscriptions workflow pages to handle the case when a manifest has already been imported. Future deployments will use the same manifest imported by the very first one. Typically if a Satellite already has a manifest that's what we want to use.