### PR TITLE
OSE UI Tweaks part 1

### DIFF
--- a/fusor-ember-cli/app/components/ose-host-review-link.js
+++ b/fusor-ember-cli/app/components/ose-host-review-link.js
@@ -11,9 +11,6 @@ export default Ember.Component.extend({
   linkValue: Ember.computed('oseHost', function() {
     return `https://${this.get('oseHost.name')}:8443`;
   }),
-  linkIp: Ember.computed('oseHost', function() {
-    return `https://${this.get('oseHost.ip')}:8443`;
-  }),
   isWorkerNode: Ember.computed('_infoObj', function() {
     const info = this.get('_infoObj');
     return info.get('labelPrefix') === 'Node';

--- a/fusor-ember-cli/app/controllers/openshift.js
+++ b/fusor-ember-cli/app/controllers/openshift.js
@@ -112,14 +112,12 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, OpenshiftMixin, {
     'exportPathValidator',
     'usernameValidator',
     'subdomainValidator',
-    'model.openshift_storage_name',
     'model.openshift_storage_host',
     'model.openshift_export_path',
     'model.openshift_username',
     'model.openshift_subdomain_name',
     function() {
       return validateZipper([
-        [this.get('storageNameValidator'), this.get('model.openshift_storage_name')],
         [this.get('storageHostValidator'), this.get('model.openshift_storage_host')],
         [this.get('exportPathValidator'), this.get('model.openshift_export_path')],
         [this.get('usernameValidator'), this.get('model.openshift_username')],

--- a/fusor-ember-cli/app/controllers/openshift/openshift-configuration.js
+++ b/fusor-ember-cli/app/controllers/openshift/openshift-configuration.js
@@ -55,10 +55,6 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
     return (this.get('model.openshift_storage_type') === 'NFS');
   }),
 
-  isDoNotUse: Ember.computed('model.openshift_storage_type', function() {
-    return (this.get('model.openshift_storage_type') === 'DoNotUse');
-  }),
-
   isGluster: Ember.computed('model.openshift_storage_type', function() {
     return (this.get('model.openshift_storage_type') === 'GFS');
   }),

--- a/fusor-ember-cli/app/mirage/factories/deployment.js
+++ b/fusor-ember-cli/app/mirage/factories/deployment.js
@@ -34,7 +34,6 @@ export default Mirage.Factory.extend({
   upstream_consumer_uuid: "7ffddefd-aacb-4192-a999-01beb7c2e473",
   upstream_consumer_name: "tsanders-rhci",
   openshift_storage_type: "NFS",
-  openshift_storage_name: "openshift-storage",
   openshift_export_path: "/share/openshift/path",
   cloudforms_vcpu: 4,
   cloudforms_ram: 6,

--- a/fusor-ember-cli/app/models/deployment.js
+++ b/fusor-ember-cli/app/models/deployment.js
@@ -83,7 +83,6 @@ export default DS.Model.extend({
   openshift_available_ram: DS.attr('number'),
   openshift_available_disk: DS.attr('number'),
   openshift_storage_type: DS.attr('string'),
-  openshift_storage_name: DS.attr('string'),
   openshift_storage_host: DS.attr('string'),
   openshift_export_path: DS.attr('string'),
   openshift_subdomain_name: DS.attr('string'),

--- a/fusor-ember-cli/app/templates/components/ose-host-review-link.hbs
+++ b/fusor-ember-cli/app/templates/components/ose-host-review-link.hbs
@@ -4,6 +4,5 @@
   {{review-link
     label=linkLabel
     value=linkValue
-    isExternalURL=true
-    ipAddress=linkIp}}
+    isExternalURL=true}}
 {{/if}}

--- a/fusor-ember-cli/app/templates/openshift/openshift-configuration.hbs
+++ b/fusor-ember-cli/app/templates/openshift/openshift-configuration.hbs
@@ -18,61 +18,50 @@
         Gluster
       </span>
     {{/radio-button}}
-    &nbsp;&nbsp;&nbsp;&nbsp;
-    {{#radio-button value="DoNotUse" groupValue=model.openshift_storage_type id='do_not_use' disabled=true}}
-      <span class="disabled">
-        Do not use
-      </span>
-    {{/radio-button}}
   {{/base-f}}
 
-  {{#unless isDoNotUse}}
+  {{text-f label="Name"
+    value=model.openshift_storage_name isRequired=true
+    cssId='openshift_storage_name' disabled=isStarted
+    validator=storageNameValidator
+  }}
 
-    {{text-f label="Name"
-      value=model.openshift_storage_name isRequired=true
-      cssId='openshift_storage_name' disabled=isStarted
-      validator=storageNameValidator
-    }}
+  {{text-f label="Host"
+    value=model.openshift_storage_host
+    isRequired=true cssId='openshift_storage_host'
+    disabled=isStarted
+    validator=storageHostValidator
+  }}
 
-    {{text-f label="Host"
-      value=model.openshift_storage_host
-      isRequired=true cssId='openshift_storage_host'
-      disabled=isStarted
-      validator=storageHostValidator
-    }}
+  {{text-f label="Export Path"
+    value=model.openshift_export_path
+    isRequired=true cssId='openshift_export_path'
+    disabled=isStarted
+    validator=exportPathValidator
+  }}
 
-    {{text-f label="Export Path"
-      value=model.openshift_export_path
-      isRequired=true cssId='openshift_export_path'
-      disabled=isStarted
-      validator=exportPathValidator
-    }}
+  <br />
 
-    <br />
+  <p>
+    Set the user account that will be created and used to configure all nodes.
+  </p>
 
-    <p>
-      Set the user account that will be created and used to configure all nodes.
-    </p>
+  {{text-f label="Username" value=model.openshift_username
+    isRequired=true cssId='openshift_username' disabled=isStarted
+    validator=usernameValidator
+  }}
 
-    {{text-f label="Username" value=model.openshift_username
-      isRequired=true cssId='openshift_username' disabled=isStarted
-      validator=usernameValidator
-    }}
+  {{text-f label="Password" type="password"
+    value=userpassword cssId="openshift_password" isRequired=true
+    placeholder="Must be 8 or more characters"
+    validator=passwordValidator
+  }}
 
-    {{text-f label="Password" type="password"
-      value=userpassword cssId="openshift_password" isRequired=true
-      placeholder="Must be 8 or more characters"
-      validator=passwordValidator
-    }}
-
-    {{text-f label="Confirm Password" type="password"
-      value=confirmUserPassword cssId="confirm_openshift_password" isRequired=true
-      placeholder="Must match user password"
-      validator=confirmUserPasswordValidator
-    }}
-  {{else}}
-    {{!-- TODO: Implement DONOTUSE (probably doesn't need anything?) --}}
-  {{/unless}}
+  {{text-f label="Confirm Password" type="password"
+    value=confirmUserPassword cssId="confirm_openshift_password" isRequired=true
+    placeholder="Must match user password"
+    validator=confirmUserPasswordValidator
+  }}
 
   <br />
   <p>

--- a/fusor-ember-cli/app/templates/openshift/openshift-configuration.hbs
+++ b/fusor-ember-cli/app/templates/openshift/openshift-configuration.hbs
@@ -20,12 +20,6 @@
     {{/radio-button}}
   {{/base-f}}
 
-  {{text-f label="Name"
-    value=model.openshift_storage_name isRequired=true
-    cssId='openshift_storage_name' disabled=isStarted
-    validator=storageNameValidator
-  }}
-
   {{text-f label="Host"
     value=model.openshift_storage_host
     isRequired=true cssId='openshift_storage_host'

--- a/fusor-ember-cli/app/templates/review/installation.hbs
+++ b/fusor-ember-cli/app/templates/review/installation.hbs
@@ -220,11 +220,6 @@
                       isRequired=true
                       value=model.openshift_storage_type}}
 
-        {{review-link label='Storage Name'
-                      routeName='openshift.openshift-configuration'
-                      isRequired=true
-                      value=model.openshift_storage_name}}
-
         {{review-link label='Storage Host'
                       routeName='openshift.openshift-configuration'
                       value=model.openshift_storage_host}}

--- a/server/app/controllers/fusor/api/v21/deployments_controller.rb
+++ b/server/app/controllers/fusor/api/v21/deployments_controller.rb
@@ -188,7 +188,7 @@ module Fusor
                                          :openshift_root_password, :openshift_master_vcpu, :openshift_master_ram,
                                          :openshift_master_disk, :openshift_node_vcpu, :openshift_node_ram, :openshift_node_disk,
                                          :openshift_available_vcpu, :openshift_available_ram, :openshift_available_disk,
-                                         :openshift_storage_type, :openshift_storage_name, :openshift_storage_host,
+                                         :openshift_storage_type, :openshift_storage_host,
                                          :openshift_export_path, :openshift_subdomain_name, :cloudforms_vcpu,
                                          :cloudforms_ram, :cloudforms_vm_disk_size, :cloudforms_db_disk_size,
                                          :cdn_url, :manifest_file, :created_at, :updated_at, :rhev_engine_host_id,

--- a/server/app/serializers/fusor/deployment_serializer.rb
+++ b/server/app/serializers/fusor/deployment_serializer.rb
@@ -38,7 +38,6 @@ module Fusor
                :openshift_number_master_nodes,
                :openshift_number_worker_nodes,
                :openshift_storage_type,
-               :openshift_storage_name,
                :openshift_storage_host,
                :openshift_export_path,
                :openshift_username,

--- a/server/db/migrate/20160609005838_remove_openshift_storage_name_from_deployments.rb
+++ b/server/db/migrate/20160609005838_remove_openshift_storage_name_from_deployments.rb
@@ -1,0 +1,9 @@
+class RemoveOpenshiftStorageNameFromDeployments < ActiveRecord::Migration
+  def up
+    remove_column :fusor_deployments, :openshift_storage_name
+  end
+
+  def down
+    add_column :fusor_deployments, :openshift_storage_name, :string
+  end
+end


### PR DESCRIPTION
Mostly removes unusable or unnecessary pieces of the as advised by UX.

* Removes "Do Not Use" option from storage configuration
* Removes openshift_storage_name, not in use
* Removes ip based node links from summary page as they're unreachable