### PR TITLE
1353236 - Updated RHEV > RHV in Web UI

### DIFF
--- a/fusor-ember-cli/app/mixins/deployment-controller-mixin.js
+++ b/fusor-ember-cli/app/mixins/deployment-controller-mixin.js
@@ -45,7 +45,7 @@ export default Ember.Mixin.create({
   }),
 
   nameRhev: Ember.computed('isUpstream', function() {
-    if (this.get('isUpstream')) { return "oVirt"; } else { return "RHEV"; }
+    if (this.get('isUpstream')) { return "oVirt"; } else { return "RHV"; }
   }),
 
   nameOpenStack: Ember.computed('isUpstream', function() {
@@ -59,7 +59,7 @@ export default Ember.Mixin.create({
   nameOpenShift: "OpenShift",
 
   fullnameRhev: Ember.computed('isUpstream', function() {
-    if (this.get('isUpstream')) { return "oVirt Project"; } else { return "Red Hat Enterprise Virtualization"; }
+    if (this.get('isUpstream')) { return "oVirt Project"; } else { return "Red Hat Virtualization"; }
   }),
 
   fullnameOpenStack: Ember.computed('isUpstream', function() {

--- a/fusor-ember-cli/app/mixins/start-controller-mixin.js
+++ b/fusor-ember-cli/app/mixins/start-controller-mixin.js
@@ -31,7 +31,7 @@ export default Ember.Mixin.create({
   }),
 
   nameRhev: Ember.computed('isUpstream', function() {
-    if (this.get('isUpstream')) { return "oVirt"; } else { return "RHEV"; }
+    if (this.get('isUpstream')) { return "oVirt"; } else { return "RHV"; }
   }),
 
   nameOpenStack: Ember.computed('isUpstream', function() {
@@ -46,7 +46,7 @@ export default Ember.Mixin.create({
 
   // TODO DRY names mixins
   fullnameRhev: Ember.computed('isUpstream', function() {
-    if (this.get('isUpstream')) { return "oVirt Project"; } else { return "Red Hat Enterprise Virtualization"; }
+    if (this.get('isUpstream')) { return "oVirt Project"; } else { return "Red Hat Virtualization"; }
   }),
 
   fullnameOpenStack: Ember.computed('isUpstream', function() {

--- a/fusor-ember-cli/app/templates/req-rhev.hbs
+++ b/fusor-ember-cli/app/templates/req-rhev.hbs
@@ -1,6 +1,6 @@
 <div class='req-section'>
 
-  <p class='req-title'>Red Hat Enterprise Virtualization</p>
+  <p class='req-title'>Red Hat Virtualization</p>
 
   Engine + Hypervisor
   <ul class='req-list'>

--- a/fusor-ember-cli/app/templates/satellite/index.hbs
+++ b/fusor-ember-cli/app/templates/satellite/index.hbs
@@ -12,7 +12,7 @@
           Optionally enter a password that the installer will use to pre-populate values for:<br />
           <ul class='common-password'>
             {{#if isRhev}}
-              <li>RHEV root and engine</li>
+              <li>RHV root and engine</li>
             {{/if}}
             {{#if isOpenStack}}
               <li>RHELOSP overcloud admin</li>

--- a/fusor-ember-cli/app/templates/where-install.hbs
+++ b/fusor-ember-cli/app/templates/where-install.hbs
@@ -8,7 +8,7 @@
     <div class='ident-radio'>
       {{#radio-button value="RHEV" groupValue=cfmeInstallLoc changed="cfmeLocationChanged" id="install_on_rhev" disabled=disableRHEVradio dataQci="rhevCfmeInstallLoc"}}
         <span class="{{if disableRHEV 'disabled'}}">
-          Install CloudForms on Red Hat Enterprise Virtualization
+          Install CloudForms on Red Hat Virtualization
         </span>
       {{/radio-button}}
     </div>

--- a/ui/public/fusor_ui/files/QCI_Requirements.txt
+++ b/ui/public/fusor_ui/files/QCI_Requirements.txt
@@ -11,7 +11,7 @@ If you are deploying into an environment that does not have external network acc
 - URL to an alternate repository to download content from
 - Subscription manifest. For more information about obtaining a manifest, see https://access.redhat.com/solutions/118573
 
-Red Hat Enterprise Virtualization
+Red Hat Virtualization
 Engine + Hypervisor
 - 2 hosts (1 for engine, 1 for hypervisor). Engine host requires 10GB disk space, 2GB RAM, and 1 CPU. Hypervisor host requires 10GB disk space, 12GB RAM, and 4 CPUs
 - All host hardware clocks are synchronized with the hardware clock on the Satellite system


### PR DESCRIPTION
Renamed "RHEV" > "RHV" and "Red Hat Enterprise Virtualization" > "Red Hat Virtualization" in WebUI. 
Didn't touch method names, DynFlow task names, repo names, log message contents.