### PR TITLE
[WIP - Still Testing]  Ability to silence requests paths defined in fusor.yaml

### DIFF
--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -378,3 +378,10 @@
           - :file: "/var/log/foreman-proxy/proxy.log"
           - :file: "/var/log/candlepin/candlepin.log"
           - :file: "/var/log/messages"
+    :silenced_logging:
+      :paths:
+        - "api/v21/foreman_tasks"
+        - "fusor/api/v21/unlogged"
+        - "katello/cp_proxy"
+        - "katello/cp_rest"
+        - "foreman-tasks/dynflow"

--- a/server/lib/fusor/middleware/silenced_logger.rb
+++ b/server/lib/fusor/middleware/silenced_logger.rb
@@ -1,0 +1,27 @@
+#
+# This file was originally included in Satellite 6.1 and was removed from Sat 6.2
+#   https://github.com/Katello/katello/blob/d24cc15da9a6943ea567363e296246e9f510864f/lib/katello/middleware/silenced_logger.rb
+#
+module Fusor
+  module Middleware
+    class SilencedLogger < Rails::Rack::Logger
+      def prefixes
+        SETTINGS[:fusor][:system][:silenced_logging][:paths]
+      end
+
+      def initialize(app, _options = {})
+        @app = app
+      end
+
+      def call(env)
+        old_level = Rails.logger.level
+        if prefixes.any? { |path|  env["PATH_INFO"].include?(path) }
+          Rails.logger.level = Logger::WARN
+        end
+        @app.call(env)
+      ensure
+        Rails.logger.level = old_level
+      end
+    end
+  end
+end


### PR DESCRIPTION
Reuses SilencedLogger implementation from Sat 6.1 with a tweak to reference our fusor.yaml for paths to silence.