### PR TITLE
Added a timeout for failed NFS mounts

### DIFF
--- a/server/app/lib/fusor/validators/deployment_validator.rb
+++ b/server/app/lib/fusor/validators/deployment_validator.rb
@@ -175,7 +175,7 @@ module Fusor
       end
 
       def validate_nfs_server(deployment, address)
-        cmd = "showmount #{address}"
+        cmd = "timeout -k 5 5 showmount #{address}"
         status, output = Utils::Fusor::CommandUtils.run_command(cmd)
 
         if status != 0

--- a/server/app/lib/utils/fusor/command_utils.rb
+++ b/server/app/lib/utils/fusor/command_utils.rb
@@ -29,7 +29,12 @@ module Utils
         #
         output = stdout_err.readlines
 
-        if status > 0
+        # In cases where we kill a process before it has finished executing, status is not set.
+        # This is used to avoid waiting for long system timeouts.
+        if !status
+          Rails.logger.error "Error running command: #{cmd}"
+          Rails.logger.error "Process was unexpectedly killed... process may have timed out"
+        elsif status > 0
           Rails.logger.error "Error running command: #{cmd}"
           Rails.logger.error "Status code: #{status}"
           Rails.logger.error "Command output: #{output}"


### PR DESCRIPTION
In the case where an invalid NFS share is given by the user, the system timeout takes a couple of minutes. This adds a timeout process on showmount to catch invalid mounts faster.