### PR TITLE
add pagination/search/sort to list of deployments + client-side sort/filter to rhev discovered hosts

### DIFF
--- a/fusor-ember-cli/app/components/column-name.js
+++ b/fusor-ember-cli/app/components/column-name.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  arrowIcon: Ember.computed('col_name', 'sort_by', 'dir', function () {
+    let col_name = this.get('col_name');
+    let sort_by = this.get('sort_by');
+    let dir = this.get('dir') ? this.get('dir').toUpperCase() : '';
+    if (col_name === sort_by) {
+      if (dir === 'DESC') {
+        return '▼';
+      } else if (dir === 'ASC') {
+        return '▲';
+      }
+    }
+  })
+});

--- a/fusor-ember-cli/app/components/pagination-footer.js
+++ b/fusor-ember-cli/app/components/pagination-footer.js
@@ -1,0 +1,47 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+
+  prevPage: Ember.computed('pageNumber', function() {
+    return parseInt(this.get('pageNumber')) - 1;
+  }),
+
+  nextPage: Ember.computed('nextPage', function() {
+    return parseInt(this.get('pageNumber')) + 1;
+  }),
+
+  disablePrevPage: Ember.computed('pageNumber', function() {
+    return parseInt(this.get('pageNumber')) === 1 || Ember.isBlank(this.get('pageNumber'));
+  }),
+
+  disableNextPage: Ember.computed('pageNumber', 'totalPages', function() {
+    return parseInt(this.get('pageNumber')) === parseInt(this.get('totalPages'));
+  }),
+
+  entriesFrom: Ember.computed('pageNumber', 'totalPages', 'totalCnt', function() {
+    return ((parseInt(this.get('pageNumber')) * 20) - 19);
+  }),
+
+  entriesTo: Ember.computed('pageNumber', 'totalPages', 'totalCnt', function() {
+    if (parseInt(this.get('pageNumber')) === parseInt(this.get('totalPages'))) {
+      return this.get('totalCnt');
+    } else {
+      return (parseInt(this.get('pageNumber')) * 20);
+    }
+  }),
+
+  showPagination: Ember.computed('totalPages', function() {
+    return (parseInt(this.get('totalPages')) > 1);
+  }),
+
+  displayingEntries: Ember.computed('totalCnt', 'totalPages', 'entriesFrom', 'entriesTo', function() {
+    if (parseInt(this.get('totalCnt') === 0)) {
+      return 'No entries found';
+    } else if (parseInt(this.get('totalPages')) < 2) {
+      return `Displaying <strong>all ${this.get('totalCnt')}</strong> entries`.htmlSafe();
+    } else {
+      return `Displaying entries <strong>${this.get('entriesFrom')} - ${this.get('entriesTo')}</strong> of <strong>${this.get('totalCnt')}</strong> in total`.htmlSafe();
+    }
+  })
+
+});

--- a/fusor-ember-cli/app/controllers/deployments.js
+++ b/fusor-ember-cli/app/controllers/deployments.js
@@ -1,26 +1,21 @@
 import Ember from 'ember';
+import PaginationControllerMixin from "../mixins/pagination-controller-mixin";
 
