### PR TITLE
Sync Docker containers to Satellite and integrate into OSE install process

### DIFF
--- a/server/app/lib/actions/fusor/content/manage_content.rb
+++ b/server/app/lib/actions/fusor/content/manage_content.rb
@@ -45,6 +45,12 @@ module Actions
             # retrieve the repos needed for the deployment and use them in actions that follow
             repositories = retrieve_deployment_repositories(deployment.organization, product_content_details)
 
+            if deployment.deploy_openshift
+              SETTINGS[:fusor][:docker_repos].each do |docker_repo|
+                repositories << ::Katello::Repository.find_by_name(docker_repo[:name])
+              end
+            end
+
             plan_action(::Actions::Fusor::Content::SyncRepositories, repositories)
 
             plan_action(::Actions::Fusor::Content::PublishContentView,

--- a/server/app/lib/actions/fusor/deployment/open_shift/install_ose.rb
+++ b/server/app/lib/actions/fusor/deployment/open_shift/install_ose.rb
@@ -72,10 +72,6 @@ module Actions
             opts[:username] = deployment.openshift_username
             opts[:ssh_key] = deployment.ose_private_key_path
 
-            # Workaround for https://trello.com/c/33ef176y
-            # // nothing
-
-
             opts[:docker_registry_host] = deployment.openshift_storage_host
             opts[:docker_registry_path] = deployment.openshift_export_path
 
@@ -88,6 +84,9 @@ module Actions
 
             opts[:subdomain_name] = deployment.openshift_subdomain_name
             opts[:helloworld_sample_app] = deployment.openshift_sample_helloworld
+
+            opts[:org_label] = Organization.find(deployment.organization_id).label.downcase
+            opts[:satellite_hostname] = `/usr/bin/hostname`.chomp
 
             opts
           end

--- a/server/app/lib/actions/fusor/deployment/open_shift/post_install_ose.rb
+++ b/server/app/lib/actions/fusor/deployment/open_shift/post_install_ose.rb
@@ -60,9 +60,6 @@ module Actions
             opts[:username] = deployment.openshift_username
             opts[:ssh_key] = deployment.ose_private_key_path
 
-            # Workaround for https://trello.com/c/33ef176y
-            # //nothing
-
             opts[:docker_registry_host] = deployment.openshift_storage_host
             opts[:docker_registry_path] = deployment.openshift_export_path
 
@@ -75,6 +72,9 @@ module Actions
 
             opts[:subdomain_name] = deployment.openshift_subdomain_name
             opts[:helloworld_sample_app] = deployment.openshift_sample_helloworld
+
+            opts[:org_label] = Organization.find(deployment.organization_id).label.downcase
+            opts[:satellite_hostname] = `/usr/bin/hostname`.chomp
 
             opts
           end

--- a/server/app/lib/actions/fusor/deployment/open_shift/setup_ose.rb
+++ b/server/app/lib/actions/fusor/deployment/open_shift/setup_ose.rb
@@ -61,9 +61,6 @@ module Actions
             opts[:username] = deployment.openshift_username
             opts[:ssh_key] = deployment.ose_private_key_path
 
-            # Workaround for https://trello.com/c/33ef176y
-            # // nothing
-
             opts[:docker_registry_host] = deployment.openshift_storage_host
             opts[:docker_registry_path] = deployment.openshift_export_path
 
@@ -76,6 +73,9 @@ module Actions
 
             opts[:subdomain_name] = deployment.openshift_subdomain_name
             opts[:helloworld_sample_app] = deployment.openshift_sample_helloworld
+
+            opts[:org_label] = Organization.find(deployment.organization_id).label.downcase
+            opts[:satellite_hostname] = `/usr/bin/hostname`.chomp
 
             opts
           end

--- a/server/app/lib/actions/fusor/deployment/prepare_org/create_repository.rb
+++ b/server/app/lib/actions/fusor/deployment/prepare_org/create_repository.rb
@@ -19,14 +19,18 @@ module Actions
             _("Create Repository")
           end
 
-          def plan
-            super
-            plan_self
+          def plan(name, type, label, url, upstream_name)
+            super()
+            plan_self(:name => name, :type => type, :label => label, :url => url, :upstream_name => upstream_name)
           end
 
           def create_sub_plans
             product = ::Katello::Product.find_by_name('Fusor')
-            repository = product.add_repo('Puppet1', 'Puppet', nil, 'puppet', 'unprotected')
+            repository = product.add_repo(input[:label], input[:name], input[:url], input[:type], true)
+            if input[:upstream_name]
+              repository[:docker_upstream_name] = input[:upstream_name]
+            end
+
             trigger(::Actions::Katello::Repository::Create, repository, false, true)
           end
         end

--- a/server/app/lib/actions/fusor/deployment/prepare_org/prepare.rb
+++ b/server/app/lib/actions/fusor/deployment/prepare_org/prepare.rb
@@ -28,7 +28,13 @@ module Actions
               end
 
               unless ::Katello::Repository.find_by_name('Puppet')
-                plan_action(::Actions::Fusor::Deployment::PrepareOrg::CreateRepository)
+                plan_action(::Actions::Fusor::Deployment::PrepareOrg::CreateRepository, 'Puppet', 'puppet', 'Puppet1', nil, nil)
+              end
+
+              SETTINGS[:fusor][:docker_repos].each do |repo|
+                unless ::Katello::Repository.find_by_name(repo[:name])
+                  plan_action(::Actions::Fusor::Deployment::PrepareOrg::CreateRepository, repo[:name], 'docker', repo[:name], 'http://registry-1.docker.io/', repo[:upstream_name])
+                end
               end
 
               plan_action(::Actions::Fusor::Deployment::PrepareOrg::UploadModule)

--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -250,6 +250,24 @@
     - :name: "ovirt::self_hosted::import_template"
     - :name: "ovirt::self_hosted::run_vm"
 
+  :docker_repos:
+    - :name: "hello-openshift"
+      :upstream_name: "openshift/hello-openshift"
+    - :name: "origin-docker-registry"
+      :upstream_name: "openshift/origin-docker-registry"
+    - :name: "origin-haproxy-router"
+      :upstream_name: "openshift/origin-haproxy-router"
+    - :name: "origin-deployer"
+      :upstream_name: "openshift/origin-deployer"
+    - :name: "origin-sti-builder"
+      :upstream_name: "openshift/origin-sti-builder"
+    - :name: "origin-pod"
+      :upstream_name: "openshift/origin-pod"
+    - :name: "origin-docker-builder"
+      :upstream_name: "openshift/origin-docker-builder"
+    - :name: "origin-keepalived-ipfailover"
+      :upstream_name: "openshift/origin-keepalived-ipfailover"
+
   :host_groups:
     :rhev:
      :root_name: "Fusor Base" # seeded by the fusor-installer

--- a/server/lib/modules/ose_installer/playbooks/setup.yml
+++ b/server/lib/modules/ose_installer/playbooks/setup.yml
@@ -11,6 +11,9 @@
     - name: scp docker storage configuration
       action: copy src="{{ output_dir }}/docker-storage-setup" dest="/etc/sysconfig/docker-storage-setup" owner=root mode=0775
 
+    - name: scp docker configuration file
+      action: copy src="{{ output_dir }}/docker" dest="/etc/sysconfig/docker" owner=root mode=0775
+
     - name: check if docker volume already exists
       stat: path=/dev/{{docker_volume}}
       register: p
@@ -23,18 +26,18 @@
       service: name=docker state=started
 
     - name: Install docker containers
-      action: shell docker pull {{item}}
+      action: shell docker pull {{org_label}}-fusor-{{item}}
       with_items:
-        - rhscl/php-56-rhel7
-        - rhscl/mysql-56-rhel7
-        - rhscl/ruby-22-rhel7
-        - openshift3/ose-docker-registry:v3.2
-        - openshift3/ose-pod:v3.2
-        - openshift3/ose-sti-builder:v3.2
-        - openshift3/ose-deployer:v3.2
-        - openshift3/ose-haproxy-router:v3.2
-        - openshift3/ose-docker-builder:v3.2
-        - openshift3/ose-keepalived-ipfailover:v3.2
+#        - rhscl/php-56-rhel7
+#        - rhscl/mysql-56-rhel7
+#        - rhscl/ruby-22-rhel7
+        - origin-docker-registry
+        - origin-pod
+        - origin-sti-builder
+        - origin-deployer
+        - origin-haproxy-router
+        - origin-docker-builder
+        - origin-keepalived-ipfailover
 
 - name: Configure master node
   hosts: masters

--- a/server/lib/modules/ose_installer/templates/ansible.hosts.template
+++ b/server/lib/modules/ose_installer/templates/ansible.hosts.template
@@ -34,6 +34,8 @@ output_dir=<output_dir>
 subdomain_name=<subdomain_name>
 helloworld_sample_app=<helloworld_sample_app>
 
+org_label=<org_label>
+
 # host group for masters
 [masters]
 <master_nodes>

--- a/server/lib/modules/ose_installer/templates/docker.template
+++ b/server/lib/modules/ose_installer/templates/docker.template
@@ -1,0 +1,40 @@
+# /etc/sysconfig/docker
+
+# Modify these options if you want to change the way the docker daemon runs
+OPTIONS='--selinux-enabled --log-driver=journald'
+DOCKER_CERT_PATH=/etc/docker
+
+# If you want to add your own registry to be used for docker search and docker
+# pull use the ADD_REGISTRY option to list a set of registries, each prepended
+# with --add-registry flag. The first registry added will be the first registry
+# searched.
+ADD_REGISTRY='--add-registry <satellite_hostname>:5000'
+
+# If you want to block registries from being used, uncomment the BLOCK_REGISTRY
+# option and give it a set of registries, each prepended with --block-registry
+# flag. For example adding docker.io will stop users from downloading images
+# from docker.io
+BLOCK_REGISTRY='--block-registry docker.io'
+
+# If you have a registry secured with https but do not have proper certs
+# distributed, you can tell docker to not look for full authorization by
+# adding the registry to the INSECURE_REGISTRY line and uncommenting it.
+INSECURE_REGISTRY='--insecure-registry <satellite_hostname>:5000'
+
+# On an SELinux system, if you remove the --selinux-enabled option, you
+# also need to turn on the docker_transition_unconfined boolean.
+# setsebool -P docker_transition_unconfined 1
+
+# Location used for temporary files, such as those created by
+# docker load and build operations. Default is /var/lib/docker/tmp
+# Can be overriden by setting the following environment variable.
+# DOCKER_TMPDIR=/var/tmp
+
+# Controls the /etc/cron.daily/docker-logrotate cron job status.
+# To disable, uncomment the line below.
+# LOGROTATE=false
+#
+
+# docker-latest daemon can be used by starting the docker-latest unitfile.
+# To use docker-latest client, uncomment below line
+#DOCKERBINARY=/usr/bin/docker-latest


### PR DESCRIPTION
This PR adds all necessary Docker repositories to the Fusor product. This hosts the containers on the crane server on port 5000 allowing for the OSE VMs to pull content straight from Satellite. Note that this PR will fail unless you have added an iptables rule to open port 5000 on Satellite. I posted a PR to fusor-installer which will do this automatically, but a stale environment will need to do this manually.

We are initially syncing content from Dockerhub and will move to the Red Hat Registry when they move to V2.