### PR TITLE
Add public to gemspec

### DIFF
--- a/ui/fusor_ui.gemspec
+++ b/ui/fusor_ui.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.summary     = "Plugin engine to enable the User Interface (UI) for RHCI"
   s.description = "Plugin engine to enable the User Interface (UI) for RHCI"
 
-  s.files = Dir["{app,config,db,lib}/**/*"] + ["LICENSE", "Rakefile", "README.md"]
+  s.files = Dir["{app,config,db,lib,public}/**/*"] + ["LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
 end


### PR DESCRIPTION
Assuming all we needed was to ensure these files made it into the gem since the gem_dir is copied over via https://github.com/fusor/fusor/blob/master/ui/rubygem-fusor_ui.spec#L93.