### PR TITLE
Validate no other hosts on OpenStack's overcloud_float_net

### DIFF
--- a/server/app/controllers/fusor/api/v21/deployments_controller.rb
+++ b/server/app/controllers/fusor/api/v21/deployments_controller.rb
@@ -80,11 +80,14 @@ module Fusor
       @deployment.valid?
       error_messages = @deployment.errors.full_messages
       error_messages += @deployment.openstack_deployment.errors.full_messages if @deployment.deploy_openstack?
+      warning_messages = @deployment.warnings
+      warning_messages += @deployment.openstack_deployment.warnings if @deployment.deploy_openstack?
+
       render json: {
         :validation => {
           :deployment_id => @deployment.id,
           :errors => error_messages,
-          :warnings => @deployment.warnings
+          :warnings => warning_messages
         }
       }
     end

--- a/server/app/lib/fusor/validators/openstack_deployment_validator.rb
+++ b/server/app/lib/fusor/validators/openstack_deployment_validator.rb
@@ -1,29 +1,32 @@
+require 'ip'
+
 module Fusor
   module Validators
     class OpenstackDeploymentValidator < ActiveModel::Validator
 
       def validate(openstack_deployment)
         validate_overcloud openstack_deployment
-        validate_ceph openstack_deployment if openstack_deployment.external_ceph_storage
+        validate_ceph openstack_deployment
+        validate_network openstack_deployment
       end
 
       private
 
       def validate_overcloud(openstack_deployment)
         if openstack_deployment.undercloud_admin_password.empty?
-          openstack_deployment.errors[:undercloud_password] << _('Openstack deployments must specify an admin password for the Undercloud')
+          openstack_deployment.errors[:undercloud_admin_password] << _('Openstack deployments must specify an admin password for the Undercloud')
         end
 
         if openstack_deployment.undercloud_ip_address.empty?
-          openstack_deployment.errors[:undercloud_ip_addr] << _('Openstack deployments must specify an ip address for the Undercloud')
+          openstack_deployment.errors[:undercloud_ip_address] << _('Openstack deployments must specify an ip address for the Undercloud')
         end
 
         if openstack_deployment.undercloud_ssh_username.empty?
-          openstack_deployment.errors[:undercloud_user] << _('Openstack deployments must specify an ssh user for the Undercloud')
+          openstack_deployment.errors[:undercloud_ssh_username] << _('Openstack deployments must specify an ssh user for the Undercloud')
         end
 
         if openstack_deployment.undercloud_ssh_password.empty?
-          openstack_deployment.errors[:undercloud_user_password] << _('Openstack deployments must specify an ssh password for the Undercloud')
+          openstack_deployment.errors[:undercloud_ssh_password] << _('Openstack deployments must specify an ssh password for the Undercloud')
         end
 
         if openstack_deployment.overcloud_deployed?
@@ -43,7 +46,7 @@ module Fusor
         end
 
         if openstack_deployment.overcloud_float_net.empty?
-          openstack_deployment.errors[:overcloud_password] << _('Openstack deployments must specify a floating network for the Overcloud')
+          openstack_deployment.errors[:overcloud_float_net] << _('Openstack deployments must specify a floating network for the Overcloud')
         end
 
         if openstack_deployment.overcloud_float_gateway.empty?
@@ -55,7 +58,7 @@ module Fusor
         end
 
         if openstack_deployment.overcloud_compute_count.nil? || openstack_deployment.overcloud_compute_count < 1
-          openstack_deployment.errors[:overcloud_compute_flavor] << _('Openstack deployments must have at least 1 Compute node for the Overcloud')
+          openstack_deployment.errors[:overcloud_compute_count] << _('Openstack deployments must have at least 1 Compute node for the Overcloud')
         end
 
         if openstack_deployment.overcloud_controller_flavor.empty?
@@ -63,7 +66,7 @@ module Fusor
         end
 
         if openstack_deployment.overcloud_controller_count.nil? || openstack_deployment.overcloud_controller_count < 1
-          openstack_deployment.errors[:overcloud_compute_flavor] << _('Openstack deployments must have at least 1 Controller node for the Overcloud')
+          openstack_deployment.errors[:overcloud_controller_count] << _('Openstack deployments must have at least 1 Controller node for the Overcloud')
         end
 
         if openstack_deployment.overcloud_ceph_storage_flavor.empty?
