### PR TITLE
revert save! and log if there's an error

### DIFF
--- a/server/app/lib/actions/fusor/host/trigger_provisioning.rb
+++ b/server/app/lib/actions/fusor/host/trigger_provisioning.rb
@@ -108,7 +108,8 @@ module Actions
             ::Fusor.log.debug "saving host of type: #{host.type}"
             ::Fusor.log.debug "calling save"
 
-            host.save!
+            rc = host.save
+            ::Fusor.log.warning "Host save failed. #{host}" if !rc
 
             return host
           end


### PR DESCRIPTION
host.save! seems to be causing ISO deployments to fail but it isn't causing a stack trace like we expected. My hunch is we're eating the exception somewhere but not sure where yet. host.save seems to let deployments work, so we're just going to log it if host.save returns false.