### PR TITLE
1349559 - Remove passwords from log files.

### DIFF
--- a/server/app/controllers/fusor/api/v2/deployments_controller.rb
+++ b/server/app/controllers/fusor/api/v2/deployments_controller.rb
@@ -10,6 +10,9 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
+require 'fusor/password_filter'
+require 'fusor/deployment_logger'
+
 module Fusor
   class Api::V2::DeploymentsController < Api::V2::BaseController
 
@@ -113,6 +116,11 @@ module Fusor
     def write_file(path, filename, text)
       file = "#{path}/#{filename}"
       FileUtils.rmtree(file) if File.exist?(file)
+
+      # Remove sensitive data from text being written
+      PasswordFilter.extract_deployment_passwords(@deployment)
+      text = PasswordFilter.filter_passwords(text)
+
       Fusor.log.info "====== '#{file}' ====== \n #{text}"
       begin
         File.write(file, text)

--- a/server/app/lib/actions/fusor/deployment/open_stack/add_osp_hostnames.rb
+++ b/server/app/lib/actions/fusor/deployment/open_stack/add_osp_hostnames.rb
@@ -25,7 +25,7 @@ module Actions
           end
 
           def run
-            Rails.logger.debug '====== AddOspHostnames run method ======'
+            ::Fusor.log.debug '====== AddOspHostnames run method ======'
             deployment = ::Fusor::Deployment.find(input[:deployment_id])
             openstack_deployment = deployment.openstack_deployment
             hostname_prefix = deployment.label.tr('_', '-')
@@ -41,7 +41,7 @@ module Actions
                                                :hostname => openstack_deployment.undercloud_hostname,
                                                :proxy => domain.proxy)
             undercloud.create
-            Rails.logger.debug '=== Leaving AddOspHostnames run method ==='
+            ::Fusor.log.debug '=== Leaving AddOspHostnames run method ==='
           end
 
         end

--- a/server/app/lib/fusor/resources/customer_portal.rb
+++ b/server/app/lib/fusor/resources/customer_portal.rb
@@ -17,13 +17,13 @@ module Fusor
     module CustomerPortal
       class Proxy
         def self.post(path, credentials, body)
-          Rails.logger.debug "Sending POST request to Customer Portal: #{path}"
+          ::Fusor.log.debug "Sending POST request to Customer Portal: #{path}"
           client = CustomerPortalResource.rest_client(path, credentials)
           client.post(body, { :accept => :json, :content_type => :json })
         end
 
         def self.delete(path, credentials, body = nil)
-          Rails.logger.debug "Sending DELETE request to Customer Portal: #{path}"
+          ::Fusor.log.debug "Sending DELETE request to Customer Portal: #{path}"
           client = CustomerPortalResource.rest_client(path, credentials)
           # Some candlepin calls will set the body in DELETE requests.
           client.options[:payload] = body unless body.nil?
@@ -31,7 +31,7 @@ module Fusor
         end
 
         def self.get(path, credentials)
-          Rails.logger.debug "Sending GET request to Customer Portal: #{path}"
+          ::Fusor.log.debug "Sending GET request to Customer Portal: #{path}"
           client = CustomerPortalResource.rest_client(path, credentials)
           client.get({ :accept => :json })
         end

--- a/server/app/lib/fusor/validators/deployment_validator.rb
+++ b/server/app/lib/fusor/validators/deployment_validator.rb
@@ -323,7 +323,7 @@ module Fusor
       def add_warning(deployment, warning, other_info = "")
         deployment.warnings << warning
         full_warning = other_info.blank? ? warning : "#{warning} #{other_info}"
-        Rails.logger.warn("#{full_warning}")
+        ::Fusor.log.warn("#{full_warning}")
       end
     end
   end

