### PR TITLE
1328304 - Added check for leading or trailing whitespace on hostname

### DIFF
--- a/fusor-ember-cli/app/controllers/storage.js
+++ b/fusor-ember-cli/app/controllers/storage.js
@@ -13,6 +13,8 @@ import {
 export default Ember.Controller.extend(NeedsDeploymentMixin, {
   actions: {
     testMountPoint() {
+      var deployment = this.get('model');
+      deployment.trimFieldsForSave();
       this.set('errorMsg', null);
       const checkExport = this.get('isCloudForms');
       const checkHosted = this.get('rhevIsSelfHosted');

--- a/fusor-ember-cli/app/mixins/deployment-route-mixin.js
+++ b/fusor-ember-cli/app/mixins/deployment-route-mixin.js
@@ -5,6 +5,7 @@ export default Ember.Mixin.create({
   actions: {
     saveDeployment(routeNameForTransition) {
       let deployment = this.get('controller.model');
+      deployment.trimFieldsForSave();
       let self = this;
       let isNew = Ember.isBlank(deployment.get('id'));
 

--- a/fusor-ember-cli/app/models/deployment.js
+++ b/fusor-ember-cli/app/models/deployment.js
@@ -176,6 +176,21 @@ export default DS.Model.extend({
     }
   }),
 
+  trimFieldsForSave() {
+    this.set('rhev_storage_name', this.get('rhev_storage_name') ? this.get('rhev_storage_name').trim() : null);
+    this.set('rhev_storage_address', this.get('rhev_storage_address') ? this.get('rhev_storage_address').trim() : null);
+    this.set('rhev_share_path', this.get('rhev_share_path') ? this.get('rhev_share_path').trim() : null);
+    this.set('rhev_export_domain_name', this.get('rhev_export_domain_name') ? this.get('rhev_export_domain_name').trim() : null);
+    this.set('rhev_export_domain_address', this.get('rhev_export_domain_address') ? this.get('rhev_export_domain_address').trim() : null);
+    this.set('rhev_export_domain_path', this.get('rhev_export_domain_path') ? this.get('rhev_export_domain_path').trim() : null);
+    this.set('hosted_storage_name', this.get('hosted_storage_name') ? this.get('hosted_storage_name').trim() : null);
+    this.set('hosted_storage_address', this.get('hosted_storage_address') ? this.get('hosted_storage_address').trim() : null);
+    this.set('hosted_storage_path', this.get('hosted_storage_path') ? this.get('hosted_storage_path').trim() : null);
+    this.set('openshift_storage_host', this.get('openshift_storage_host') ? this.get('openshift_storage_host').trim() : null);
+    this.set('openshift_export_path', this.get('openshift_export_path') ? this.get('openshift_export_path').trim() : null);
+    this.set('openshift_subdomain_name', this.get('openshift_subdomain_name') ? this.get('openshift_subdomain_name').trim() : null);
+  },
+
   progressPercent: Ember.computed('progress', function() {
     if (this.get('progress')) {
       return (this.get('progress') * 100).toFixed(1) + '%';

--- a/fusor-ember-cli/app/utils/validators.js
+++ b/fusor-ember-cli/app/utils/validators.js
@@ -291,6 +291,14 @@ const IpSubnetValidator = Validator.extend({
   }
 });
 
+const NoSpacesValidator = Validator.extend({
+  message: 'This field must not have spaces.',
+  isValid(value) {
+    let spaceRegex = /\s/;
+    return !spaceRegex.test(value);
+  }
+});
+
 const MacAddressValidator = RegExpValidator.extend({
   regExp: new RegExp(/^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$/),
   message: 'This is an invalid MAC address.'
@@ -333,14 +341,16 @@ const NoLeadingSlashValidator = Validator.extend({
 const NfsPathValidator = AllValidator.extend({
   validators: [
     LeadingSlashValidator.create({}),
-    NoTrailingSlashValidator.create({})
+    NoTrailingSlashValidator.create({}),
+    NoSpacesValidator.create({})
   ]
 });
 
 const GlusterPathValidator = AllValidator.extend({
   validators: [
     NoLeadingSlashValidator.create({}),
-    NoTrailingSlashValidator.create({})
+    NoTrailingSlashValidator.create({}),
+    NoSpacesValidator.create({})
   ]
 });
 

--- a/server/app/lib/fusor/validators/deployment_validator.rb
+++ b/server/app/lib/fusor/validators/deployment_validator.rb
@@ -1,5 +1,6 @@
 module Fusor
   module Validators
+    # rubocop:disable ClassLength
     class DeploymentValidator < ActiveModel::Validator
 
       def validate(deployment)
@@ -40,52 +41,36 @@ module Fusor
           deployment.errors[:rhev_storage_type] << _('RHEV deployments must specify a valid storage type (NFS, Local, glusterfs)')
         end
 
-        if deployment.rhev_storage_type == 'NFS'
-          if deployment.rhev_storage_address.empty?
-            deployment.errors[:rhev_storage_address] << _('NFS share specified but missing address of NFS server')
-          end
-
-          if deployment.rhev_share_path.empty?
-            deployment.errors[:rhev_share_path] << _('NFS share specified but missing path to the share')
-          else
-            # See https://tools.ietf.org/html/rfc2224#section-1
-            # NFS paths cannot end in slash or contain non-ascii chars
-            if deployment.rhev_share_path.end_with?("/") && deployment.rhev_share_path.length > 1
-              deployment.errors[:rhev_share_path] << _('NFS path specified ends in a "/", which is invalid')
-            end
-
-            # NFS paths must start with a slash
-            if !deployment.rhev_share_path.start_with?("/")
-              deployment.errors[:rhev_share_path] << _('NFS path specified does not start with a "/", which is invalid')
-            end
-
-            if !deployment.rhev_share_path.ascii_only?
-              deployment.errors[:rhev_share_path] << _('NFS path specified contains non-ascii characters, which is invalid')
-            end
-
-            validate_nfs_share(deployment, deployment.rhev_storage_address, deployment.rhev_share_path, 36, 36)
-          end
-        elsif deployment.rhev_storage_type == 'Local'
+        if deployment.rhev_storage_type == 'Local'
           if deployment.rhev_local_storage_path.empty?
             deployment.errors[:rhev_local_storage_path] << _('Local storage specified but missing local storage path')
           end
-        elsif deployment.rhev_storage_type == 'glusterfs'
+        else
           if deployment.rhev_share_path.empty?
-            deployment.errors[:rhev_share_path] << _('Gluster share specified but missing path to the share')
+            deployment.errors[:rhev_share_path] << _('RHEV storage specified but missing path to the share')
           else
-            # See https://tools.ietf.org/html/rfc2224#section-1
-            # NFS paths cannot end in slash or contain non-ascii chars
-            if deployment.rhev_share_path.end_with?("/") && deployment.rhev_share_path.length > 1
-              deployment.errors[:rhev_share_path] << _('Gluster path specified ends in a "/", which is invalid')
+            error = validate_storage_path(deployment, deployment.rhev_share_path)
+            if error
+              deployment.errors[:rhev_share_path] << _(error)
+            elsif deployment.rhev_storage_address.empty?
+              deployment.errors[:rhev_storage_address] << _('RHEV storage specified but missing address to the share')
+            else
+              validate_storage_share(deployment, deployment.rhev_storage_address, deployment.rhev_share_path, 36, 36)
             end
+          end
+        end
 
-            # Glusterfs paths must start with a slash
-            if deployment.rhev_share_path.start_with?("/")
-              deployment.errors[:rhev_share_path] << _('Gluster path specified starts with a "/", which is invalid')
-            end
-
-            if !deployment.rhev_share_path.ascii_only?
-              deployment.errors[:rhev_share_path] << _('Gluster path specified contains non-ascii characters, which is invalid')
+        if deployment.rhev_is_self_hosted
+          if deployment.hosted_storage_path.empty?
+            deployment.errors[:hosted_storage_path] << _('RHEV self hosted deployments must specify hosted storage path')
+          else
+            error = validate_storage_path(deployment, deployment.hosted_storage_path)
+            if error
+              deployment.errors[:hosted_storage_path] << _(error)
+            elsif deployment.hosted_storage_address.empty?
+              deployment.errors[:hosted_storage_address] << _('RHEV self hosted deployments must specify hosted storage address')
+            else
+              validate_storage_share(deployment, deployment.hosted_storage_address, deployment.hosted_storage_path, 36, 36)
             end
           end
         end
@@ -99,6 +84,7 @@ module Fusor
         end
 
         validate_hostname(deployment)
+        validate_storage_addresses(deployment)
       end
 
       def validate_cfme_parameters(deployment)
@@ -115,6 +101,20 @@ module Fusor
 
         if deployment.cfme_root_password.empty?
           deployment.errors[:cfme_root_password] << _('CloudForms deployments must specify a root password for the CloudForms machines')
+        end
+
+        if deployment.rhev_export_domain_address.empty?
+          deployment.errors[:rhev_export_domain_address] << _('NFS share specified but missing address of NFS server')
+        else
+          if deployment.rhev_export_domain_path.empty?
+            deployment.errors[:rhev_export_domain_path] << _('NFS share specified but missing path to the share')
+          else
+            error = validate_storage_path(deployment, deployment.rhev_export_domain_path)
+            if error
+              deployment.errors[:rhev_export_domain_path] << _(error)
+            end
+            validate_storage_share(deployment, deployment.rhev_export_domain_address, deployment.rhev_export_domain_path, 36, 36)
+          end
         end
       end
 
@@ -160,21 +160,52 @@ module Fusor
           validate_openshift_subdomain(deployment, subdomain)
         end
 
-        validate_nfs_share(deployment, deployment.openshift_storage_host, deployment.openshift_export_path, -1, -1)
+        validate_storage_share(deployment, deployment.openshift_storage_host, deployment.openshift_export_path, -1, -1)
       end
 
       private
 
-      def validate_nfs_share(deployment, address, path, uid, gid)
-        # validate that the NFS server exists
-        # don't proceed if it doesn't
-        return unless validate_nfs_server(deployment, address)
+      def validate_storage_path(deployment, path)
+        error = nil
+        if deployment.rhev_storage_type == 'NFS'
+          # See https://tools.ietf.org/html/rfc2224#section-1
+          # NFS paths cannot end in slash or contain non-ascii chars
+          if path.end_with?("/") && path.length > 1
+            error = 'NFS path specified ends in a "/", which is invalid'
+          end
+          # NFS paths must start with a slash
+          if !path.start_with?("/")
+            error = 'NFS path specified does not start with a "/", which is invalid'
+          end
+          if !path.ascii_only?
+            error = 'NFS path specified contains non-ascii characters, which is invalid'
+          end
+        elsif deployment.rhev_storage_type == 'glusterfs'
+          if path.end_with?("/") && path.length > 1
+            error = 'Gluster path specified ends in a "/", which is invalid'
+          end
 
-        # validate that the NFS share exists and is clean
-        validate_nfs_mount(deployment, address, path, uid, gid)
+          if path.start_with?("/")
+            error = 'Gluster path specified starts with a "/", which is invalid'
+          end
+
+          if !path.ascii_only?
+            error = 'Gluster path specified contains non-ascii characters, which is invalid'
+          end
+        end
+        return error
       end
 
-      def validate_nfs_server(deployment, address)
+      def validate_storage_share(deployment, address, path, uid, gid)
+        # validate that the NFS server exists
+        # don't proceed if it doesn't
+        return unless validate_storage_server(deployment, address)
+
+        # validate that the NFS share exists and is clean
+        validate_storage_mount(deployment, address, path, uid, gid)
+      end
+
+      def validate_storage_server(deployment, address)
         cmd = "showmount #{address}"
         status, output = Utils::Fusor::CommandUtils.run_command(cmd)
 
@@ -188,8 +219,13 @@ module Fusor
         return true
       end
 
-      def validate_nfs_mount(deployment, address, path, uid, gid)
-        cmd = "sudo safe-mount.sh '#{deployment.id}' '#{address}' '#{path}'"
+      def validate_storage_mount(deployment, address, path, uid, gid)
+        if deployment.rhev_storage_type == "NFS"
+          type = "nfs"
+        else
+          type = "glusterfs"
+        end
+        cmd = "sudo safe-mount.sh '#{deployment.id}' '#{address}' '#{path}' '#{type}'"
         status, output = Utils::Fusor::CommandUtils.run_command(cmd)
 
         if status != 0
@@ -202,7 +238,7 @@ module Fusor
         # Check if we want to verify NFS mount credentials as well
         # If specified UID is -1, do not check
         if uid != -1
-          validate_nfs_credentials(deployment, uid, gid)
+          validate_storage_credentials(deployment, uid, gid)
         end
 
         files = Dir["/tmp/fusor-test-mount-#{deployment.id}/*"] # this may return [] if it can't read the share
@@ -215,7 +251,7 @@ module Fusor
         end
       end
 
-      def validate_nfs_credentials(deployment, uid, gid)
+      def validate_storage_credentials(deployment, uid, gid)
         if File.stat("/tmp/fusor-test-mount-#{deployment.id}").uid != uid
           add_warning(deployment, _("NFS share has an invalid UID. The expected UID is '%s'. " \
                                     "Please check NFS share permissions.") % "#{uid}")
@@ -258,6 +294,28 @@ module Fusor
         deployment.rhev_hypervisor_hosts.each do |host|
           unless host.name =~ regex
             deployment.errors[:base] << _("RHEV hypervisor hosts '%s' does not have proper mac naming scheme." % "#{host.name}")
+          end
+        end
+      end
+
+      def validate_storage_addresses(deployment)
+        regex = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/
+
+        unless deployment.rhev_storage_address.nil?
+          unless deployment.rhev_storage_address =~ regex
+            deployment.errors[:base] << _("RHEV storage address '%s' is an invalid host or ip address." % "#{deployment.rhev_storage_address}")
+          end
+        end
+
+        unless deployment.rhev_export_domain_address.nil?
+          unless deployment.rhev_export_domain_address =~ regex
+            deployment.errors[:base] << _("RHEV export domain address '%s' is an invalid host or ip address" % "#{deployment.rhev_export_domain_address}")
+          end
+        end
+
+        unless deployment.hosted_storage_address.nil?
+          unless deployment.hosted_storage_address =~ regex
+            deployment.errors[:base] << _("RHEV self hosted storage address '%s' is an invalid host or ip address" % "#{deployment.hosted_storage_address}")
           end
         end
       end

--- a/server/test/controllers/deployments_controller_test.rb
+++ b/server/test/controllers/deployments_controller_test.rb
@@ -68,7 +68,7 @@ module Fusor
       Fusor::Api::V2::DeploymentsController.any_instance.stubs(:async_task).returns(
         ::ForemanTasks::Task.find(running_deployment_task_id))
 
-      Fusor::Validators::DeploymentValidator.any_instance.stubs(:validate_nfs_share)
+      Fusor::Validators::DeploymentValidator.any_instance.stubs(:validate_storage_share)
 
       assert_nil @deployment.foreman_task_uuid
       put(:deploy, :id => @deployment.id)

--- a/server/test/fixtures/fusor_deployments.yml
+++ b/server/test/fixtures/fusor_deployments.yml
@@ -41,7 +41,9 @@ rhev_and_cfme:
   rhev_engine_admin_password: redhat1234
   rhev_is_self_hosted: false
   rhev_share_path: /storage/rhev_storage
+  rhev_export_domain_path: /storage/export
   rhev_storage_address: 10.13.129.106
+  rhev_export_domain_address: 10.13.129.106
   rhev_storage_type: NFS
   rhev_engine_host: engine3
   deploy_openstack: false
@@ -62,6 +64,8 @@ rhev_self_hosted:
   rhev_is_self_hosted: true
   rhev_share_path: /storage/rhev_storage
   rhev_storage_address: 10.13.129.106
+  hosted_storage_path: /storage/hosted_storage
+  hosted_storage_address: 10.13.129.106
   rhev_storage_type: NFS
   deploy_openstack: false
   deploy_cfme: false

--- a/server/test/models/deployment_test.rb
+++ b/server/test/models/deployment_test.rb
@@ -6,7 +6,7 @@ class DeploymentTest < ActiveSupport::TestCase
   describe "deployment" do
     before do
       # skip nfs mount validation as it calls commands from the command line
-      Fusor::Validators::DeploymentValidator.any_instance.stubs(:validate_nfs_share)
+      Fusor::Validators::DeploymentValidator.any_instance.stubs(:validate_storage_share)
     end
 
     test "should not save without name" do
@@ -199,6 +199,54 @@ class DeploymentTest < ActiveSupport::TestCase
         rhev.rhev_share_path = '/gv0'
         assert_not rhev.save, "Saved rhev deployment who's glusterfs path ended in a slash"
       end
+
+      test "should not save rhev deployment if self hosted and storage is empty" do
+        rhev = fusor_deployments(:rhev_self_hosted)
+        rhev.hosted_storage_address = nil
+        assert_not rhev.save, "Saved self hosted rhev deployment who's hosted storage address is empty"
+      end
+
+      test "should not save rhev deployment if self hosted and path is empty" do
+        rhev = fusor_deployments(:rhev_self_hosted)
+        rhev.hosted_storage_path = nil
+        assert_not rhev.save, "Saved self hosted rhev deployment who's hosted storage path is empty"
+      end
+
+      test "should not save rhev deployment if self hosted and gluster path ends in a slash" do
+        rhev = fusor_deployments(:rhev_self_hosted)
+        rhev.rhev_storage_type = 'glusterfs'
+        rhev.hosted_storage_path = 'gv0/'
+        assert_not rhev.save, "Saved self hosted rhev deployment who's hosted gluster storage path ends in a slash"
+      end
+
+      test "should not save rhev deployment if self hosted and gluster path begins with a slash" do
+        rhev = fusor_deployments(:rhev_self_hosted)
+        rhev.rhev_storage_type = 'glusterfs'
+        rhev.hosted_storage_path = '/gv0'
+        assert_not rhev.save, "Saved self hosted rhev deployment who's hosted gluster storage path begins with a slash"
+      end
+
+      test "should not save rhev self hosted deployment if hosted nfs storage path ends in slash" do
+        rhev = fusor_deployments(:rhev_self_hosted)
+        rhev.rhev_storage_type = 'NFS'
+        rhev.hosted_storage_path = '/invalid/path/'
+        assert_not rhev.save, "Saved rhev self hosted deployment who's hosted nfs storage path ended in a slash"
+      end
+
+      test "should invalidate rhev self hosted deployment if hosted NFS path does not have a leading slash" do
+        rhev = fusor_deployments(:rhev_self_hosted)
+        rhev.rhev_storage_type = 'NFS'
+        rhev.hosted_storage_path = 'test/this/out'
+        assert rhev.invalid?
+        assert_equal 'NFS path specified does not start with a "/", which is invalid',
+                     rhev.errors[:hosted_storage_path].first
+      end
+
+      test "should not save rhev self hosted deployment if hosted storage path contains non-ascii characters" do
+        rhev = fusor_deployments(:rhev_self_hosted)
+        rhev.hosted_storage_path = '/å'
+        assert_not rhev.save, "Saved rhev self hosted deployment who's storage path contained non-ascii characters"
+      end
     end
 
     describe "cfme deployment" do
@@ -227,6 +275,32 @@ class DeploymentTest < ActiveSupport::TestCase
         cfme = fusor_deployments(:rhev_and_cfme)
         cfme.cfme_root_password = ''
         assert_not cfme.save, "Saved cfme deployment that did not specify root password"
+      end
+
+      test "cfme deployments should not save if export storage address is empty" do
+        cfme = fusor_deployments(:rhev_and_cfme)
+        cfme.rhev_export_domain_address = nil
+        assert_not cfme.save, "Saved cfme deployment with empty export storage address"
+      end
+
+      test "cfme deployments should not save if export storage path is empty" do
+        cfme = fusor_deployments(:rhev_and_cfme)
+        cfme.rhev_export_domain_path = nil
+        assert_not cfme.save, "Saved cfme deployment with empty export storage path"
+      end
+
+      test "cfme deployments should not save if export gluster storage path ends in a slash" do
+        cfme = fusor_deployments(:rhev_and_cfme)
+        cfme.rhev_storage_type = 'glusterfs'
+        cfme.rhev_export_domain_path = "gv0/"
+        assert_not cfme.save, "Saved cfme deployment with gluster storage path that ends in a slash"
+      end
+
+      test "cfme deployments should not save if export gluster storage path begins with a slash" do
+        cfme = fusor_deployments(:rhev_and_cfme)
+        cfme.rhev_storage_type = 'glusterfs'
+        cfme.rhev_export_domain_path = "/gv0"
+        assert_not cfme.save, "Saved cfme deployment with gluster storage path beginning in a slash"
       end
     end
   end


### PR DESCRIPTION
An error occurs if a user enters a hostname or path with leading spaces so I added a check to not trim the whitespace when validating hostname and to verify no spaces in the NFS or Gluster path.