### PR TITLE
1322506 - Add user feedback when deleting OSP nodes.

### DIFF
--- a/fusor-ember-cli/app/controllers/openstack/register-nodes.js
+++ b/fusor-ember-cli/app/controllers/openstack/register-nodes.js
@@ -84,9 +84,12 @@ const RegisterNodesController = Ember.Controller.extend(NeedsDeploymentMixin, {
   },
 
   deleteNodeRequest() {
-    let url = `/fusor/api/openstack/deployments/${this.get('deployment.id')}/nodes/${this.get('nodeToDelete.id')}`;
+    let nodeToDelete = this.get('nodeToDelete');
+    let url = `/fusor/api/openstack/deployments/${this.get('deployment.id')}/nodes/${nodeToDelete.get('id')}`;
 
     this.send('resetError');
+    nodeToDelete.set('deleteInProgress', true);
+
     return request({
       url: url,
       type: 'DELETE',
@@ -98,6 +101,7 @@ const RegisterNodesController = Ember.Controller.extend(NeedsDeploymentMixin, {
     }).then(result => {
       this.removeNode(this.get('nodeToDelete'));
     }).catch(error => {
+      nodeToDelete.set('deleteInProgress', false);
       this.send('error', error, `Unable to delete node. DELETE ${url}.`);
     });
   },

--- a/fusor-ember-cli/app/styles/openstack.scss
+++ b/fusor-ember-cli/app/styles/openstack.scss
@@ -780,6 +780,19 @@ span.registered-node-count {
   margin-left: 2px;
 }
 
+.osp-node-progress-bar-deleting {
+  background-color: transparent;
+
+  .osp-node-progress-bar-label {
+    text-decoration: line-through;
+  }
+
+  .osp-node-progress-bar-extra {
+    font-style: italic;
+    font-weight: lighter;
+  }
+}
+
 .osp-node-progress-bar.progress-bar-danger {
   background-color: $error-color;
   color: white;

--- a/fusor-ember-cli/app/templates/components/osp-node.hbs
+++ b/fusor-ember-cli/app/templates/components/osp-node.hbs
@@ -1,6 +1,8 @@
 
 <div class="col-xs-1 osp-node-status-column">
-  {{#if isNodeReady}}
+  {{#if isNodeDeleting}}
+    <span class="spinner spinner-xs spinner-inline"></span>
+  {{else if isNodeReady}}
     <span class="pficon pficon-ok"></span>
   {{else if isNodeInspecting}}
     <span class="spinner spinner-xs spinner-inline"></span>
@@ -13,11 +15,11 @@
 <div class="col-xs-9 osp-node-progress-column">
   <div class="progress osp-node-progress">
     <div class="{{progressBarClass}}" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style={{progressWidth}}>
-      <span class="osp-node-progress-bar-label">{{label}}</span>
+      <span class="osp-node-progress-bar-label">{{label}}</span> <span class="osp-node-progress-bar-extra">{{extraInfo}}</span>
     </div>
   </div>
 </div>
 <div class="col-xs-2 osp-node-action-column ">
     <button type="button" id="deleteNodeButton{{safeLabel}}" class="btn btn-icon btn-delete-node"
-      {{action "onDeleteClicked"}} disabled={{disabled}}><i class="pficon pficon-delete"></i></button>
+      {{action "onDeleteClicked"}} disabled={{isDeleteDisabled}}><i class="pficon pficon-delete"></i></button>
 </div>


### PR DESCRIPTION
When deleting a node (which is a background process) let the user know it is being deleted:
- displayed spinner
- line-through of node label
- disabled delete button.

![screenshot from 2016-06-27 11-26-46](https://cloud.githubusercontent.com/assets/1448375/16385917/bd99361a-3c5c-11e6-8ab1-7cba7b7ea425.png)
