### PR TITLE
1357484 - Consolidate messages in '1B. Update Availability'

### DIFF
--- a/fusor-ember-cli/app/controllers/configure-environment.js
+++ b/fusor-ember-cli/app/controllers/configure-environment.js
@@ -43,10 +43,13 @@ export default Ember.Controller.extend(ConfigureEnvironmentMixin, NeedsDeploymen
       this.set('showAlertMessage', false);
       this.set('selectedEnvironment', environment);
       this.get('deploymentController.model').set('lifecycle_environment', environment);
+      this.get('deploymentController').set('errorMsg', null);
+      this.set('errorMsg', null);
     },
 
     createEnvironment(fields_env) {
       var self = this;
+      this.set('showAlertMessage', false);
 
       var nameAlreadyExists =  self.get('lifecycleEnvironments').findBy('name', fields_env.name);
       if (nameAlreadyExists) {
@@ -69,7 +72,9 @@ export default Ember.Controller.extend(ConfigureEnvironmentMixin, NeedsDeploymen
         self.get('deploymentController').set('errorMsg', null);
         self.set('showAlertMessage', true);
       }, function(error) {
-        self.get('deploymentController').set('errorMsg', 'error saving environment' + error);
+        let errorMsg = 'error saving environment' + error;
+        self.get('deploymentController').set('errorMsg', errorMsg);
+        self.set('errorMsg', errorMsg);
       });
 
     }

--- a/fusor-ember-cli/app/mixins/configure-environment-mixin.js
+++ b/fusor-ember-cli/app/mixins/configure-environment-mixin.js
@@ -48,6 +48,7 @@ export default Ember.Mixin.create(NeedsDeploymentMixin, {
     newEnvironment() {
       this.set('name', null);
       this.set('description', null);
+      this.set('showValidationError', false);
       this.set('openModal', true);
     }
   }

--- a/fusor-ember-cli/app/templates/components/new-environment-modal.hbs
+++ b/fusor-ember-cli/app/templates/components/new-environment-modal.hbs
@@ -5,6 +5,7 @@
       {{#pf-modal-body}}
             {{text-f label="Environment Name"
                      value=name
+                     showValidationError=showValidationError
                      validator=envNameValidator
                      labelSize='col-md-4'
                      inputSize='col-md-8'}}

--- a/fusor-ember-cli/app/templates/configure-environment.hbs
+++ b/fusor-ember-cli/app/templates/configure-environment.hbs
@@ -95,11 +95,13 @@
       {{/each}}
     {{/if}}
 
-    <div style='margin-top:15px;'>
+    <div style='margin:15px 0px;'>
       <button class="btn btn-default" {{action 'newEnvironment'}} disabled={{isStarted}}>
         New Environment Path
       </button>
     </div>
+
+    {{error-message errorMsg=errorMsg}}
 
   </div>
 </div>
@@ -110,6 +112,7 @@
 
 
 {{new-environment-modal openModal=openModal
+                        showValidationError=showValidationError
                         createEnvironment='createEnvironment'
                         name=name
                         envNameValidator=envNameValidator


### PR DESCRIPTION
* remove 1st success message upon creating 2nd lifecycle environment
* remove success or error messages upon selecting different lifecycle environment
* create error message under "New Environment Path" so user doesn't need to scroll up
* remove validation error 'This field cannot be blank' in modal upon entering 2nd lifecycle environment