@@ -92,6 +95,8 @@ module Fusor
       end
 
       def validate_ceph(openstack_deployment)
+        return unless openstack_deployment.external_ceph_storage
+
         if openstack_deployment.ceph_ext_mon_host.empty?
           openstack_deployment.errors[:ceph_ext_mon_host] << _('Openstack deployment is missing external host address for external Ceph Storage')
         end
@@ -119,6 +124,38 @@ module Fusor
         if openstack_deployment.glance_rbd_pool_name.empty?
           openstack_deployment.errors[:glance_rbd_pool_name] << _('Openstack deployment is missing the Glance RBD pool name for external Ceph Storage')
         end
+      end
+
+      def validate_network(openstack_deployment)
+        return unless openstack_deployment.deploy_cfme?
+
+        float_sn = get_ip(openstack_deployment.overcloud_float_net)
+        return unless float_sn
+
+        conflict_found = Host.all.any? do |host|
+          ip = get_ip(host.ip)
+          ip && ip.is_in?(float_sn)
+        end
+
+        if conflict_found
+          warning = "You already have hosts with addresses on the floating IP subnet #{float_sn} for this deployment. "\
+                    "If you proceed and a VM is assigned a conflicting IP address by OpenStack your deployment will fail."
+          add_warning(openstack_deployment, warning)
+        end
+      end
+
+      def get_ip(ip_str)
+        begin
+          IP.new(ip_str)
+        rescue ArgumentError
+          nil
+        end
+      end
+
+      def add_warning(openstack_deployment, warning, other_info = '')
+        openstack_deployment.warnings << warning
+        full_warning = other_info.blank? ? warning : "#{warning} #{other_info}"
+        Rails.logger.warn("#{full_warning}")
       end
     end
   end

--- a/server/app/models/fusor/openstack_deployment.rb
+++ b/server/app/models/fusor/openstack_deployment.rb
@@ -38,9 +38,19 @@ module Fusor
         glance_rbd_pool_name: 'GlanceRbdPoolName'
     }
 
+    attr_accessor :warnings
+
+    after_initialize :setup_warnings
     validates_with Fusor::Validators::OpenstackDeploymentValidator, on: :update
 
     has_one :deployment, :class_name => "Fusor::Deployment"
 
+    def setup_warnings
+      self.warnings = []
+    end
+
+    def deploy_cfme?
+      deployment && deployment.deploy_cfme && deployment.cfme_install_loc == 'OpenStack'
+    end
   end
 end

--- a/server/test/fixtures/fusor_deployments.yml
+++ b/server/test/fixtures/fusor_deployments.yml
@@ -81,6 +81,8 @@ osp:
   upstream_consumer_uuid: 1
   organization_id: 1
   deploy_openstack: true
-  deploy_cfme: false
+  deploy_cfme: true
   deploy_rhev: false
+  cfme_root_password: redhat1234
+  cfme_install_loc: OpenStack
   openstack_deployment: osp

--- a/server/test/fixtures/hosts.yml
+++ b/server/test/fixtures/hosts.yml
@@ -27,3 +27,11 @@ engine2:
 
 engine3:
   name: engine3
+
+managed_host1:
+  name: managed1
+  type: 'Host::Managed'
+
+managed_host2:
+  name: managed2
+  type: 'Host::Managed'

--- a/server/test/models/openstack_deployment_test.rb
+++ b/server/test/models/openstack_deployment_test.rb
@@ -14,189 +14,266 @@ require 'test_plugin_helper'
 
 class OpenstackDeploymentTest < ActiveSupport::TestCase
 
-  describe "openstack deployment" do
+  describe 'openstack deployment' do
 
-    describe "validate overcloud" do
+    describe 'validate overcloud' do
+      test 'openstack deployments validates true when all fields are valid' do
+        osp = fusor_openstack_deployments(:osp)
+        assert osp.valid?, 'Validated openstack deployment with valid data'
+        assert_empty osp.errors
+      end
 
-      test "openstack deployments must specify undercloud admin password" do
+      test 'openstack deployments must specify undercloud admin password' do
         osp = fusor_openstack_deployments(:osp)
         osp.undercloud_admin_password = ''
-        assert_not osp.save, "Saved openstack deployment that did not specify undercloud admin password"
+        assert_not osp.valid?, 'Validated openstack deployment that did not specify undercloud admin password'
+        assert_not_empty osp.errors[:undercloud_admin_password]
       end
 
