### PR TITLE
Upgraded fusor.yaml to RHEL 6.8 kickstart

### DIFF
--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -22,7 +22,7 @@
         :repository_set_id: "1952"
         :repository_set_name: "Red Hat Enterprise Linux 6 Server (Kickstart)"
         :basearch: "x86_64"
-        :releasever: "6.7"
+        :releasever: "6.8"
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"


### PR DESCRIPTION
Tested with RHEV deployment. Successfuly synced content for 6.8.