### PR TITLE
1327243 - OSP Edit Deployment Role changes.

### DIFF
--- a/fusor-ember-cli/app/components/edit-deployment-role.js
+++ b/fusor-ember-cli/app/components/edit-deployment-role.js
@@ -6,6 +6,40 @@ export default Ember.Component.extend({
     return "Edit Deployment Role - " + this.get('editedRole.label');
   }),
 
+  profileOptions: Ember.computed('profiles.[]', function() {
+    let options = [Ember.Object.create({name: 'baremetal'})];
+    let profiles = this.get('profiles');
+    if (profiles) {
+      this.get('profiles').forEach(profile => options.pushObject(profile));
+    }
+    return options;
+  }),
+
+  matchingNodeCount: Ember.computed('editedRoleProfile', 'nodes.[]', 'profiles.[]', function () {
+    let profiles = this.get('profiles');
+    if (!profiles) {
+      return 0;
+    }
+
+    let profile = profiles.findBy('name', this.get('editedRoleProfile'));
+    if (!profile) {
+      return 0;
+    }
+
+    return profile.matchingNodeCount(this.get('nodes'));
+  }),
+
+  roleNodeCountOptions: Ember.computed('matchingNodeCount', function() {
+    let options = [];
+    let maxNodes = this.get('matchingNodeCount');
+
+    for (let i = 0; i <= maxNodes; i++) {
+      options.pushObject(i);
+    }
+
+    return options;
+  }),
+
   actions: {
     doShowSettings() {
       this.sendAction('doShowSettings');

--- a/fusor-ember-cli/app/components/node-profile.js
+++ b/fusor-ember-cli/app/components/node-profile.js
@@ -12,32 +12,8 @@ export default Ember.Component.extend({
     return this.get('roles').filter(role => !role.isAssigned());
   }),
 
-  nodeMatchesProfile(node, profile) {
-    let nodeMemory = node.get('properties.memory_mb');
-    let nodeCPUs = node.get('properties.cpus');
-    let workerDisk = node.get('properties.local_gb');
-    let nodeCPUArch = node.get('properties.cpu_arch');
-    let profileMemory = profile.get('ram');
-    let profileCPUs = profile.get('vcpus');
-    let profileDisk = profile.get('disk');
-    let profileCPUArch = profile.get('extra_specs.cpu_arch');
-
-    return nodeMemory == profileMemory &&
-      nodeCPUs == profileCPUs &&
-      workerDisk == profileDisk &&
-      nodeCPUArch == profileCPUArch;
-  },
-
   matchingNodeCount: Ember.computed('profile', 'nodes.[]', function () {
-    let nodeCount = 0;
-    let profile = this.get('profile');
-    let self = this;
-    this.get('nodes').forEach(function (node) {
-      if (self.nodeMatchesProfile(node, profile)) {
-        nodeCount++;
-      }
-    });
-    return nodeCount;
+    return this.get('profile').matchingNodeCount(this.get('nodes'));
   }),
 
   hideAssignMenu() {

--- a/fusor-ember-cli/app/models/flavor.js
+++ b/fusor-ember-cli/app/models/flavor.js
@@ -5,7 +5,11 @@ export default DS.Model.extend({
   ram: DS.attr('number'),
   vcpus: DS.attr('number'),
   disk: DS.attr('number'),
-  extra_specs: DS.attr()
+  extra_specs: DS.attr(),
+
+  matchingNodeCount(nodes) {
+    return nodes.reduce((nodeCount, node) => nodeCount + (node.matchesProfile(this) ? 1 : 0), 0);
+  }
 });
 
 

--- a/fusor-ember-cli/app/models/node.js
+++ b/fusor-ember-cli/app/models/node.js
@@ -33,6 +33,22 @@ export default DS.Model.extend({
 
     let introspectionTask = this.getIntrospectionTask(introspectionTasks);
     return introspectionTask ? foremanTasks.findBy('id', introspectionTask.get('task_id')) : null;
+  },
+
+  matchesProfile(profile) {
+    let nodeMemory = this.get('properties.memory_mb');
+    let nodeCPUs = this.get('properties.cpus');
+    let workerDisk = this.get('properties.local_gb');
+    let nodeCPUArch = this.get('properties.cpu_arch');
+    let profileMemory = profile.get('ram');
+    let profileCPUs = profile.get('vcpus');
+    let profileDisk = profile.get('disk');
+    let profileCPUArch = profile.get('extra_specs.cpu_arch');
+
+    return nodeMemory == profileMemory &&
+      nodeCPUs == profileCPUs &&
+      workerDisk == profileDisk &&
+      nodeCPUArch == profileCPUArch;
   }
 });
 

--- a/fusor-ember-cli/app/templates/components/edit-deployment-role.hbs
+++ b/fusor-ember-cli/app/templates/components/edit-deployment-role.hbs
@@ -28,8 +28,17 @@
               </div>
             </div>
             {{select-f label="Provisioning Image" labelSize='col-sm-4' inputSize='col-sm-8' content=images value=editedRoleImage isRequired=false optionLabelPath="content.name" optionValuePath="content.name"}}
-            {{select-f label="Flavor" labelSize='col-sm-4' inputSize='col-sm-8' content=profiles value=editedRoleProfile  isRequired=false optionLabelPath="content.name" optionValuePath="content.name"}}
-            {{text-f label="Number of Nodes" type='number' labelSize='col-sm-4' inputSize='col-sm-8' value=editedRoleNodeCount isRequired=false}}
+            {{select-f label="Flavor" labelSize='col-sm-4' inputSize='col-sm-8' content=profileOptions value=editedRoleProfile  isRequired=false optionLabelPath="content.name" optionValuePath="content.name"}}
+            <div class="form-group">
+              <label class="control-label col-sm-4 ">Number of Nodes</label>
+              <div class="col-sm-8">
+                {{#x-select value=editedRoleNodeCount disabled=disabled}}
+                  {{#each roleNodeCountOptions as |opt| }}
+                    {{#x-option value=opt}}{{opt}}{{/x-option}}
+                  {{/each}}
+                {{/x-select}}
+              </div>
+            </div>
           </fieldset>
         </div>
       </div>

--- a/fusor-ember-cli/app/templates/openstack/assign-nodes.hbs
+++ b/fusor-ember-cli/app/templates/openstack/assign-nodes.hbs
@@ -85,10 +85,12 @@
                          configActiveClass=configActiveClass
                          doShowSettings='doShowSettings'
                          doShowConfig='doShowConfig'
-                         editedRole=editedRole
-                         editedRoleImage=editedRoleImage
                          images=images
                          profiles=profiles
+                         nodes=nodes
+                         editedRole=editedRole
+                         editedRoleImage=editedRoleImage
+                         editedRoleProfile=editedRoleProfile
                          editedRoleNodeCount=editedRoleNodeCount
                          editedRoleParameters=editedRoleParameters
                          saveRole='saveRole'}}


### PR DESCRIPTION
OSP Edit Deployment Role changes:
- Allows profile to be set to baremetal.
- Change number of nodes input to a dropdown that changes options based on profile selection.