--- a/server/app/lib/utils/cloud_forms/add_credentials_for_hosts.rb
+++ b/server/app/lib/utils/cloud_forms/add_credentials_for_hosts.rb
@@ -15,7 +15,7 @@ module Utils
   module CloudForms
     class AddCredentialsForHosts
       def self.add(cfme_ip, deployment)
-        Rails.logger.info "Starting - Adding Host credentials to the RHEV provider at #{cfme_ip}"
+        ::Fusor.log.info "Starting - Adding Host credentials to the RHEV provider at #{cfme_ip}"
         begin
           ssh_username  = "root"
           ssh_password  = deployment.cfme_root_password
@@ -61,7 +61,7 @@ module Utils
           @io.close if @io && !@io.closed?
           fail _("Failed to add host credentials. Error message: #{e.message}")
         end
-        Rails.logger.info "Finished - Adding Host credentials to the RHEV provider at #{cfme_ip}"
+        Fusor.log.info "Finished - Adding Host credentials to the RHEV provider at #{cfme_ip}"
       end
     end
   end

--- a/server/app/lib/utils/cloud_forms/add_provider.rb
+++ b/server/app/lib/utils/cloud_forms/add_provider.rb
@@ -18,7 +18,7 @@ module Utils
   module CloudForms
     class AddProvider
       def self.add(cfme_ip, provider_params, deployment)
