### PR TITLE
1354551 - Subscription credentials logout now clears more info.

### DIFF
--- a/fusor-ember-cli/app/controllers/subscriptions/credentials.js
+++ b/fusor-ember-cli/app/controllers/subscriptions/credentials.js
@@ -10,7 +10,6 @@ const MirrorStatus = {
 
 export default Ember.Controller.extend(NeedsDeploymentMixin, {
 
-  deploymentId: Ember.computed.alias("deploymentController.model.id"),
   cdnUrl: Ember.computed.alias("deploymentController.model.cdn_url"),
   manifestFile: Ember.computed.alias("deploymentController.model.manifest_file"),
 

--- a/fusor-ember-cli/app/mixins/needs-deployment-mixin.js
+++ b/fusor-ember-cli/app/mixins/needs-deployment-mixin.js
@@ -10,13 +10,13 @@ export default Ember.Mixin.create({
 
   isNew: false,
 
-  deploymentName: Ember.computed.alias("deploymentController.model.name"),
-
   ////////////////////////////////////////////////////////////
   // ALIASES AND COMMONLY USED COMPUTED PROPS
   // Consolidates these and makes them available for free to any mixee
   // Prevents littering leaf controllers with duplicated aliases
   ////////////////////////////////////////////////////////////
+  deploymentId: Ember.computed.alias("deploymentController.model.id"),
+  deploymentName: Ember.computed.alias("deploymentController.model.name"),
   upstreamConsumerUuid: Ember.computed.alias(
     'deploymentController.model.upstream_consumer_uuid'),
   hasUpstreamConsumerUuid: Ember.computed('upstreamConsumerUuid', function() {

--- a/server/app/models/fusor/deployment.rb
+++ b/server/app/models/fusor/deployment.rb
@@ -48,7 +48,7 @@ module Fusor
     alias_attribute :discovered_host_id, :rhev_engine_host_id
     attr_accessor :foreman_task_id
 
-    has_many :subscriptions, :class_name => "Fusor::Subscription", :foreign_key => :deployment_id
+    has_many :subscriptions, :class_name => "Fusor::Subscription", :foreign_key => :deployment_id, dependent: :destroy
     has_many :introspection_tasks, :class_name => 'Fusor::IntrospectionTask'
 
     belongs_to :foreman_task, :class_name => "::ForemanTasks::Task", :foreign_key => :foreman_task_uuid


### PR DESCRIPTION
Subscription credentials logout now clears the session portal, clears the deployment fields, and deletes fusor subscription records associated with the deployment.  This prevents the user from progressing without re-choosing an SMA and also prevents the incorrect association of subscription info due to previous logins.