### PR TITLE
Add C&U credentials to CFME 

### DIFF
--- a/server/app/lib/actions/fusor/configure_host_groups.rb
+++ b/server/app/lib/actions/fusor/configure_host_groups.rb
@@ -254,7 +254,8 @@ module Actions
               :parameters =>
               [
                 { :name => "storage_type", :value => deployment.rhev_storage_type },
-                { :name => "admin_password", :value => deployment.rhev_engine_admin_password }
+                { :name => "admin_password", :value => deployment.rhev_engine_admin_password },
+                { :name => "db_password", :value => deployment.rhev_engine_admin_password }
               ]
             }
           ]
@@ -302,6 +303,7 @@ module Actions
                 { :name => "engine_mac_address", :value => Utils::Fusor::MacAddresses.generate_mac_address },
                 { :name => "engine_fqdn", :value => "#{deployment.label.tr('_', '-')}-rhev-engine.#{hostgroup.domain.name}" },
                 { :name => "engine_admin_password", :value => deployment.rhev_engine_admin_password },
+                { :name => "engine_db_password", :value => deployment.rhev_engine_admin_password },
                 { :name => "engine_activation_key", :value => hostgroup.group_parameters.where(:name => 'kt_activation_keys').try(:first).try(:value) },
                 { :name => "export_name", :value => deployment.rhev_export_domain_name },
                 { :name => "export_address", :value => deployment.rhev_export_domain_address },

--- a/server/app/lib/actions/fusor/deployment/cloud_forms/deploy.rb
+++ b/server/app/lib/actions/fusor/deployment/cloud_forms/deploy.rb
@@ -54,6 +54,9 @@ module Actions
                             deployment, upload_action.output[:template_name])
 
                 plan_action(::Actions::Fusor::Deployment::Rhev::CfmeLaunch, deployment)
+
+                plan_action(::Actions::Fusor::Deployment::Rhev::OpenPostgresToCFME, deployment)
+
               elsif deployment.cfme_install_loc == 'OpenStack'
                 plan_action(::Actions::Fusor::Deployment::OpenStack::CfmeUpload, deployment,
                             file_repositories(repositories).first,

--- a/server/app/lib/actions/fusor/deployment/rhev/open_postgres_to_cfme.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/open_postgres_to_cfme.rb
@@ -1,0 +1,66 @@
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+require 'stringio'
+
+module Actions
+  module Fusor
+    module Deployment
+      module Rhev
+        class OpenPostgresToCFME < Actions::Fusor::FusorBaseAction
+
+          def humanized_name
+            _("Allow CFME access to the RHEV Engine history database")
+          end
+
+          def plan(deployment)
+            super(deployment)
+            plan_self(deployment_id: deployment.id)
+          end
+
+          def run
+            ::Fusor.log.debug "================ OpenPostgresToCFME run method ===================="
+
+            deployment = ::Fusor::Deployment.find(input[:deployment_id])
+            fail _("CFME address not found, cannot whitelist IP in postgres") unless deployment.cfme_address
+
+            ssh_host = deployment.rhev_engine_host.ip
+            ssh_username = "root"
+
+            pg_conf_line = "host    all    all    #{deployment.cfme_address}/32    md5"
+            pg_conf_file = '/var/lib/pgsql/data/pg_hba.conf'
+
+            cmd = "if ! grep -q '^#{pg_conf_line}' #{pg_conf_file} ; then "\
+                "echo '#{pg_conf_line}' >> #{pg_conf_file} && "\
+                "service postgresql restart ; fi"
+
+            # RHEV-host username password
+            client = Utils::Fusor::SSHConnection.new(ssh_host, ssh_username, deployment.rhev_root_password)
+            client.on_complete(lambda { open_postgres_completed })
+            client.on_failure(lambda { open_postgres_failed })
+            ::Fusor.log.debug "Running command: #{cmd}"
+            client.execute(cmd)
+
+            ::Fusor.log.debug "================ Leaving OpenPostgresToCFME run method ===================="
+          end
+
+          def open_postgres_completed
+            ::Fusor.log.info "Successfully opened postgres to CFME"
+          end
+
+          def open_postgres_failed
+            fail _("Failed to open postgres to CFME")
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/app/lib/utils/cloud_forms/infra_provider.rb
+++ b/server/app/lib/utils/cloud_forms/infra_provider.rb
@@ -29,10 +29,14 @@ module Utils
               :hostname => provider_params[:hostname],
               :port => "443",
               :zone_id => "1000000000001",
-              :credentials => {
+              :credentials => [{
                 :userid => provider_params[:username],
                 :password => provider_params[:password]
-              }
+              }, {
+                :userid => "engine",
+                :password => deployment.rhev_engine_admin_password,
+                :auth_type => 'metrics'
+              }]
             }
           ]
         }


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1255119

- Whitelists the CFME IP for RHEV engine's postgres server
- Imports credentials for RHEV engine database into CFME when creating the provider