-        Rails.logger.debug "Adding the provider at #{provider_params[:ip]} to the CloudForms VM at #{cfme_ip}"
+        ::Fusor.log.debug "Adding the provider at #{provider_params[:ip]} to the CloudForms VM at #{cfme_ip}"
 
         data = {
           :action => "create",

--- a/server/app/lib/utils/fusor/command_utils.rb
+++ b/server/app/lib/utils/fusor/command_utils.rb
@@ -10,6 +10,7 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 require 'open3'
+require 'fusor/password_filter'
 
 module Utils
   module Fusor
@@ -29,14 +30,23 @@ module Utils
         #
         output = stdout_err.readlines
 
+        cmd_filtered = cmd
+        output_filtered = output
+
+        # run password filtering code if we're going to log something
+        if status > 0 or log_on_success
+          cmd_filtered = PasswordFilter.filter_passwords(cmd.clone)
+          output_filtered = PasswordFilter.filter_passwords(output.clone)
+        end
+
         if status > 0
-          Rails.logger.error "Error running command: #{cmd}"
-          Rails.logger.error "Status code: #{status}"
-          Rails.logger.error "Command output: #{output}"
+          ::Fusor.log.error "Error running command: #{cmd_filtered}"
+          ::Fusor.log.error "Status code: #{status}"
+          ::Fusor.log.error "Command output: #{output_filtered}"
         elsif log_on_success
-          Rails.logger.info "Command: #{cmd}"
-          Rails.logger.info "Status code: #{status}"
-          Rails.logger.info "Command output: #{output}"
+          ::Fusor.log.info "Command: #{cmd_filtered}"
+          ::Fusor.log.info "Status code: #{status}"
+          ::Fusor.log.info "Command output: #{output_filtered}"
         end
 
         # need to close these explicitly as per the docs

--- a/server/app/lib/utils/fusor/command_utils.rb
+++ b/server/app/lib/utils/fusor/command_utils.rb
@@ -34,7 +34,7 @@ module Utils
         output_filtered = output
 
         # run password filtering code if we're going to log something
-        if status > 0 or log_on_success
+        if status > 0 || log_on_success
           cmd_filtered = PasswordFilter.filter_passwords(cmd.clone)
           output_filtered = PasswordFilter.filter_passwords(output.clone)
         end

--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -382,6 +382,7 @@
   :system:
     :logging:
       :level: ":debug"
+      :show_passwords: false # show passwords in logs for non-prod environments
       :watch:
         :production:
           - :file: "/var/log/foreman/production.log"

--- a/server/lib/fusor/deployment_logger.rb
+++ b/server/lib/fusor/deployment_logger.rb
@@ -1,0 +1,28 @@
+require 'logger'
+require 'fusor/password_filter'
+
+##
+# DeploymentLogger
+# ================
+# Child of Ruby base logging class. Filters passwords from logs using context
+# provided by a Deployment object.
+#
+class DeploymentLogger < Logger
+
+  def initialize(*args, deployment)
+    super(*args)
+    if !deployment.nil?
+        PasswordFilter.extract_deployment_passwords(deployment)
+    end
+  end
+
+  def add(severity, message = nil, progname = nil)
+    if !message.nil?
+      message = PasswordFilter.filter_passwords(message.clone)
+    end
+    if !progname.nil?
+      progname = PasswordFilter.filter_passwords(progname.clone)
+    end
+    super(severity, message, progname)
+  end
+end

--- a/server/lib/fusor/deployment_logger.rb
+++ b/server/lib/fusor/deployment_logger.rb
@@ -12,7 +12,7 @@ class DeploymentLogger < Logger
   def initialize(*args, deployment)
     super(*args)
     if !deployment.nil?
-        PasswordFilter.extract_deployment_passwords(deployment)
+      PasswordFilter.extract_deployment_passwords(deployment)
     end
   end
 

--- a/server/lib/fusor/engine.rb
+++ b/server/lib/fusor/engine.rb
@@ -18,9 +18,9 @@ module Fusor
         for sil_path in silenced_paths
           ::Katello.config.logging.ignored_paths.push(sil_path)
         end
-        Rails.logger.warn "fusor_server has added '#{silenced_paths}' to 'Katello.config.logging.ignored_paths': #{::Katello.config.logging.ignored_paths}"
+        Fusor.log.warn "fusor_server has added '#{silenced_paths}' to 'Katello.config.logging.ignored_paths': #{::Katello.config.logging.ignored_paths}"
       else
-        Rails.logger.warn "fusor_server did not find 'Katello.config.logging.ignored_paths' available, skipping silence of logs for '#{silenced_paths}'"
+        Fusor.log.warn "fusor_server did not find 'Katello.config.logging.ignored_paths' available, skipping silence of logs for '#{silenced_paths}'"
       end
     end
 

--- a/server/lib/fusor/multilog.rb
+++ b/server/lib/fusor/multilog.rb
@@ -10,11 +10,11 @@ class MultiLogger
     @watchlist ||= {}
   end
 
-  # Creates and write to additional log file(s).
-  def attach(name)
+  # Creates and writes to additional log file(s).
+  def attach(name, deployment = nil)
     @logdev ||= {}
     if !name.nil? and !@logdev.key? name
-      logger = Logger.new(name)
+      logger = DeploymentLogger.new(name, deployment)
       logger.level = log_level
       @logdev[name] = logger
     end

--- a/server/lib/fusor/password_filter.rb
+++ b/server/lib/fusor/password_filter.rb
@@ -11,7 +11,7 @@ class PasswordFilter
 
   def self.extract_deployment_passwords(deployment)
     # act as passthrough (no filtering) if we're in dev/test AND show_passwords is enabled
-    if !Rails.env.production? and SETTINGS[:fusor][:system][:logging][:show_passwords]
+    if !Rails.env.production? && SETTINGS[:fusor][:system][:logging][:show_passwords]
       return nil
     end
 
@@ -23,17 +23,16 @@ class PasswordFilter
       :cfme_admin_password,
       :cfme_db_password,
       :openshift_user_password,
-      :openshift_root_password,
+      :openshift_root_password
     ]
     osp_deployment_passwords = [
       :undercloud_admin_password,
       :undercloud_ssh_password,
-      :overcloud_password,
+      :overcloud_password
     ]
 
     # get passwords from main deployment
-    extracted_passwords = Set.new
-    extracted_passwords += cautious_get_attrs(main_deployment_passwords, deployment)
+    extracted_passwords = cautious_get_attrs(main_deployment_passwords, deployment)
 
     # check if osp deployment exists, if so get passwords from it as well
     if deployment.respond_to? :openstack_deployment
