### PR TITLE
Rhev Self-hosted multiple hypervisors

### DIFF
--- a/server/app/lib/actions/fusor/configure_host_groups.rb
+++ b/server/app/lib/actions/fusor/configure_host_groups.rb
@@ -300,7 +300,7 @@ module Actions
                 { :name => "engine_mac_address", :value => Utils::Fusor::MacAddresses.generate_mac_address },
                 { :name => "engine_fqdn", :value => "#{deployment.label.tr('_', '-')}-rhev-engine.#{hostgroup.domain.name}" },
                 { :name => "engine_admin_password", :value => deployment.rhev_engine_admin_password },
-                { :name => "engine_activation_key", :value => hostgroup.params['kt_activation_keys'] },
+                { :name => "engine_activation_key", :value => hostgroup.group_parameters.where(:name => 'kt_activation_keys').try(:first).try(:value) },
                 { :name => "export_name", :value => deployment.rhev_export_domain_name },
                 { :name => "export_address", :value => deployment.rhev_export_domain_address },
                 { :name => "export_path", :value => deployment.rhev_export_domain_path },

--- a/server/app/lib/actions/fusor/deployment/rhev/deploy.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/deploy.rb
@@ -26,16 +26,39 @@ module Actions
               if deployment.rhev_is_self_hosted
                 # Self-hosted RHEV
                 fail _("Unable to locate a RHEV Hypervisor Host") unless (deployment.discovered_hosts.count > 0)
-                # TODO(fabianvf): additional hypervisors
-                hypervisor = deployment.discovered_hosts[0]
+
+                first_host = deployment.discovered_hosts[0]
+                additional_hosts = deployment.discovered_hosts[1..-1]
 
                 plan_action(::Actions::Fusor::Deployment::Rhev::CreateEngineHostRecord, deployment, 'RHEV-Self-hosted')
                 plan_action(::Actions::Fusor::Host::TriggerProvisioning,
                             deployment,
                             "RHEV-Self-hosted",
-                            hypervisor)
+                            first_host)
                 plan_action(::Actions::Fusor::Host::WaitUntilProvisioned,
-                            hypervisor.id)
+                            first_host.id, true)
+
+                additional_hosts.each_with_index do |host, index|
+                  # Override puppet class for host_id and is additional host
+                  puppetclass_id = Puppetclass.where(:name => 'ovirt::self_hosted::setup').first.id
+                  overrides = {
+                    puppetclass_id => {
+                     :host_id => (index + 2),
+                     :additional_host => true
+                    }
+                  }
+                  plan_action(::Actions::Fusor::Host::TriggerProvisioning,
+                              deployment,
+                              "RHEV-Self-hosted",
+                              host, overrides)
+                end
+                concurrence do
+                  additional_hosts.each do |host|
+                    plan_action(::Actions::Fusor::Host::WaitUntilProvisioned,
+                                host.id, true)
+                  end
+                end
+
               else
                 # Hypervisor + Engine separate
 
@@ -61,8 +84,8 @@ module Actions
 
                 plan_action(::Actions::Fusor::Host::WaitUntilProvisioned,
                             deployment.rhev_engine_host.id)
-              end
 
+              end
               plan_action(::Actions::Fusor::Deployment::Rhev::WaitForDataCenter,
                             deployment)
               plan_action(::Actions::Fusor::Deployment::Rhev::CreateCr, deployment)