-      test "openstack deployments must specify undercloud IP address" do
+      test 'openstack deployments must specify undercloud IP address' do
         osp = fusor_openstack_deployments(:osp)
         osp.undercloud_ip_address = ''
-        assert_not osp.save, "Saved openstack deployment that did not specify undercloud IP address"
+        assert_not osp.valid?, 'Validated openstack deployment that did not specify undercloud IP address'
+        assert_not_empty osp.errors[:undercloud_ip_address]
       end
 
-      test "openstack deployments must specify undercloud SSH user" do
+      test 'openstack deployments must specify undercloud SSH user' do
         osp = fusor_openstack_deployments(:osp)
         osp.undercloud_ssh_username = ''
-        assert_not osp.save, "Saved openstack deployment that did not specify undercloud SSH user"
+        assert_not osp.valid?, 'Validated openstack deployment that did not specify undercloud SSH user'
+        assert_not_empty osp.errors[:undercloud_ssh_username]
       end
 
-      test "openstack deployments must specify undercloud SSH password" do
+      test 'openstack deployments must specify undercloud SSH password' do
         osp = fusor_openstack_deployments(:osp)
         osp.undercloud_ssh_password = ''
-        assert_not osp.save, "Saved openstack deployment that did not specify undercloud SSH password"
+        assert_not osp.valid?, 'Validated openstack deployment that did not specify undercloud SSH password'
+        assert_not_empty osp.errors[:undercloud_ssh_password]
       end
 
-      test "openstack deployments overcloud_deployed must be false" do
+      test 'openstack deployments overcloud_deployed must be false' do
         osp = fusor_openstack_deployments(:osp)
         osp.overcloud_deployed = true
-        assert_not osp.save, "Saved openstack deployment that already had a deployed overcloud"
+        assert_not osp.valid?, 'Validated openstack deployment that already had a deployed overcloud'
+        assert_not_empty osp.errors[:overcloud_deployed]
       end
 
-      test "openstack deployments must specify overcloud admin password" do
+      test 'openstack deployments must specify overcloud admin password' do
         osp = fusor_openstack_deployments(:osp)
         osp.overcloud_password = ''
-        assert_not osp.save, "Saved openstack deployment that did not specify overcloud admin password"
+        assert_not osp.valid?, 'Validated openstack deployment that did not specify overcloud admin password'
+        assert_not_empty osp.errors[:overcloud_password]
       end
 
-      test "openstack deployments must specify overcloud external network interface" do
+      test 'openstack deployments must specify overcloud external network interface' do
         osp = fusor_openstack_deployments(:osp)
         osp.overcloud_ext_net_interface = ''
-        assert_not osp.save, "Saved openstack deployment that did not specify overcloud external network interface"
+        assert_not osp.valid?, 'Validated openstack deployment that did not specify overcloud external network interface'
+        assert_not_empty osp.errors[:overcloud_ext_net_interface]
       end
 
-      test "openstack deployments must specify overcloud private network" do
+      test 'openstack deployments must specify overcloud private network' do
         osp = fusor_openstack_deployments(:osp)
         osp.overcloud_private_net = ''
-        assert_not osp.save, "Saved openstack deployment that did not specify overcloud private network"
+        assert_not osp.valid?, 'Validated openstack deployment that did not specify overcloud private network'
+        assert_not_empty osp.errors[:overcloud_private_net]
       end
 
-      test "openstack deployments must specify overcloud floating network" do
+      test 'openstack deployments must specify overcloud floating network' do
         osp = fusor_openstack_deployments(:osp)
         osp.overcloud_float_net = ''
-        assert_not osp.save, "Saved openstack deployment that did not specify overcloud floating network"
+        assert_not osp.valid?, 'Validated openstack deployment that did not specify overcloud floating network'
+        assert_not_empty osp.errors[:overcloud_float_net]
       end
 
-      test "openstack deployments must specify overcloud floating network gateway" do
+      test 'openstack deployments must specify overcloud floating network gateway' do
         osp = fusor_openstack_deployments(:osp)
         osp.overcloud_float_gateway = ''
-        assert_not osp.save, "Saved openstack deployment that did not specify overcloud floating network gateway"
+        assert_not osp.valid?, 'Validated openstack deployment that did not specify overcloud floating network gateway'
+        assert_not_empty osp.errors[:overcloud_float_gateway]
       end
 