@@ -41,7 +40,7 @@ class PasswordFilter
       extracted_passwords += cautious_get_attrs(osp_deployment_passwords, osp_deployment)
     end
 
-    if extracted_passwords.size > 0
+    if !extracted_passwords.empty?
       @password_cache = extracted_passwords.clone
     end
     return extracted_passwords
@@ -63,11 +62,11 @@ class PasswordFilter
 
   def self.filter_passwords(text_to_filter, passwords = nil, replacement_text = "[FILTERED]")
     # act as passthrough (no filtering) if we're in dev/test AND show_passwords is enabled
-    if !Rails.env.production? and SETTINGS[:fusor][:system][:logging][:show_passwords]
+    if !Rails.env.production? && SETTINGS[:fusor][:system][:logging][:show_passwords]
       return text_to_filter
     end
     # convert arrays etc. to strings so that gsub! is possible
-    if !text_to_filter.kind_of?(String)
+    if !text_to_filter.is_a?(String)
       text_to_filter = text_to_filter.to_s
     end
     # read from the password_cache if passwords aren't passed in
@@ -75,7 +74,7 @@ class PasswordFilter
       passwords = @password_cache
     end
     # ensure that we have a set of passwords to filter out
-    if !passwords.nil? and passwords.kind_of?(Set)
+    if !passwords.nil? and passwords.is_a?(Set)
       passwords.each do |password|
         text_to_filter.gsub!(password, replacement_text)
       end

--- a/server/lib/fusor/password_filter.rb
+++ b/server/lib/fusor/password_filter.rb
@@ -1,0 +1,85 @@
+##
+# PasswordFilter
+# ================
+# Extracts passwords from deployment objects.
+# Provides functionality for filtering sensitive data (passwords) from text.
+
+class PasswordFilter
+  def self.password_cache
+    return @password_cache
+  end
+
+  def self.extract_deployment_passwords(deployment)
+    # act as passthrough (no filtering) if we're in dev/test AND show_passwords is enabled
+    if !Rails.env.production? and SETTINGS[:fusor][:system][:logging][:show_passwords]
+      return nil
+    end
+
+    main_deployment_passwords = [
+      :rhev_engine_admin_password,
+      :rhev_root_password,
+      :rhev_gluster_root_password,
+      :cfme_root_password,
+      :cfme_admin_password,
+      :cfme_db_password,
+      :openshift_user_password,
+      :openshift_root_password,
+    ]
+    osp_deployment_passwords = [
+      :undercloud_admin_password,
+      :undercloud_ssh_password,
+      :overcloud_password,
+    ]
+
+    # get passwords from main deployment
+    extracted_passwords = Set.new
+    extracted_passwords += cautious_get_attrs(main_deployment_passwords, deployment)
+
+    # check if osp deployment exists, if so get passwords from it as well
+    if deployment.respond_to? :openstack_deployment
+      osp_deployment = deployment.send(:openstack_deployment)
+      extracted_passwords += cautious_get_attrs(osp_deployment_passwords, osp_deployment)
+    end
+
+    if extracted_passwords.size > 0
+      @password_cache = extracted_passwords.clone
+    end
+    return extracted_passwords
+  end
+
+  # cautiously gets a list of attributes from an object
+  def self.cautious_get_attrs(attr_symbols, obj_to_search)
+    attr_values = Set.new
+    attr_symbols.each do |attr_symbol|
+      if obj_to_search.respond_to?(attr_symbol)
+        attr_value = obj_to_search.send(attr_symbol)
+        if !attr_value.nil?
+          attr_values.add(attr_value)
+        end
+      end
+    end
+    return attr_values
+  end
+
+  def self.filter_passwords(text_to_filter, passwords = nil, replacement_text = "[FILTERED]")
+    # act as passthrough (no filtering) if we're in dev/test AND show_passwords is enabled
+    if !Rails.env.production? and SETTINGS[:fusor][:system][:logging][:show_passwords]
+      return text_to_filter
+    end
+    # convert arrays etc. to strings so that gsub! is possible
+    if !text_to_filter.kind_of?(String)
+      text_to_filter = text_to_filter.to_s
+    end
+    # read from the password_cache if passwords aren't passed in
+    if passwords.nil? and !@password_cache.nil?
+      passwords = @password_cache
+    end
+    # ensure that we have a set of passwords to filter out
+    if !passwords.nil? and passwords.kind_of?(Set)
+      passwords.each do |password|
+        text_to_filter.gsub!(password, replacement_text)
+      end
+    end
+    return text_to_filter
+  end
+end

