### PR TITLE
Update OSE deployment to use the deployment.label vs deployment.name

### DIFF
--- a/server/app/lib/actions/fusor/deployment/open_shift/install_ose.rb
+++ b/server/app/lib/actions/fusor/deployment/open_shift/install_ose.rb
@@ -28,7 +28,7 @@ module Actions
             ::Fusor.log.info "================ OpenShift InstallOSE run method ===================="
             deployment = ::Fusor::Deployment.find(input[:deployment_id])
             opts = parse_deployment(deployment)
-            launcher = OSEInstaller::Launch.new("#{Rails.root}/tmp/#{deployment.name}", ::Fusor.log)
+            launcher = OSEInstaller::Launch.new("#{Rails.root}/tmp/#{deployment.label}", ::Fusor.log)
             inventory = launcher.prepare(opts)
 
             # Workaround for https://trello.com/c/4T7e9IFr

--- a/server/app/lib/actions/fusor/deployment/open_shift/post_install_ose.rb
+++ b/server/app/lib/actions/fusor/deployment/open_shift/post_install_ose.rb
@@ -29,7 +29,7 @@ module Actions
 
             deployment = ::Fusor::Deployment.find(input[:deployment_id])
             opts = parse_deployment(deployment)
-            launcher = OSEInstaller::Launch.new("#{Rails.root}/tmp/#{deployment.name}", ::Fusor.log)
+            launcher = OSEInstaller::Launch.new("#{Rails.root}/tmp/#{deployment.label}", ::Fusor.log)
             inventory = launcher.prepare(opts)
             exit_code = launcher.post_install(inventory, true)
             if exit_code > 0

--- a/server/app/lib/actions/fusor/deployment/open_shift/setup_ose.rb
+++ b/server/app/lib/actions/fusor/deployment/open_shift/setup_ose.rb
@@ -29,7 +29,7 @@ module Actions
 
             deployment = ::Fusor::Deployment.find(input[:deployment_id])
             opts = parse_deployment(deployment)
-            launcher = OSEInstaller::Launch.new("#{Rails.root}/tmp/#{deployment.name}", ::Fusor.log)
+            launcher = OSEInstaller::Launch.new("#{Rails.root}/tmp/#{deployment.label}", ::Fusor.log)
             inventory = launcher.prepare(opts)
             exit_code = launcher.setup(inventory, true)
             if exit_code > 0


### PR DESCRIPTION
Using deployment.name causes the following error in running ansible when the deployment name entered has a 'space' character such as "QCI Demo"


2016-06-07 17:15:29,258 p=30428 u=vagrant |  /usr/bin/ansible-playbook -v /git/fusor/server/lib/modules/ose_installer/playbooks/setup.yml -i /git/foreman/tmp/QCI Demo/ansible.hosts
2016-06-07 17:15:29,260 p=30428 u=vagrant |  ERROR: the playbook: Demo/ansible.hosts could not be found