-export default Ember.Controller.extend({
+export default Ember.Controller.extend(PaginationControllerMixin, {
 
-  sortedDeployments: Ember.computed('model.[]', 'model.@each.name', function() {
-    return this.get('model').sortBy('name');
-  }),
+  filteredDeployments: Ember.computed('model', 'search', 'model.[]', function(){
+    var search = this.get('search');
+    var rx = new RegExp(search, 'gi');
+    var model = this.get('model');
 
-  searchDeploymentString: '',
-
-  filteredDeployments: Ember.computed('sortedDeployments', 'searchDeploymentString', 'model.[]', function(){
-    var searchDeploymentString = this.get('searchDeploymentString');
-    var rx = new RegExp(searchDeploymentString, 'gi');
-    var sortedDeployments = this.get('sortedDeployments');
-
-    if (sortedDeployments.get('length') > 1) {
-      return sortedDeployments.filter(function(record) {
+    if (model.get('length') > 1) {
+      return model.filter(function(record) {
         if (Ember.isPresent(record.get('name'))) {
           return record.get('name').match(rx);
         }
       });
     } else {
-      return sortedDeployments;
+      return model;
     }
   })
 

--- a/fusor-ember-cli/app/controllers/engine/discovered-host.js
+++ b/fusor-ember-cli/app/controllers/engine/discovered-host.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
 import NeedsDeploymentMixin from "../../mixins/needs-deployment-mixin";
+import PaginationControllerMixin from "../../mixins/pagination-controller-mixin";
 
-export default Ember.Controller.extend(NeedsDeploymentMixin, {
+export default Ember.Controller.extend(NeedsDeploymentMixin, PaginationControllerMixin, {
 
   rhevController: Ember.inject.controller('rhev'),
 
@@ -52,6 +53,13 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
       return availableHosts;
     }
   }),
+
+  sortCriteria: Ember.computed('sort_by', 'dir', function () {
+    let sort_by = this.get('sort_by') || 'name';
+    let dir = this.get('dir') || 'asc';
+    return [sort_by+':'+dir];
+  }),
+  sortedHosts: Ember.computed.sort('filteredHosts', 'sortCriteria'),
 
   numSelected: Ember.computed('model.id', function() {
     return (this.get('model.id')) ? 1 : 0;

--- a/fusor-ember-cli/app/mirage/config.js
+++ b/fusor-ember-cli/app/mirage/config.js
@@ -7,7 +7,16 @@ export default function() {
     return {};
   });
 
-  this.get('/fusor/api/v21/deployments');
+  this.get('/fusor/api/v21/deployments', function(db, request) {
+    return {deployments: db.deployments,
+            meta: {
+              total: 107,
+              total_pages: 5,
+              page: 1
+            }
+           };
+  });
+
   this.post('/fusor/api/v21/deployments');
   this.get('/fusor/api/v21/deployments/:id');
   this.put('/fusor/api/v21/deployments/:id');

--- a/fusor-ember-cli/app/mirage/scenarios/default.js
+++ b/fusor-ember-cli/app/mirage/scenarios/default.js
@@ -89,4 +89,6 @@ export default function(server) {
                                       discovered_host_ids: [hypervisor1.id, hypervisor2.id]
                                      });
 
+  server.createList('deployment', 100);
+
 }

--- a/fusor-ember-cli/app/mixins/discovered-host-route-mixin.js
+++ b/fusor-ember-cli/app/mixins/discovered-host-route-mixin.js
@@ -6,7 +6,7 @@ export default Ember.Mixin.create({
     controller.set('model', model);
     if (this.modelFor('deployment').get('isNotStarted')) {
       controller.set('isLoadingHosts', true);
-      this.store.findAll('discovered-host').then(function(results) {
+      this.store.query('discovered-host', {per_page: 1000}).then(function(results) {
         controller.set('allDiscoveredHosts', results.filterBy('is_discovered', true));
         controller.set('isLoadingHosts', false);
       });
@@ -18,7 +18,7 @@ export default Ember.Mixin.create({
       console.log('refresh allDiscoveredHosts');
       var controller = this.get('controller');
       controller.set('isLoadingHosts', true);
-      this.store.findAll('discovered-host').then(function(results) {
+      this.store.query('discovered-host', {per_page: 1000}).then(function(results) {
         controller.set('allDiscoveredHosts', results.filterBy('is_discovered', true));
         controller.set('isLoadingHosts', false);
       });

--- a/fusor-ember-cli/app/mixins/pagination-controller-mixin.js
+++ b/fusor-ember-cli/app/mixins/pagination-controller-mixin.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+
+  queryParams: ['search', 'page', 'sort_by', 'dir'],
+
+  sortByDirection: Ember.computed('dir', function() {
+    if (this.get('dir') === 'DESC') {
+      return 'ASC';
+    } else {
+      return 'DESC';
+    }
+  })
+
+});

--- a/fusor-ember-cli/app/mixins/pagination-route-mixin.js
+++ b/fusor-ember-cli/app/mixins/pagination-route-mixin.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+import _ from 'lodash/lodash';
+
+export default Ember.Mixin.create({
+
+  queryParams: {
+    search: {
+      refreshModel: true
+    },
+    page: {
+      refreshModel: true
+    },
+    sort_by: {
+      refreshModel: true
+    },
+    dir: {
+      refreshModel: true
+    }
+  }
+
+});

--- a/fusor-ember-cli/app/routes/application.js
+++ b/fusor-ember-cli/app/routes/application.js
@@ -9,6 +9,9 @@ export default Ember.Route.extend({
   actions: {
     invalidateSession() {
       return this.transitionTo('login');
+    },
+    loading() {
+      this.controllerFor('deployments').set('isLoading', true);
     }
   }
 });

--- a/fusor-ember-cli/app/routes/deployments.js
+++ b/fusor-ember-cli/app/routes/deployments.js
@@ -1,8 +1,26 @@
 import Ember from 'ember';
+import PaginationRouteMixin from "../mixins/pagination-route-mixin";
+import _ from 'lodash/lodash';
 
-export default Ember.Route.extend({
-  model() {
-    return this.store.findAll('deployment');
+export default Ember.Route.extend(PaginationRouteMixin, {
+
+  model(params) {
+    // server-side deployments controller uses scoped search params[:order] for sorting
+    let sort_by = params['sort_by'] || 'updated_at';
+    let dir = params['dir'] || 'DESC';
+    let page = params['page'] || 1;
+    params['order'] = sort_by + ' ' + dir;
+    let controller = this.controllerFor('deployments');
+    return this.store.query('deployment', params);
+  },
+
+  setupController(controller, model) {
+    controller.set('model', model);
+    controller.set('totalCnt', model.get('meta.total'));
+    controller.set('pageNumber', model.get('meta.page'));
+    controller.set('totalPages', model.get('meta.total_pages'));
+    controller.set('pageRange', _.range(1, model.get('meta.total_pages') + 1));
+    controller.set('isLoading', false);
   },
 
   actions: {

--- a/fusor-ember-cli/app/styles/custom.scss
+++ b/fusor-ember-cli/app/styles/custom.scss
@@ -940,3 +940,29 @@ span.hanging-indent{
   vertical-align: top;
   margin-bottom: 0px !important; /* overides form-group default */
 }
+
+.deployments-table {
+  table-layout:fixed;
+  width: 100%;
+}
+.deployments-table>thead:first-child>tr:first-child>th:first-child
+{
+    width: 40%;
+}
+.deployments-table> tbody > tr > td:first-child {
+    width: 40%;
+}
+
+.pagination {
+  display: table-cell;
+  vertical-align: bottom;
+  float: none;
+}
+
+.darkgrey, .darkgray {
+  color: #606060 !important;
+}
+
+.displaying-entries {
+  margin-left: -20px;
+}

--- a/fusor-ember-cli/app/styles/custom.scss
+++ b/fusor-ember-cli/app/styles/custom.scss
@@ -594,7 +594,7 @@ table.fusor-table {
 
 .new-deployment-button {
   float: right;
-  margin-top: -33px;
+  margin-top: 24px;
 }
 
 .filter-deployments {
@@ -965,4 +965,9 @@ span.hanging-indent{
 
 .displaying-entries {
   margin-left: -20px;
+}
+
+.rhci-title {
+  display: inline-block;
+  padding: 0px 8px 8px 0px;
 }

--- a/fusor-ember-cli/app/templates/components/column-name.hbs
+++ b/fusor-ember-cli/app/templates/components/column-name.hbs
@@ -1,0 +1,1 @@
+{{arrowIcon}} {{name}}

--- a/fusor-ember-cli/app/templates/components/pagination-footer.hbs
+++ b/fusor-ember-cli/app/templates/components/pagination-footer.hbs
@@ -1,0 +1,23 @@
+<div class='displaying-entries col-md-5'>
+  <div class="pull-left pull-bottom darkgray pagination">
+    {{displayingEntries}}
+  </div>
+</div>
+
+{{#if showPagination}}
+  <div class="col-md-7">
+    <ul class="pagination pull-right">
+      <li class="prev previous_page {{if disablePrevPage 'disabled'}}">
+        {{#link-to routeName (query-params page=prevPage) disabled=disablePrevPage}}«{{/link-to}}
+      </li>
+      {{#each pageRange as |num|}}
+        <li>
+          {{#link-to routeName (query-params page=num)}}{{num}}{{/link-to}}
+        </li>
+      {{/each}}
+      <li class="next next_page {{if disableNextPage 'disabled'}}">
+        {{#link-to routeName (query-params page=nextPage) disabled=disableNextPage}}»{{/link-to}}
+      </li>
+    </ul>
+  </div>
+{{/if}}

--- a/fusor-ember-cli/app/templates/components/tr-deployment.hbs
+++ b/fusor-ember-cli/app/templates/components/tr-deployment.hbs
@@ -2,6 +2,7 @@
 <td> {{deployment.lifecycle_environment.name}} </td>
 <td> {{deployment.organization.name}} </td>
 <td> {{foremanTask.state}} {{!deployment.progressPercent}}  </td>
+<td> {{moment deployment.created_at 'lll'}} </td>
 <td>
     {{#link-to 'deployment' deployment class='btn btn-sm btn-default'}} Edit {{/link-to}}
     {{#if canDelete}}

--- a/fusor-ember-cli/app/templates/deployments.hbs
+++ b/fusor-ember-cli/app/templates/deployments.hbs
@@ -1,4 +1,11 @@
-<h1>Deployments</h1>
+<h1 class='rhci-title'>Deployments</h1>
+
+{{#if isLoading}}
+  <div class="spinner spinner-md spinner-inline"></div>
+  <span class='spinner-text'>
+    Loading ....
+  </span>
+{{/if}}
 
 <div class='new-deployment-button'>
   {{#link-to 'deployment-new.start' class='btn btn-success'}}
@@ -13,21 +20,43 @@
      <div class='col-md-5'>
        {{input type='text' class='form-control filter-input'
                            placeholder='Filter ...'
-                           value=searchDeploymentString}}
+                           value=search}}
      </div>
      <button class='btn btn-default' style='margin-left:-20px'><i class="fa fa-search"></i> Search</button>
    </div>
 </div>
 </form>
-<br />
+
+<div class='table-responsive'>
 <table class="table table-bordered table-striped small deployments-table">
   <thead>
     <tr>
-      <th> Name </th>
-      <th> Environment </th>
-      <th> Organization </th>
-      <th> Status </th>
-      <th> </th>
+      <th>
+        {{#link-to 'deployments' (query-params sort_by="name" dir=sortByDirection)}}
+          {{column-name name='Name' col_name="name" sort_by=sort_by dir=dir}}
+        {{/link-to}}
+      </th>
+      <th>
+        {{#link-to 'deployments' (query-params sort_by="lifecycle_environment" dir=sortByDirection)}}
+          {{column-name name='Environment' col_name="lifecycle_environment" sort_by=sort_by dir=dir}}
+        {{/link-to}}
+      </th>
+      <th>
+        {{#link-to 'deployments' (query-params sort_by="organization" dir=sortByDirection)}}
+          {{column-name name='Organization' col_name="organization" sort_by=sort_by dir=dir}}
+        {{/link-to}}
+      </th>
+      <th>
+        {{#link-to 'deployments' (query-params sort_by="status" dir=sortByDirection)}}
+          {{column-name name='Status' col_name="status" sort_by=sort_by dir=dir}}
+        {{/link-to}}
+      </th>
+      <th>
+        {{#link-to 'deployments' (query-params sort_by="updated_at" dir=sortByDirection)}}
+          {{column-name name='Last Updated' col_name="updated_at" sort_by=sort_by dir=dir}}
+        {{/link-to}}
+      </th>
+      <th></th>
     </tr>
   </thead>
 
@@ -37,12 +66,13 @@
   {{/each}}
   </tbody>
 </table>
+</div>
 
-<p class='displaying-entries'>
-  Displaying <strong>{{filteredDeployments.length}} of {{model.length}}</strong> entries
-</p>
-
-{{outlet}}
+{{pagination-footer routeName='deployments'
+                    totalCnt=totalCnt
+                    pageNumber=pageNumber
+                    totalPages=totalPages
+                    pageRange=pageRange}}
 
 {{delete-deployment-modal openModal=openModal
                           deployment=deploymentInModal

--- a/fusor-ember-cli/app/templates/engine/discovered-host.hbs
+++ b/fusor-ember-cli/app/templates/engine/discovered-host.hbs
@@ -35,21 +35,9 @@
       </div>
 
       <table class="table table-bordered small fusor-table">
-        <thead>
-          <tr>
-            <th class='rhev-checkbox'> {{!input type="checkbox" checked=allChecked}}</th>
-            <th class='rhev-hostname'> Host Name </th>
-            <th class='rhev-mac-address'> MAC Address </th>
-            <th class='rhev-host-type text-center'> Host Type </th>
-            <th class='rhev-cpu text-center'> CPU </th>
-            <th class='rhev-memory text-center'> Memory </th>
-            <th class='rhev-disks text-center'> # Disks </th>
-            <th class='rhev-diskspace text-center'> Disk Space </th>
-            <th class='rhev-network'> Network </th>
-          </tr>
-        </thead>
+        {{partial 'thead-discovered-hosts'}}
         <tbody>
-          {{#each filteredHosts as |host|}}
+          {{#each sortedHosts as |host|}}
              {{tr-engine host=host
                          selectedRhevEngineHost=selectedRhevEngineHost
                          disabled=isStarted

--- a/fusor-ember-cli/app/templates/hypervisor/discovered-host.hbs
+++ b/fusor-ember-cli/app/templates/hypervisor/discovered-host.hbs
@@ -51,20 +51,7 @@
       </div>
 
       <table class="table table-bordered small fusor-table">
-        <thead>
-          <tr>
-            <th class='rhev-checkbox'> {{!input type="checkbox" checked=allChecked}}</th>
-            <th class='rhev-hostname'> Host Name </th>
-            <th class='rhev-mac-address'> MAC Address </th>
-            <th class='rhev-host-type text-center'> Host Type </th>
-            <th class='rhev-cpu text-center'> CPU </th>
-            <th class='rhev-memory text-center'> Memory </th>
-            <th class='rhev-disks text-center'> # Disks </th>
-            <th class='rhev-diskspace text-center'> Disk Space </th>
-            <th class='rhev-network'> Network </th>
-          </tr>
-        </thead>
-
+        {{partial 'thead-discovered-hosts'}}
         <tbody>
         {{#each filteredHosts as |host|}}
            {{tr-hypervisor host=host

--- a/fusor-ember-cli/app/templates/thead-discovered-hosts.hbs
+++ b/fusor-ember-cli/app/templates/thead-discovered-hosts.hbs
@@ -1,0 +1,45 @@
+<thead>
+  <tr>
+    <th class='rhev-checkbox'></th>
+    <th class='rhev-hostname'>
+      {{#link-to 'engine.discovered-host' (query-params sort_by="name" dir=sortByDirection)}}
+        {{column-name name='Host Name' col_name="name" sort_by=sort_by dir=dir}}
+      {{/link-to}}
+    </th>
+    <th class='rhev-mac-address'>
+      {{#link-to 'engine.discovered-host' (query-params sort_by="mac" dir=sortByDirection)}}
+        {{column-name name='MAC Address' col_name="mac" sort_by=sort_by dir=dir}}
+      {{/link-to}}
+    </th>
+    <th class='rhev-host-type text-center'>
+      {{#link-to 'engine.discovered-host' (query-params sort_by="is_virtual" dir=sortByDirection)}}
+        {{column-name name='Host Type' col_name="is_virtual" sort_by=sort_by dir=dir}}
+      {{/link-to}}
+    </th>
+    <th class='rhev-cpu text-center'>
+      {{#link-to 'engine.discovered-host' (query-params sort_by="cpus" dir=sortByDirection)}}
+        {{column-name name='CPU' col_name="cpus" sort_by=sort_by dir=dir}}
+      {{/link-to}}
+    </th>
+    <th class='rhev-memory text-center'>
+      {{#link-to 'engine.discovered-host' (query-params sort_by="memory_human_size" dir=sortByDirection)}}
+        {{column-name name='Memory' col_name="memory_human_size" sort_by=sort_by dir=dir}}
+      {{/link-to}}
+    </th>
+    <th class='rhev-disks text-center'>
+      {{#link-to 'engine.discovered-host' (query-params sort_by="disk_count" dir=sortByDirection)}}
+        {{column-name name='# Disks' col_name="disk_count" sort_by=sort_by dir=dir}}
+      {{/link-to}}
+    </th>
+    <th class='rhev-diskspace text-center'>
+      {{#link-to 'engine.discovered-host' (query-params sort_by="disks_human_size" dir=sortByDirection)}}
+        {{column-name name='Disk Space' col_name="disks_human_size" sort_by=sort_by dir=dir}}
+      {{/link-to}}
+    </th>
+    <th class='rhev-network'>
+      {{#link-to 'engine.discovered-host' (query-params sort_by="subnet_to_s" dir=sortByDirection)}}
+        {{column-name name='Network' col_name="subnet_to_s" sort_by=sort_by dir=dir}}
+      {{/link-to}}
+    </th>
+  </tr>
+</thead>

--- a/fusor-ember-cli/package.json
+++ b/fusor-ember-cli/package.json
@@ -48,6 +48,7 @@
     "ember-drag-drop": "0.3.1",
     "ember-export-application-global": "^1.0.3",
     "ember-localstorage-adapter": "1.0.0-rc.1",
+    "ember-lodash": "0.0.9",
     "ember-moment": "1.1.1",
     "ember-power-select": "0.10.3",
     "ember-radio-button": "~1.0.1",

--- a/fusor-ember-cli/tests/acceptance/deployments-test.js
+++ b/fusor-ember-cli/tests/acceptance/deployments-test.js
@@ -47,7 +47,7 @@ test('user should see all elements on deployments page', function(assert) {
         assert.equal($.trim(find('table.deployments-table > thead > tr > th:nth-child(4)').text()),
                      'Status');
         assert.equal(find('tr.deployment-row').length, 10);
-        assert.equal($.trim(find('.displaying-entries').text()), 'Displaying 10 of 10 entries');
+        assert.equal($.trim(find('.displaying-entries').text()), 'Displaying entries 1 - 20 of 107 in total');
     });
 });
 

--- a/fusor-ember-cli/tests/integration/components/column-name-test.js
+++ b/fusor-ember-cli/tests/integration/components/column-name-test.js
@@ -1,0 +1,20 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('column-name', 'Integration | Component | column name', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });" + EOL + EOL +
+
+  this.render(hbs`{{column-name name='Environment'
+                                col_name="lifecycle_environment"
+                                sort_by="lifecycle_environment"
+                                dir="DESC"}}`);
+
+  assert.equal(this.$().text().trim(), '▼ Environment');
+
+});

--- a/fusor-ember-cli/tests/integration/components/pagination-footer-test.js
+++ b/fusor-ember-cli/tests/integration/components/pagination-footer-test.js
@@ -1,0 +1,21 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('pagination-footer', 'Integration | Component | pagination footer', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });" + EOL + EOL +
+
+  this.render(hbs`{{pagination-footer routeName='deployments'
+                                      totalCnt=25
+                                      pageNumber=1
+                                      totalPages=2
+                                      pageRange=[1,2]}}`);
+
+  assert.equal(this.$('.displaying-entries').text().trim(), 'Displaying entries 1 - 20 of 25 in total');
+
+});

--- a/fusor-ember-cli/tests/unit/mixins/pagination-controller-mixin-test.js
+++ b/fusor-ember-cli/tests/unit/mixins/pagination-controller-mixin-test.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import PaginationControllerMixinMixin from '../../../mixins/pagination-controller-mixin';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | pagination controller mixin');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let PaginationControllerMixinObject = Ember.Object.extend(PaginationControllerMixinMixin);
+  let subject = PaginationControllerMixinObject.create();
+  assert.ok(subject);
+});

--- a/fusor-ember-cli/tests/unit/mixins/pagination-route-mixin-test.js
+++ b/fusor-ember-cli/tests/unit/mixins/pagination-route-mixin-test.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import PaginationRouteMixinMixin from '../../../mixins/pagination-route-mixin';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | pagination route mixin');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let PaginationRouteMixinObject = Ember.Object.extend(PaginationRouteMixinMixin);
+  let subject = PaginationRouteMixinObject.create();
+  assert.ok(subject);
+});

--- a/server/app/controllers/fusor/api/v21/deployments_controller.rb
+++ b/server/app/controllers/fusor/api/v21/deployments_controller.rb
@@ -27,7 +27,15 @@ module Fusor
                                          :discovered_hosts, :ose_master_hosts, :ose_worker_hosts, :subscriptions,
                                          :introspection_tasks, :foreman_task, :openstack_deployment)
                                 .search_for(params[:search], :order => params[:order]).by_id(params[:id])
-      render :json => @deployments, :each_serializer => Fusor::DeploymentSerializer, :serializer => RootArraySerializer
+                                .paginate(:page => params[:page])
+      cnt_search = Deployment.search_for(params[:search], :order => params[:order]).count
+      render :json => @deployments,
+             :each_serializer => Fusor::DeploymentSerializer,
+             :serializer => RootArraySerializer,
+             :meta => {:total => cnt_search,
+                       :page => params[:page].present? ? params[:page].to_i : 1,
+                       :total_pages => (cnt_search / 20.0).ceil
+                      }
     end
 
     def show

--- a/server/app/models/fusor/deployment.rb
+++ b/server/app/models/fusor/deployment.rb
@@ -57,7 +57,10 @@ module Fusor
     before_validation :update_label, :ensure_openstack_deployment, on: :create  # we validate on create, so we need to do it before those validations
     before_save :update_label, :ensure_openstack_deployment, on: :update        # but we don't validate on update, so we need to call before_save
 
-    scoped_search :on => [:id, :name], :complete_value => true
+    scoped_search :on => [:id, :name, :updated_at], :complete_value => true
+    scoped_search :in => :organization, :on => :name, :rename => :organization
+    scoped_search :in => :lifecycle_environment, :on => :name, :rename => :lifecycle_environment
+    scoped_search :in => :foreman_task, :on => :state, :rename => :status
 
     # used by ember-data for .find('model', {id: [1,2,3]})
     scope :by_id, proc { |n| where(:id => n) if n.present? }


### PR DESCRIPTION
This uses server-side sort, search, and pagination for deployments and 
client-side sort and filter/search (no pagination) for discovered hosts. 