--- a/server/lib/init_log.rb
+++ b/server/lib/init_log.rb
@@ -16,7 +16,7 @@ module Fusor
       log.attach(@default_log_file)
     else
       FileUtils.mkdir_p(self.log_file_dir(deployment.label, deployment.id)) unless File.exist?(self.log_file_dir(deployment.label, deployment.id))
-      log.attach(self.log_file_path(deployment.label, deployment.id))
+      log.attach(self.log_file_path(deployment.label, deployment.id), deployment)
     end
   end
 

--- a/server/test/fixtures/fusor_deployments.yml
+++ b/server/test/fixtures/fusor_deployments.yml
@@ -58,6 +58,28 @@ rhev_and_cfme:
   upstream_consumer_uuid: 1
   organization_id: 1
 
+rhev_and_cfme_different_passwords:
+  rhev_root_password: redhat1234
+  rhev_engine_admin_password: redhat1234
+  rhev_is_self_hosted: false
+  rhev_share_path: /storage/rhev_storage
+  rhev_storage_address: 10.13.129.106
+  rhev_storage_type: NFS
+  rhev_engine_host: engine3
+  deploy_openstack: false
+  deploy_cfme: true
+  deploy_rhev: true
+  name: rhev_and_cfme
+  label: rhev_and_cfme
+  organization: empty_organization
+  cfme_root_password: redhat4321
+  cfme_db_password: redhat4321
+  cfme_admin_password: redhat4321
+  cfme_install_loc: RHEV
+  lifecycle_environment: library
+  upstream_consumer_uuid: 1
+  organization_id: 1
+
 rhev_self_hosted:
   rhev_root_password: redhat1234
   rhev_engine_admin_password: redhat1234
@@ -72,6 +94,24 @@ rhev_self_hosted:
   deploy_rhev: true
   name: rhev_self_hosted
   label: rhev_self_hosted
+  organization: empty_organization
+  lifecycle_environment: library
+  upstream_consumer_uuid: 1
+  organization_id: 1
+
+rhev_different_passwords:
+  rhev_root_password: redhat1234
+  rhev_engine_admin_password: redhat4321
+  rhev_is_self_hosted: false
+  rhev_share_path: /storage/rhev_storage
+  rhev_storage_address: 10.13.129.106
+  rhev_storage_type: NFS
+  rhev_engine_host: engine1
+  deploy_openstack: false
+  deploy_cfme: false
+  deploy_rhev: true
+  name: rhev
+  label: rhev
   organization: empty_organization
   lifecycle_environment: library
   upstream_consumer_uuid: 1

--- a/server/test/fixtures/fusor_deployments.yml
+++ b/server/test/fixtures/fusor_deployments.yml
@@ -110,8 +110,8 @@ rhev_different_passwords:
   deploy_openstack: false
   deploy_cfme: false
   deploy_rhev: true
-  name: rhev
-  label: rhev
+  name: rhev_different_passwords
+  label: rhev_different_passwords
   organization: empty_organization
   lifecycle_environment: library
   upstream_consumer_uuid: 1

