### PR TITLE
1259046 - Allow deletion of successful deployments

### DIFF
--- a/fusor-ember-cli/app/components/tr-deployment.js
+++ b/fusor-ember-cli/app/components/tr-deployment.js
@@ -28,12 +28,14 @@ export default Ember.Component.extend({
     return (this.get('foremanTask.result') === 'error');
   }),
 
-  canDelete: Ember.computed('isStarted', 'isError', function() {
-    if (!(this.get('isStarted'))) {
-      return true;
-    } else {
-      return this.get('isError');
-    }
+  isSuccessful: Ember.computed('foremanTask.result', function() {
+    return this.get('foremanTask.result') === 'success';
+  }),
+
+  canDelete: Ember.computed('isStarted', 'isError', 'isSuccessful', function() {
+    return !this.get('isStarted') ||
+      this.get('isSuccessful') ||
+      this.get('isError');
   }),
 
   routeNameForEdit: Ember.computed('isComplete', 'isStarted', function() {


### PR DESCRIPTION
Tested this a bunch and I'm fairly confident we're safe doing a standard delete on successful, complete deployments. Effectively it erases the fusor representation of the deployment while leaving any external systems like Foreman Hosts alone.