### PR TITLE
Make the hypervisors discovered host tab link use the correct link to itself

### DIFF
--- a/fusor-ember-cli/app/templates/rhev.hbs
+++ b/fusor-ember-cli/app/templates/rhev.hbs
@@ -18,7 +18,7 @@
       {{/link-to}}
       {{/unless}}
 
-      {{#link-to 'hypervisor' tagName='li' disabled=disableTabRhevHypervisors}}
+      {{#link-to 'hypervisor.discovered-host' tagName='li' disabled=disableTabRhevHypervisors}}
         <a>
           <span class="hanging-indent">
             {{if isSelfHost '2B' '2C'}}. {{hypervisorTabName }}


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1298654