--- a/server/test/lib/utils/fusor/password_filter_test.rb
+++ b/server/test/lib/utils/fusor/password_filter_test.rb
@@ -1,0 +1,144 @@
+require 'set'
+require 'test_plugin_helper'
+require 'fusor/password_filter'
+
+class PasswordFilterTest < ActiveSupport::TestCase
+  def assert_passwords_match_expections(expected_passwords, passwords, passwords_cached)
+    # assert password set sizes match
+    assert passwords.size == expected_passwords.size,
+      "passwords.size(#{passwords.size}) != expected_passwords.size(#{expected_passwords.size})"
+    assert passwords_cached.size == expected_passwords.size,
+      "passwords_cached.size(#{passwords.size}) != expected_passwords.size(#{expected_passwords.size})"
+
+    # assert that all expected passwords are present
+    expected_passwords.each do |expected_password|
+      assert passwords.include?(expected_password),
+        "expected_password(#{expected_password}) not found in passwords(#{passwords})"
+      assert passwords_cached.include?(expected_password),
+        "expected_password(#{expected_password}) not found in passwords_cache(#{passwords_cached})"
+    end
+  end
+
+  test "In production env, PasswordFilter should extract all RHEV passwords and cache them." do
+    # extracting: rhev_engine_admin_password, rhev_root_password
+    Rails.env = "production"
+
+    # stage 1: grab deployment record for a rhev deployment with a single password.
+    deployment_rhev = fusor_deployments(:rhev)
+    expected_passwords = [
+      "redhat1234"
+    ]
+    password_set = PasswordFilter.extract_deployment_passwords(deployment_rhev)
+    assert_passwords_match_expections(expected_passwords, password_set, PasswordFilter.password_cache)
+
+    # stage 2: grab deployment record for a rhev deployment with two passwords
+    deployment_rhev = fusor_deployments(:rhev_different_passwords)
+    expected_passwords = [
+      "redhat1234",
+      "redhat4321"
+    ]
+    password_set = PasswordFilter.extract_deployment_passwords(deployment_rhev)
+    assert_passwords_match_expections(expected_passwords, password_set, PasswordFilter.password_cache)
+  end
+
+  test "In production env, PasswordFilter should extract all RHEV+CFME passwords and cache them." do
+    # extracting: rhev_engine_admin_password, rhev_root_password
+    #             cfme_root_password, cfme_admin_password, cfme_db_password
+    Rails.env = "production"
+
+    # stage 1: grab deployment record for a rhev/cfme deploy with two passwords
+    deployment_rhev_cfme = fusor_deployments(:rhev_and_cfme_different_passwords)
+
+    expected_passwords = [
+      "redhat1234",
+      "redhat4321"
+    ]
+    password_set = PasswordFilter.extract_deployment_passwords(deployment_rhev_cfme)
+    assert_passwords_match_expections(expected_passwords, password_set, PasswordFilter.password_cache)
+  end
+
+  test "In production env, PasswordFilter should extract all RHEV+CFME+OSP passwords and cache them." do
+    # extracting: rhev_engine_admin_password, rhev_root_password
+    #             cfme_root_password, cfme_admin_password, cfme_db_password
+    #             undercloud_admin_password, undercloud_ssh_password, overcloud_password
+    Rails.env = "production"
+
+    # stage 1: grab deployment record for rhev+cfme, and an osp deployment record
+    deployment_rhev_cfme_osp = fusor_deployments(:rhev_and_cfme_different_passwords)
+    deployment_osp = fusor_openstack_deployments(:osp)
+
+    # attach osp deployment to base deployment object
+    deployment_rhev_cfme_osp.openstack_deployment = deployment_osp
+
+    expected_passwords = [
+      "undercloudAdminPassword",
+      "undercloudSshPassword1234",
+      "overcloudAdminPassword",
+      "redhat1234",
+      "redhat4321"
+    ]
+    password_set = PasswordFilter.extract_deployment_passwords(deployment_rhev_cfme_osp)
+    assert_passwords_match_expections(expected_passwords, password_set, PasswordFilter.password_cache)
+  end
+
+  test "In production env, PasswordFilter should cache passwords and be able to use them for filtering." do
+    # extracting: rhev_engine_admin_password, rhev_root_password
+    Rails.env = "production"
+
+    # stage 1: grab deployment record for a rhev deployment with a single password.
+    deployment_rhev = fusor_deployments(:rhev)
+
+    expected_passwords = [
+      "redhat1234"
+    ]
+    password_set = PasswordFilter.extract_deployment_passwords(deployment_rhev)
+    assert_passwords_match_expections(expected_passwords, password_set, PasswordFilter.password_cache)
+
+    # stage 2: run extract_deployment_passwords with a nil deployment and verify cache remains
+    password_set = PasswordFilter.extract_deployment_passwords(nil)
+    assert password_set.size == 0
+    assert PasswordFilter.password_cache.size == 1
+  end
+
+
+  test "In production env, PasswordFilter.filter_passwords should accept a custom password Set." do
+    # extracting: rhev_engine_admin_password, rhev_root_password
+    Rails.env = "production"
+
+    # stage 1: ensure the filtering function works on a manually defined password set
+    custom_password_set = Set.new
+    custom_password_set.add("redhat1234")
+    custom_password_set.add("redhat4321")
+    custom_password_array = custom_password_set.to_a
+    text_to_filter = "ERROR: About to show passwords. #{custom_password_array[0]} and #{custom_password_array[1]}"
+    filtered_text = PasswordFilter.filter_passwords(text_to_filter, custom_password_set)
+
+    assert !filtered_text.include?(custom_password_array[0])
+    assert !filtered_text.include?(custom_password_array[1])
+
+    deployment_rhev = fusor_deployments(:rhev)
+  end
+
+
+  test "In development with force_show_passwords on, PasswordFilter should act as passthrough." do
+    Rails.env = "development"
+
+    # stage 1: grab deployment record for a rhev deployment with a single password.
+    deployment_rhev = fusor_deployments(:rhev)
+    expected_passwords = [
+      "redhat1234"
+    ]
+    password_set = PasswordFilter.extract_deployment_passwords(deployment_rhev)
+
+    if SETTINGS[:fusor][:system][:logging][:show_passwords]
+      assert password_set.nil?
+    elsif
+      assert password_set.size == 1
+    end
+  end
+
+
+  after do
+    Rails.env = "test"
+  end
+end

