### PR TITLE
Update RHEV self-hosted engine OS 

### DIFF
--- a/server/app/lib/actions/fusor/deployment/rhev/create_engine_host_record.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/create_engine_host_record.rb
@@ -70,7 +70,7 @@ module Actions
                      "enabled" => "1",
                      "managed" => "1",
                      "architecture_id" => Architecture.find_by_name('x86_64')['id'],
-                     "operatingsystem_id" => Operatingsystem.find_by_title('RedHat 6.7')['id'],
+                     "operatingsystem_id" => Operatingsystem.find_by_title('RedHat 6.8')['id'],
                      "ptable_id" => Ptable.find { |p| p["name"] == "Kickstart default" }.id,
                      "domain_id" => 1,
                      "root_pass" => deployment.rhev_root_password,


### PR DESCRIPTION
RedHat 6.7 -> RedHat 6.8
Unbreaks RHEV Self-hosted deployments that were failing to find the 6.7 OS, due to a recent update to fusor.yaml. Longer term fix would update this automatically with fusor.yaml.