### PR TITLE
Fix invalid tabs on refresh doing OSE depl

### DIFF
--- a/fusor-ember-cli/app/controllers/deployment.js
+++ b/fusor-ember-cli/app/controllers/deployment.js
@@ -105,7 +105,7 @@ export default Ember.Controller.extend(DeploymentControllerMixin, DisableTabMixi
       const isConnectedSync = !this.get('isDisconnected');
       const subsNotReady =
        this.get('isDisabledSubscriptions') ||
-       !this.get("hasSubscriptionUUID") ||
+       !this.get('hasSubscriptionUUID') ||
        this.get('disableNextOnSelectSubscriptions');
 
       // Disable review if this is a connected sync and subs are not ready

--- a/fusor-ember-cli/app/controllers/openshift.js
+++ b/fusor-ember-cli/app/controllers/openshift.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import NeedsDeploymentMixin from "../mixins/needs-deployment-mixin";
 import OpenshiftMixin from "../mixins/openshift-mixin";
 
 import {
@@ -12,9 +11,8 @@ import {
   validateZipper
 } from '../utils/validators';
 
-export default Ember.Controller.extend(NeedsDeploymentMixin, OpenshiftMixin, {
-
-  stepNumberOpenShift: Ember.computed.alias("deploymentController.stepNumberOpenShift"),
+export default Ember.Controller.extend(OpenshiftMixin, {
+  stepNumberOpenShift: Ember.computed.alias('deploymentController.stepNumberOpenShift'),
 
   isVcpuOverCapacity: Ember.computed('vcpuNeeded', 'vcpuAvailable', function() {
     return (this.get('vcpuNeeded') > this.get('vcpuAvailable'));
@@ -112,16 +110,16 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, OpenshiftMixin, {
     'exportPathValidator',
     'usernameValidator',
     'subdomainValidator',
-    'model.openshift_storage_host',
-    'model.openshift_export_path',
-    'model.openshift_username',
-    'model.openshift_subdomain_name',
+    'deployment.openshift_storage_host',
+    'deployment.openshift_export_path',
+    'deployment.openshift_username',
+    'deployment.openshift_subdomain_name',
     function() {
       return validateZipper([
-        [this.get('storageHostValidator'), this.get('model.openshift_storage_host')],
-        [this.get('exportPathValidator'), this.get('model.openshift_export_path')],
-        [this.get('usernameValidator'), this.get('model.openshift_username')],
-        [this.get('subdomainValidator'), this.get('model.openshift_subdomain_name')]
+        [this.get('storageHostValidator'), this.get('deployment.openshift_storage_host')],
+        [this.get('exportPathValidator'), this.get('deployment.openshift_export_path')],
+        [this.get('usernameValidator'), this.get('deployment.openshift_username')],
+        [this.get('subdomainValidator'), this.get('deployment.openshift_subdomain_name')]
       ]);
     }
   ),

--- a/fusor-ember-cli/app/controllers/review/installation.js
+++ b/fusor-ember-cli/app/controllers/review/installation.js
@@ -46,11 +46,17 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, OpenshiftMixin, {
     'showErrorMessage',
     'showValidationErrors',
     function () {
-      return this.get('deploymentController.isDisabledReview') ||
-        this.get('isMissingSubscriptions') ||
-        (this.get('isDisconnected') && this.get('hasNoManifestFile')) ||
-        this.get('showErrorMessage') ||
-        this.get('showValidationErrors') > 0;
+      const isReviewTabDisabled = this.get('deploymentController.isDisabledReview');
+      const isMissingSubscriptions = this.get('isMissingSubscriptions');
+      const disconnectedWithoutManifest =
+        this.get('isDisconnected') && this.get('hasNoManifestFile');
+      const hasErrors =
+        this.get('showErrorMessage') || this.get('showValidationErrors') > 0;
+
+      return isReviewTabDisabled ||
+        isMissingSubscriptions ||
+        disconnectedWithoutManifest ||
+        hasErrors;
     }
   ),
 

--- a/fusor-ember-cli/app/mixins/openshift-mixin.js
+++ b/fusor-ember-cli/app/mixins/openshift-mixin.js
@@ -1,17 +1,19 @@
 import Ember from 'ember';
+import NeedsDeploymentMixin from "./needs-deployment-mixin";
 import {
   AllValidator,
   NumberValidator,
   IntegerValidator
 } from '../utils/validators';
 
-export default Ember.Mixin.create({
+export default Ember.Mixin.create(NeedsDeploymentMixin, {
 
-  openshiftInstallLoc: Ember.computed.alias("model.openshift_install_loc"),
-  cfmeInstallLoc: Ember.computed.alias("model.cfme_install_loc"),
-  isRhev: Ember.computed.alias("model.deploy_rhev"),
-  isOpenStack: Ember.computed.alias("model.deploy_openstack"),
-  isCloudForms: Ember.computed.alias("model.deploy_cfme"),
+  deployment: Ember.computed.alias('deploymentController.model'),
+  openshiftInstallLoc: Ember.computed.alias("deployment.openshift_install_loc"),
+  cfmeInstallLoc: Ember.computed.alias("deployment.cfme_install_loc"),
+  isRhev: Ember.computed.alias("deployment.deploy_rhev"),
+  isOpenStack: Ember.computed.alias("deployment.deploy_openstack"),
+  isCloudForms: Ember.computed.alias("deployment.deploy_cfme"),
 
   positiveIntegerValidator: AllValidator.create({
     validators: [
@@ -20,7 +22,7 @@ export default Ember.Mixin.create({
     ]
   }),
 
-  numNodes: Ember.computed.alias("model.numNodes"),
+  numNodes: Ember.computed.alias("deployment.numNodes"),
   numNodesDisplay: Ember.computed(
     'numNodes',
     'positiveIntegerValidator',
@@ -32,22 +34,22 @@ export default Ember.Mixin.create({
   ),
 
 
-  numMasterNodes: Ember.computed.alias("model.openshift_number_master_nodes"),
-  numWorkerNodes: Ember.computed.alias("model.openshift_number_worker_nodes"),
+  numMasterNodes: Ember.computed.alias("deployment.openshift_number_master_nodes"),
+  numWorkerNodes: Ember.computed.alias("deployment.openshift_number_worker_nodes"),
 
-  storageSize: Ember.computed.alias("model.openshift_storage_size"),
+  storageSize: Ember.computed.alias("deployment.openshift_storage_size"),
 
-  masterVcpu: Ember.computed.alias("model.openshift_master_vcpu"),
-  workerVcpu: Ember.computed.alias("model.openshift_node_vcpu"),
-  cfmeVcpu: Ember.computed.alias("model.cloudforms_vcpu"),
+  masterVcpu: Ember.computed.alias("deployment.openshift_master_vcpu"),
+  workerVcpu: Ember.computed.alias("deployment.openshift_node_vcpu"),
+  cfmeVcpu: Ember.computed.alias("deployment.cloudforms_vcpu"),
 
-  masterRam: Ember.computed.alias("model.openshift_master_ram"),
-  workerRam: Ember.computed.alias("model.openshift_node_ram"),
-  cfmeRam: Ember.computed.alias("model.cloudforms_ram"),
+  masterRam: Ember.computed.alias("deployment.openshift_master_ram"),
+  workerRam: Ember.computed.alias("deployment.openshift_node_ram"),
+  cfmeRam: Ember.computed.alias("deployment.cloudforms_ram"),
 
-  masterDisk: Ember.computed.alias("model.openshift_master_disk"),
-  workerDisk: Ember.computed.alias("model.openshift_node_disk"),
-  cfmeDisk: Ember.computed.alias("model.cfmeDisk"),
+  masterDisk: Ember.computed.alias("deployment.openshift_master_disk"),
+  workerDisk: Ember.computed.alias("deployment.openshift_node_disk"),
+  cfmeDisk: Ember.computed.alias("deployment.cfmeDisk"),
 
   ignoreCfme: Ember.computed(
     "isCloudForms",
@@ -66,52 +68,52 @@ export default Ember.Mixin.create({
   ),
   substractCfme: Ember.computed.not('ignoreCfme'),
 
-  diskAvailableMinusCfme: Ember.computed("model.openshift_available_disk", "cfmeDisk", function() {
-    return this.get("model.openshift_available_disk") - this.get("cfmeDisk");
+  diskAvailableMinusCfme: Ember.computed("deployment.openshift_available_disk", "cfmeDisk", function() {
+    return this.get("deployment.openshift_available_disk") - this.get("cfmeDisk");
   }),
 
   diskAvailable: Ember.computed(
-    "model.openshift_available_disk",
+    "deployment.openshift_available_disk",
     "ignoreCfme",
     "diskAvailableMinusCfme",
     function() {
       if (this.get('ignoreCfme')) {
-        return this.get('model.openshift_available_disk');
+        return this.get('deployment.openshift_available_disk');
       } else {
         return this.get('diskAvailableMinusCfme');
       }
     }
   ),
 
-  ramAvailableMinusCfme: Ember.computed("model.openshift_available_ram", "model.cloudforms_ram", function() {
-    const rawVal = this.get("model.openshift_available_ram") - this.get("model.cloudforms_ram");
+  ramAvailableMinusCfme: Ember.computed("deployment.openshift_available_ram", "deployment.cloudforms_ram", function() {
+    const rawVal = this.get("deployment.openshift_available_ram") - this.get("deployment.cloudforms_ram");
     return Math.round(rawVal * 100) / 100; // Make sure to truncate since we can get some weird fp nums
   }),
 
   ramAvailable: Ember.computed(
-    "model.openshift_available_ram",
+    "deployment.openshift_available_ram",
     "ignoreCfme",
     "ramAvailableMinusCfme",
     function() {
       if (this.get('ignoreCfme')) {
-        return this.get('model.openshift_available_ram');
+        return this.get('deployment.openshift_available_ram');
       } else {
         return this.get('ramAvailableMinusCfme');
       }
     }
   ),
 
-  vcpuAvailableMinusCfme: Ember.computed("model.openshift_available_vcpu", "model.cloudforms_vcpu", function() {
-    return this.get("model.openshift_available_vcpu") - this.get("model.cloudforms_vcpu");
+  vcpuAvailableMinusCfme: Ember.computed("deployment.openshift_available_vcpu", "deployment.cloudforms_vcpu", function() {
+    return this.get("deployment.openshift_available_vcpu") - this.get("deployment.cloudforms_vcpu");
   }),
 
   vcpuAvailable: Ember.computed(
-    "model.openshift_available_vcpu",
+    "deployment.openshift_available_vcpu",
     "ignoreCfme",
     "vcpuAvailableMinusCfme",
     function() {
       if (this.get('ignoreCfme')) {
-        return this.get('model.openshift_available_vcpu');
+        return this.get('deployment.openshift_available_vcpu');
       } else {
         return this.get('vcpuAvailableMinusCfme');
       }


### PR DESCRIPTION
Similar issue existed with RHEV & OSP, openshift data needs to be loaded
via the deploymentController in the event the openshift route has never
been run (ex: on a page reload at review).