--- a/server/app/lib/actions/fusor/host/wait_for_puppet.rb
+++ b/server/app/lib/actions/fusor/host/wait_for_puppet.rb
@@ -1,0 +1,71 @@
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+module Actions
+  module Fusor
+    module Host
+      class WaitForPuppet < Actions::Fusor::FusorBaseAction
+        include Actions::Base::Polling
+
+        input_format do
+          param :host_id
+        end
+
+        def humanized_name
+          _("Wait for Puppet Run")
+        end
+
+        def plan(host_id)
+          super()
+          plan_self(host_id: host_id)
+        end
+
+        def done?
+          external_task
+        end
+
+        def poll_intervals
+          # 6m, 4m, 1m, 30s, 8s, 4s, 1s, .5s
+          [360, 240, 60, 30, 8, 4, 1, 0.5]
+        end
+
+        def invoke_external_task
+          is_done? input[:host_id]
+        end
+
+        def poll_external_task
+          is_done? input[:host_id]
+        end
+
+        private
+
+        def is_done?(host_id)
+          ::Fusor.log.info "================ Host::WaitForPuppetRun is_done? method ===================="
+          host = ::Host::Managed.find(host_id)
+          fail _("====== Host is null! Cannot wait for host! ====== ") unless host
+
+          ::Fusor.log.info "Waiting for host #{host.name}'s puppet run to complete"
+          ::Fusor.log.debug("Current puppet run status is #{host.configuration_status_label}")
+
+          if ['Failed', 'Error', 'Out of Sync'].include?(host.configuration_status_label)
+            fail _("====== Puppet run for host #{host.name} status reported as #{host.configuration_status_label} ======")
+          elsif host.configuration_status_label == 'Active'
+            true
+          else
+            false
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/server/app/lib/actions/fusor/host/wait_until_provisioned.rb
+++ b/server/app/lib/actions/fusor/host/wait_until_provisioned.rb
@@ -23,9 +23,14 @@ module Actions
         # the WaitUntilProvisioned because it's not a polling action.
         middleware.use Actions::Fusor::Middleware::Timeout
 
-        def plan(hostid)
+        def plan(hostid, wait_for_puppet = false)
           super()
-          plan_self host_id: hostid
+          sequence do
+            plan_self(host_id: hostid)
+            if wait_for_puppet
+              plan_action(::Actions::Fusor::Host::WaitForPuppet, hostid)
+            end
+          end
         end
 
         def run(event = nil)

--- a/server/app/models/fusor/concerns/host_extensions.rb
+++ b/server/app/models/fusor/concerns/host_extensions.rb
@@ -1,0 +1,37 @@
+module Fusor
+  module Concerns
+    module HostExtensions
+      extend ActiveSupport::Concern
+
+      def current_param_value(key)
+        lookup_value = LookupValue.where(:lookup_key_id => key.id, :id => lookup_values).first
+        if lookup_value
+          [lookup_value.value, to_label]
+        else
+          [nil, nil]
+        end
+      end
+
+      def current_param_value_str(key)
+        lookup_value, _ = current_param_value(key)
+        return key.value_before_type_cast(lookup_value)
+      end
+
+      def set_param_value_if_changed(puppetclass, key, value)
+        if puppetclass
+          lookup_key         = puppetclass.class_params.where(:key => key).first
+          fail _("Failed to find puppet parameter for key #{key} in #{puppetclass.name}") unless  !lookup_key.nil?
+          lookup_value_value = current_param_value(lookup_key)[0]
+          current_value      = lookup_key.value_before_type_cast(lookup_value_value).to_s.chomp
+          if current_value != value
+            lookup       = LookupValue.where(:match         => lookup_value_match,
+                                            :lookup_key_id => lookup_key.id).first_or_initialize
+            lookup.value = value
+            lookup.use_puppet_default = value.blank? ? true : false
+            lookup.save!
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/lib/fusor/engine.rb
+++ b/server/lib/fusor/engine.rb
@@ -88,6 +88,7 @@ module Fusor
       # include concerns
       ::Hostgroup.send :include, Fusor::Concerns::HostgroupExtensions
       ::Host::Managed.send :include, Fusor::Concerns::HostOrchestrationBuildHook
+      ::Host::Managed.send :include, Fusor::Concerns::HostExtensions
       # The following line disabled CSRF and should only be uncommented in development environments
       # ::ActionController::Base.send :include, Fusor::Concerns::ApplicationControllerExtension
 