-      test "openstack deployments must specify overcloud compute flavor" do
+      test 'openstack deployments must specify overcloud compute flavor' do
         osp = fusor_openstack_deployments(:osp)
         osp.overcloud_compute_flavor = ''
-        assert_not osp.save, "Saved openstack deployment that did not specify overcloud compute flavor"
+        assert_not osp.valid?, 'Validated openstack deployment that did not specify overcloud compute flavor'
+        assert_not_empty osp.errors[:overcloud_compute_flavor]
       end
 
-      test "openstack deployments must specify overcloud compute node count" do
+      test 'openstack deployments must specify overcloud compute node count' do
         osp = fusor_openstack_deployments(:osp)
         osp.overcloud_compute_count = nil
-        assert_not osp.save, "Saved openstack deployment that did not specify overcloud compute node count"
+        assert_not osp.valid?, 'Validated openstack deployment that did not specify overcloud compute node count'
+        assert_not_empty osp.errors[:overcloud_compute_count]
       end
 
-      test "openstack deployments must have at least 1 compute node" do
+      test 'openstack deployments must have at least 1 compute node' do
         osp = fusor_openstack_deployments(:osp)
         osp.overcloud_compute_count = 0
-        assert_not osp.save, "Saved openstack deployment that did not have at least 1 compute node"
+        assert_not osp.valid?, 'Validated openstack deployment that did not have at least 1 compute node'
+        assert_not_empty osp.errors[:overcloud_compute_count]
       end
 
-      test "openstack deployments must specify overcloud controller flavor" do
+      test 'openstack deployments must specify overcloud controller flavor' do
         osp = fusor_openstack_deployments(:osp)
         osp.overcloud_controller_flavor = ''
-        assert_not osp.save, "Saved openstack deployment that did not specify overcloud controller flavor"
+        assert_not osp.valid?, 'Validated openstack deployment that did not specify overcloud controller flavor'
+        assert_not_empty osp.errors[:overcloud_controller_flavor]
       end
 
-      test "openstack deployments must specify overcloud controller node count" do
+      test 'openstack deployments must specify overcloud controller node count' do
         osp = fusor_openstack_deployments(:osp)
         osp.overcloud_controller_count = nil
-        assert_not osp.save, "Saved openstack deployment that did not specify overcloud controller node count"
+        assert_not osp.valid?, 'Validated openstack deployment that did not specify overcloud controller node count'
+        assert_not_empty osp.errors[:overcloud_controller_count]
       end
 
-      test "openstack deployments must have at least 1 controller node" do
+      test 'openstack deployments must have at least 1 controller node' do
         osp = fusor_openstack_deployments(:osp)
         osp.overcloud_controller_count = 0
-        assert_not osp.save, "Saved openstack deployment that did not have at least 1 controller node"
+        assert_not osp.valid?, 'Validated openstack deployment that did not have at least 1 controller node'
+        assert_not_empty osp.errors[:overcloud_controller_count]
       end
 
-      test "openstack deployments must specify overcloud ceph-storage flavor" do
+      test 'openstack deployments must specify overcloud ceph-storage flavor' do
         osp = fusor_openstack_deployments(:osp)
         osp.overcloud_ceph_storage_flavor = ''
-        assert_not osp.save, "Saved openstack deployment that did not specify overcloud ceph-storage flavor"
+        assert_not osp.valid?, 'Validated openstack deployment that did not specify overcloud ceph-storage flavor'
+        assert_not_empty osp.errors[:overcloud_ceph_storage_flavor]
       end
 
-      test "openstack deployments must specify overcloud ceph-storage nodecount" do
+      test 'openstack deployments must specify overcloud ceph-storage nodecount' do
         osp = fusor_openstack_deployments(:osp)
         osp.overcloud_ceph_storage_count = nil
-        assert_not osp.save, "Saved openstack deployment that did not specify overcloud ceph-storage node count"
+        assert_not osp.valid?, 'Validated openstack deployment that did not specify overcloud ceph-storage node count'
+        assert_not_empty osp.errors[:overcloud_ceph_storage_count]
       end
 
-      test "openstack deployments must specify overcloud block-storage flavor" do
+      test 'openstack deployments must specify overcloud block-storage flavor' do
         osp = fusor_openstack_deployments(:osp)
         osp.overcloud_block_storage_flavor = ''