--- a/server/test/lib/utils/fusor/password_filter_test.rb
+++ b/server/test/lib/utils/fusor/password_filter_test.rb
@@ -115,8 +115,6 @@ class PasswordFilterTest < ActiveSupport::TestCase
 
     assert !filtered_text.include?(custom_password_array[0])
     assert !filtered_text.include?(custom_password_array[1])
-
-    deployment_rhev = fusor_deployments(:rhev)
   end
 
 
@@ -125,14 +123,11 @@ class PasswordFilterTest < ActiveSupport::TestCase
 
     # stage 1: grab deployment record for a rhev deployment with a single password.
     deployment_rhev = fusor_deployments(:rhev)
-    expected_passwords = [
-      "redhat1234"
-    ]
     password_set = PasswordFilter.extract_deployment_passwords(deployment_rhev)
 
     if SETTINGS[:fusor][:system][:logging][:show_passwords]
       assert password_set.nil?
-    elsif
+    else
       assert password_set.size == 1
     end
   end


### PR DESCRIPTION
Made Fusor.log context-aware to the current deployment in order to provide password filtering functionality from all logs. Added optional switch to enabled password output while in dev environment. 

Passwords will always be automatically filtered in production.

Tested with RHEV deploy and RHEV + OSP8 deploy.

Response to BZ 1349559.