--- a/server/test/fixtures/fusor_deployment_hosts.yml
+++ b/server/test/fixtures/fusor_deployment_hosts.yml
@@ -17,3 +17,11 @@ deployment_host4:
 deployment_host5:
   discovered_host: host5
   deployment: rhev_self_hosted
+
+deployment_host6:
+  discovered_host: host6
+  deployment: rhev_self_hosted
+
+deployment_host7:
+  discovered_host: host7
+  deployment: rhev_self_hosted

--- a/server/test/fixtures/hosts.yml
+++ b/server/test/fixtures/hosts.yml
@@ -13,6 +13,12 @@ host4:
 host5:
   name: host5
 
+host6:
+  name: host6
+
+host7:
+  name: host7
+
 engine1:
   name: engine1
 

--- a/server/test/lib/actions/fusor/deployment/rhev/deploy_test.rb
+++ b/server/test/lib/actions/fusor/deployment/rhev/deploy_test.rb
@@ -49,7 +49,7 @@ module Actions::Fusor::Deployment::Rhev
                                   hypervisor)
         assert_action_planed_with(@deploy,
                                   WaitUntilProvisioned,
-                                  hypervisor.id)
+                                  hypervisor.id, true)
       end
     end
 

--- a/server/test/lib/actions/fusor/deployment/rhev/deploy_test.rb
+++ b/server/test/lib/actions/fusor/deployment/rhev/deploy_test.rb
@@ -6,8 +6,16 @@ module Actions::Fusor::Deployment::Rhev
     WaitUntilProvisioned = ::Actions::Fusor::Host::WaitUntilProvisioned
     CreateEngineHostRecord = ::Actions::Fusor::Deployment::Rhev::CreateEngineHostRecord
 
+    class ID
+      def id
+        return 1
+      end
+    end
+
     def setup
       @deploy = create_action ::Actions::Fusor::Deployment::Rhev::Deploy
+      ::Puppetclass.stubs(:where).returns([ID.new])
+      ::Puppetclass.stubs(:find).returns(ID.new)
     end
 
     test "plan call should schedule provision and wait actions for each host for hypervisor + engine" do
@@ -41,12 +49,31 @@ module Actions::Fusor::Deployment::Rhev
                                 @deployment,
                                 'RHEV-Self-hosted')
 
-      for hypervisor in @deployment.rhev_hypervisor_hosts
+      first_host = @deployment.rhev_hypervisor_hosts[0]
+      additional_hosts = @deployment.rhev_hypervisor_hosts[1..-1]
+      puppetclass_id = 1
+
+      assert_action_planed_with(@deploy,
+                                  TriggerProvisioning,
+                                @deployment,
+                                'RHEV-Self-hosted',
+                                first_host)
+      assert_action_planed_with(@deploy,
+                                WaitUntilProvisioned,
+                                first_host.id, true)
+
+      additional_hosts.each_with_index do |hypervisor, index|
+        override = {
+          puppetclass_id => {
+            :additional_host => true,
+            :host_id => index + 2
+          }
+        }
         assert_action_planed_with(@deploy,
                                   TriggerProvisioning,
                                   @deployment,
                                   'RHEV-Self-hosted',
-                                  hypervisor)
+                                  hypervisor, override)
         assert_action_planed_with(@deploy,
                                   WaitUntilProvisioned,
                                   hypervisor.id, true)


### PR DESCRIPTION
- [x] Extend TriggerProvisioning to allow the user to pass in host-specific overrides for puppet values after it is converted to a managed host. 
- [x] Extend WaitUntilProvisioned to optionally also wait for the puppet run to complete
- [x] Add logic for deploying RHEV self-hosted to multiple hypervisors.

Depends on https://gitlab.sat.lab.tlv.redhat.com/rhci/puppet-ovirt/merge_requests/23