-        assert_not osp.save, "Saved openstack deployment that did not specify overcloud block-storage flavor"
+        assert_not osp.valid?, 'Validated openstack deployment that did not specify overcloud block-storage flavor'
+        assert_not_empty osp.errors[:overcloud_block_storage_flavor]
       end
 
-      test "openstack deployments must specify overcloud block-storage nodecount" do
+      test 'openstack deployments must specify overcloud block-storage nodecount' do
         osp = fusor_openstack_deployments(:osp)
         osp.overcloud_block_storage_count = nil
-        assert_not osp.save, "Saved openstack deployment that did not specify overcloud block-storage node count"
+        assert_not osp.valid?, 'Validated openstack deployment that did not specify overcloud block-storage node count'
+        assert_not_empty osp.errors[:overcloud_block_storage_count]
       end
 
-      test "openstack deployments must specify overcloud object-storage flavor" do
+      test 'openstack deployments must specify overcloud object-storage flavor' do
         osp = fusor_openstack_deployments(:osp)
         osp.overcloud_object_storage_flavor = ''
-        assert_not osp.save, "Saved openstack deployment that did not specify overcloud object-storage flavor"
+        assert_not osp.valid?, 'Validated openstack deployment that did not specify overcloud object-storage flavor'
+        assert_not_empty osp.errors[:overcloud_object_storage_flavor]
       end
 
-      test "openstack deployments must specify overcloud object-storage nodecount" do
+      test 'openstack deployments must specify overcloud object-storage nodecount' do
         osp = fusor_openstack_deployments(:osp)
         osp.overcloud_object_storage_count = nil
-        assert_not osp.save, "Saved openstack deployment that did not specify overcloud object-storage node count"
+        assert_not osp.valid?, 'Validated openstack deployment that did not specify overcloud object-storage node count'
+        assert_not_empty osp.errors[:overcloud_object_storage_count]
       end
     end
 
-    describe "validate ceph" do
+    describe 'validate ceph' do
+      test 'openstack deployments validates with ceph enabled' do
+        osp_ceph = fusor_openstack_deployments(:osp_ceph)
+        assert osp_ceph.valid?, 'Validated openstack deployment with valid ceph data'
+        assert_empty osp_ceph.errors
+      end
 
-      test "openstack deployments must specify external host ip if external ceph is enabled" do
+      test 'openstack deployments must specify external host ip if external ceph is enabled' do
         osp_ceph = fusor_openstack_deployments(:osp_ceph)
         osp_ceph.ceph_ext_mon_host = nil
-        assert_not osp_ceph.save, "Saved openstack deployment that did not specify Ceph external host"
+        assert_not osp_ceph.valid?, 'Validated openstack deployment that did not specify Ceph external host'
+        assert_not_empty osp_ceph.errors[:ceph_ext_mon_host]
       end
 
-
-      test "openstack deployments must specify Ceph cluster FSID if external ceph is enabled" do
+      test 'openstack deployments must specify Ceph cluster FSID if external ceph is enabled' do
         osp_ceph = fusor_openstack_deployments(:osp_ceph)
         osp_ceph.ceph_cluster_fsid = nil
-        assert_not osp_ceph.save, "Saved openstack deployment that did not specify Ceph cluster FSID"
+        assert_not osp_ceph.valid?, 'Validated openstack deployment that did not specify Ceph cluster FSID'
+        assert_not_empty osp_ceph.errors[:ceph_cluster_fsid]
       end
 
-
-      test "openstack deployments must specify Ceph client username if external ceph is enabled" do
+      test 'openstack deployments must specify Ceph client username if external ceph is enabled' do
         osp_ceph = fusor_openstack_deployments(:osp_ceph)
         osp_ceph.ceph_client_username = nil
-        assert_not osp_ceph.save, "Saved openstack deployment that did not specify Ceph client username"
+        assert_not osp_ceph.valid?, 'Validated openstack deployment that did not specify Ceph client username'
+        assert_not_empty osp_ceph.errors[:ceph_client_username]
       end
 
-
-      test "openstack deployments must specify Ceph client Key if external ceph is enabled" do
+      test 'openstack deployments must specify Ceph client Key if external ceph is enabled' do
         osp_ceph = fusor_openstack_deployments(:osp_ceph)
         osp_ceph.ceph_client_key = nil
