### PR TITLE
Use more direct way to detect manifest

### DIFF
--- a/fusor-ember-cli/app/mixins/needs-existing-manifest-helpers.js
+++ b/fusor-ember-cli/app/mixins/needs-existing-manifest-helpers.js
@@ -8,34 +8,15 @@ export default Ember.Mixin.create({
     const hasModelUpstreamConsumerUuid = Ember.isPresent(modelUpstreamConsumerUuid);
 
     return new Ember.RSVP.Promise((res, rej) => {
-      const url = `/katello/api/v2/organizations/${orgId}`;
-      Ember.$.getJSON(url).then(results => {
-        const satManifestExists =
-          Ember.isPresent(results.owner_details) &&
-          Ember.isPresent(results.owner_details.upstreamConsumer);
+      const url = `/katello/api/v2/organizations/${orgId}/subscriptions`;
+      Ember.$.getJSON(url).then(response => {
 
-        if(!satManifestExists && hasModelUpstreamConsumerUuid) {
-          // Edge case where an upstream_consumer_uuid has been saved into the
-          // fusor model but not yet uploaded to satellite. Indicates a deployment
-          // in progress, but not one where satellite already has an existing
-          // manifest available for reuse
-          res(false);
-        } else if(satManifestExists && hasModelUpstreamConsumerUuid){
-          if(results.owner_details.upstreamConsumer.uuid !== modelUpstreamConsumerUuid) {
-            // ERROR: Manifest uuid reported by satellite differs from that on the model
-            // something is corrupt. Assert failure.
-            throw 'ERROR: upstreamConsumer.uuid does not match the one found on the' +
-              'fusor deployment model!';
-          } else {
-            // Existing manifest was found in satellite and matches the one set on the
-            // model by the deployment route, continue with streamlined subs
-            res(true);
-          }
-        } else {
-          // Standard new deployment with no manifest in Sat and with no manifest
-          // having ever been uploaded via the Fusor wizard
-          res(false);
-        }
+        const satManifestExists = response.results.filter(sub => {
+          return sub.name !== 'Fusor';
+        }).length > 0;
+
+        res(satManifestExists);
+
       }, () => rej(false));
     });
   },


### PR DESCRIPTION
Simplified the logic since I didn't realize we could get subscription information directly for an organization rather than by-proxy via upstreamConsumerUuid (which is *not* reliable).