### PR TITLE
1331556 - Filter cleartext undercloud credentials.

### DIFF
--- a/fusor-ember-cli/app/routes/openstack/undercloud-deploy.js
+++ b/fusor-ember-cli/app/routes/openstack/undercloud-deploy.js
@@ -74,9 +74,9 @@ export default Ember.Route.extend(PollingPromise, {
       url: `/fusor/api/openstack/deployments/${deploymentId}/underclouds`,
       type: 'POST',
       data: JSON.stringify({
-        'underhost': openstackDeployment.get('undercloud_ip_address'),
-        'underuser': openstackDeployment.get('undercloud_ssh_username'),
-        'underpass': openstackDeployment.get('undercloud_ssh_password'),
+        'undercloud_host': openstackDeployment.get('undercloud_ip_address'),
+        'undercloud_user': openstackDeployment.get('undercloud_ssh_username'),
+        'undercloud_password': openstackDeployment.get('undercloud_ssh_password'),
         'deployment_id': deploymentId
       }),
       headers: {

--- a/server/app/controllers/fusor/api/openstack/underclouds_controller.rb
+++ b/server/app/controllers/fusor/api/openstack/underclouds_controller.rb
@@ -27,9 +27,9 @@ module Fusor
         end
 
         def create
-          underhost = params[:underhost]
-          underuser = params[:underuser]
-          underpass = params[:underpass]
+          underhost = params[:undercloud_host]
+          underuser = params[:undercloud_user]
+          underpass = params[:undercloud_password]
 
           begin
             ssh = Net::SSH.start(underhost, underuser, :password => underpass, :timeout => 2,


### PR DESCRIPTION
Changing param name "underpass" > "undercloud_password" facilitates automatic password filtering thorugh the Rails config we already had in place.

In response to BZ 1331556.