-        assert_not osp_ceph.save, "Saved openstack deployment that did not specify Ceph client key"
+        assert_not osp_ceph.valid?, 'Validated openstack deployment that did not specify Ceph client key'
+        assert_not_empty osp_ceph.errors[:ceph_client_key]
       end
 
-
-      test "openstack deployments must specify Nova RBD pool name if external ceph is enabled" do
+      test 'openstack deployments must specify Nova RBD pool name if external ceph is enabled' do
         osp_ceph = fusor_openstack_deployments(:osp_ceph)
         osp_ceph.nova_rbd_pool_name = ''
-        assert_not osp_ceph.save, "Saved openstack deployment that did not specify Nova RBD pool name"
+        assert_not osp_ceph.valid?, 'Validated openstack deployment that did not specify Nova RBD pool name'
+        assert_not_empty osp_ceph.errors[:nova_rbd_pool_name]
       end
 
-      test "openstack deployments must specify Cinder RBD pool name if external ceph is enabled" do
+      test 'openstack deployments must specify Cinder RBD pool name if external ceph is enabled' do
         osp_ceph = fusor_openstack_deployments(:osp_ceph)
         osp_ceph.cinder_rbd_pool_name = ''
-        assert_not osp_ceph.save, "Saved openstack deployment that did not specify Cinder RBD pool name"
+        assert_not osp_ceph.valid?, 'Validated openstack deployment that did not specify Cinder RBD pool name'
+        assert_not_empty osp_ceph.errors[:cinder_rbd_pool_name]
       end
 
-      test "openstack deployments must specify Glance RBD pool name if external ceph is enabled" do
+      test 'openstack deployments must specify Glance RBD pool name if external ceph is enabled' do
         osp_ceph = fusor_openstack_deployments(:osp_ceph)
         osp_ceph.glance_rbd_pool_name = ''
-        assert_not osp_ceph.save, "Saved openstack deployment that did not specify Glance RBD pool name"
+        assert_not osp_ceph.valid?, 'Validated openstack deployment that did not specify Glance RBD pool name'
+        assert_not_empty osp_ceph.errors[:glance_rbd_pool_name]
+      end
+    end
+
+    describe 'validate network' do
+      test 'should not set warning if deployment is not deploying cfme' do
+        Nic::Base.create({host: hosts(:managed_host1), ip: '192.168.152.2', primary: true})
+        Nic::Base.create({host: hosts(:managed_host2), ip: '192.168.153.2', primary: true})
+        osp = fusor_openstack_deployments(:osp)
+        osp.deployment.deploy_cfme = false
+        osp.deployment.save
+        osp.overcloud_float_net = '192.168.153.0/24'
+        osp.save
+        assert_empty osp.warnings
+      end
+
+      test 'should not set warning if deployment is not deploying cfme on OpenStack' do
+        Nic::Base.create({host: hosts(:managed_host1), ip: '192.168.152.2', primary: true})
+        Nic::Base.create({host: hosts(:managed_host2), ip: '192.168.153.2', primary: true})
+        osp = fusor_openstack_deployments(:osp)
+        osp.deployment.cfme_install_loc = 'RHEV'
+        osp.deployment.save
+        osp.overcloud_float_net = '192.168.153.0/24'
+        osp.save
+        assert_empty osp.warnings
+      end
+
+      test 'should set warning if a host is found on overcloud float network' do
+        Nic::Base.create({host: hosts(:managed_host1), ip: '192.168.152.2', primary: true})
+        Nic::Base.create({host: hosts(:managed_host2), ip: '192.168.153.2', primary: true})
+        osp = fusor_openstack_deployments(:osp)
+        osp.overcloud_float_net = '192.168.153.0/24'
+        osp.save
+        assert_not_empty osp.warnings
+      end
+
+      test 'should not set warning if no hosts are found on overcloud float network' do
+        Nic::Base.create({host: hosts(:managed_host1), ip: '192.168.152.2', primary: true})
+        Nic::Base.create({host: hosts(:managed_host2), ip: '192.168.154.2', primary: true})
+        osp = fusor_openstack_deployments(:osp)
+        osp.overcloud_float_net = '192.168.153.0/24'
+        osp.save
+        assert_empty osp.warnings
       end
     end
   end


### PR DESCRIPTION
Add validation for OpenstackDeployment.overcloud_float_net to check for hosts already using that subnet.  This would cause deployment failures when creating CFME on an address that was already taken.