### PR TITLE
fix rhevm version in hostgroup section of fusor.yaml

### DIFF
--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -274,7 +274,7 @@
        - :name: "RHEV-Engine"
          :os: "RedHat"
          :major: "6"
-         :minor: "7"
+         :minor: "8"
          :parent: :root_deployment
          :puppet_classes:
            - :name: "ovirt"


### PR DESCRIPTION
Changed rhevm version in hostgroup section of fusor.yaml to 6.8 to match kickstart tree