### PR TITLE
1356080 - Deployment reset between self-hosted & standard RHEV

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,10 @@ AllCops:
   Exclude:
     - 'fusor-ember-cli/**/*'
 
+Metrics/ClassLength:
+  Exclude:
+    - 'server/app/controllers/fusor/api/v21/deployments_controller.rb'
+
 #MethodLength:
   #Description: 'Avoid methods longer than 30 lines of code.'
   #Max: 30 # default is 10

--- a/fusor-ember-cli/app/controllers/rhev-setup.js
+++ b/fusor-ember-cli/app/controllers/rhev-setup.js
@@ -49,8 +49,6 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, NeedsDiscoveredHost
     return deployment
       .save()
       .then(() => this.postDiscoveredHostIds(deployment, []))
-      .then(() => deployment.loadOpenshiftDefaults({reset: true}))
-      .then(() => deployment.loadCloudformsDefaults({reset: true}));
+      .then(() => this.send('loadDefaultData', deployment, {reset: true}));
   }
-
 });

--- a/fusor-ember-cli/app/controllers/rhev-setup.js
+++ b/fusor-ember-cli/app/controllers/rhev-setup.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
 import NeedsDeploymentMixin from "../mixins/needs-deployment-mixin";
+import NeedsDiscoveredHostsAjax from '../mixins/needs-discovered-hosts-ajax';
 
-export default Ember.Controller.extend(NeedsDeploymentMixin, {
+export default Ember.Controller.extend(NeedsDeploymentMixin, NeedsDiscoveredHostsAjax, {
 
   rhevIsSelfHosted: Ember.computed.alias("deploymentController.model.rhev_is_self_hosted"),
 
@@ -27,8 +28,29 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
 
   actions: {
     rhevSetupChanged() {
-      this.get('deploymentController').set('model.rhev_is_self_hosted', this.get('isSelfHosted'));
+      this.get('deploymentController').set(
+        'model.rhev_is_self_hosted',
+        this.get('isSelfHosted')
+      );
+
+      // Changing from self-hosted to hv+engine setup needs to reset
+      // host associations to a clean slate.
+      this.resetEngineAndHypervisors().catch(err => {
+        console.log('Error occurred while resetting engine and hypervisors');
+        console.log(err);
+      });
     }
+  },
+
+  resetEngineAndHypervisors() {
+    const deployment = this.get('deploymentController.model');
+
+    deployment.set('discovered_host', null); // Engine reset
+    return deployment
+      .save()
+      .then(() => this.postDiscoveredHostIds(deployment, []))
+      .then(() => deployment.loadOpenshiftDefaults({reset: true}))
+      .then(() => deployment.loadCloudformsDefaults({reset: true}));
   }
 
 });

--- a/fusor-ember-cli/app/mixins/needs-discovered-hosts-ajax.js
+++ b/fusor-ember-cli/app/mixins/needs-discovered-hosts-ajax.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+import request from 'ic-ajax';
+
+export default Ember.Mixin.create({
+  postDiscoveredHostIds(deployment, hypervisorIds) {
+    const token = Ember.$('meta[name="csrf-token"]').attr('content');
+    return request({
+      url: '/fusor/api/v21/deployments/' + deployment.get('id'),
+      type: 'PUT',
+      data: JSON.stringify({'deployment': { 'discovered_host_ids': hypervisorIds } }),
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': token
+      }
+    }).then(() => deployment.reload()); // Reload to update models
+  }
+});

--- a/fusor-ember-cli/app/models/deployment.js
+++ b/fusor-ember-cli/app/models/deployment.js
@@ -211,57 +211,47 @@ export default DS.Model.extend(UsesOseDefaults, {
     }
   },
 
-  loadOpenshiftDefaults(opt) {
-    const shouldReset = opt && (opt.reset || false);
-
+  loadOpenshiftDefaults(settings, opt) {
     if (this.get('deploy_openshift')) {
-      return request('/api/v2/settings?search=openshift').then(settings => {
-        const results = settings['results'];
+      const shouldReset = opt && (opt.reset || false);
 
-        [
-          'openshift_master_vcpu',
-          'openshift_master_ram',
-          'openshift_master_disk',
-          'openshift_node_vcpu',
-          'openshift_node_ram',
-          'openshift_node_disk'
-        ].forEach(prop => {
-          this.handleReset(shouldReset, prop);
-          this.setOpenshiftDefault(
-            prop, results.findBy('name', prop).value);
-        });
-
-        this.handleReset(shouldReset, 'openshift_number_master_nodes');
-        this.handleReset(shouldReset, 'openshift_number_worker_nodes');
-        this.handleReset(shouldReset, 'openshift_storage_size');
-
+      [
+        'openshift_master_vcpu',
+        'openshift_master_ram',
+        'openshift_master_disk',
+        'openshift_node_vcpu',
+        'openshift_node_ram',
+        'openshift_node_disk'
+      ].forEach(prop => {
+        this.handleReset(shouldReset, prop);
         this.setOpenshiftDefault(
-          'openshift_number_master_nodes', 1);
-        this.setOpenshiftDefault(
-          'openshift_number_worker_nodes', 1);
-        this.setOpenshiftDefault(
-          'openshift_storage_size', 30);
+          prop, settings.findBy('name', prop).value);
       });
+
+      this.handleReset(shouldReset, 'openshift_number_master_nodes');
+      this.handleReset(shouldReset, 'openshift_number_worker_nodes');
+      this.handleReset(shouldReset, 'openshift_storage_size');
+
+      this.setOpenshiftDefault(
+        'openshift_number_master_nodes', 1);
+      this.setOpenshiftDefault(
+        'openshift_number_worker_nodes', 1);
+      this.setOpenshiftDefault(
+        'openshift_storage_size', 30);
     }
   },
 
-  loadCloudformsDefaults(opt) {
-    const shouldReset = opt && (opt.reset || false);
-
-    // GET from API v2 CFME settings for Foreman/Sat6 - if CFME is selected
+  loadCloudformsDefaults(settings, opt) {
     if (this.get('deploy_cfme')) {
-      return request('/api/v2/settings?search=cloudforms').then((settings) => {
-        // overwrite values for deployment since Sat6 settings is only place to change CFME VM requirements
-        const results = settings['results'];
+      const shouldReset = opt && (opt.reset || false);
 
-        [
-          'cloudforms_vcpu',
-          'cloudforms_ram',
-          'cloudforms_vm_disk_size',
-          'cloudforms_db_disk_size'
-        ].forEach(prop => {
-          this.set(prop, results.findBy('name', prop).value);
-        });
+      [
+        'cloudforms_vcpu',
+        'cloudforms_ram',
+        'cloudforms_vm_disk_size',
+        'cloudforms_db_disk_size'
+      ].forEach(prop => {
+        this.set(prop, settings.findBy('name', prop).value);
       });
     }
   }

--- a/fusor-ember-cli/app/routes/deployment.js
+++ b/fusor-ember-cli/app/routes/deployment.js
@@ -24,11 +24,10 @@ export default Ember.Route.extend(DeploymentRouteMixin, {
       }
     });
 
-    model.loadOpenshiftDefaults();
-    model.loadCloudformsDefaults();
-
     this.loadDefaultDomainName(controller);
     this.loadUpstreamConsumer(controller, model);
+
+    this.loadDefaultData(model);
   },
 
   loadDefaultDomainName(controller) {
@@ -52,6 +51,17 @@ export default Ember.Route.extend(DeploymentRouteMixin, {
         controller.set('model.upstream_consumer_name', results.owner_details.upstreamConsumer.name);
       }
     });
+  },
+
+  loadDefaultData(model, opt) {
+    Ember.RSVP.all([
+      request('/api/v2/settings?search=openshift').then(settings => {
+        model.loadOpenshiftDefaults(settings['results'], opt);
+      }),
+      request('/api/v2/settings?search=cloudforms').then(settings => {
+        model.loadCloudformsDefaults(settings['results'], opt);
+      })
+    ]);
   },
 
   actions: {
@@ -189,6 +199,10 @@ export default Ember.Route.extend(DeploymentRouteMixin, {
     refreshModel() {
       console.log('refreshModelOnDeploymentRoute');
       return this.refresh();
+    },
+
+    loadDefaultData(model, opt) {
+      this.loadDefaultData(model, opt);
     }
   }
 });

--- a/fusor-ember-cli/app/routes/deployment.js
+++ b/fusor-ember-cli/app/routes/deployment.js
@@ -1,9 +1,8 @@
 import Ember from 'ember';
 import DeploymentRouteMixin from '../mixins/deployment-route-mixin';
-import UsesOseDefaults from '../mixins/uses-ose-defaults';
 import request from 'ic-ajax';
 
-export default Ember.Route.extend(DeploymentRouteMixin, UsesOseDefaults, {
+export default Ember.Route.extend(DeploymentRouteMixin, {
 
   model(params) {
     return this.store.findRecord('deployment', params.deployment_id);
@@ -25,8 +24,9 @@ export default Ember.Route.extend(DeploymentRouteMixin, UsesOseDefaults, {
       }
     });
 
-    this.loadOpenshiftDefaults(controller, model);
-    this.loadCloudFormsDefaults(controller, model);
+    model.loadOpenshiftDefaults();
+    model.loadCloudformsDefaults();
+
     this.loadDefaultDomainName(controller);
     this.loadUpstreamConsumer(controller, model);
   },
@@ -52,60 +52,6 @@ export default Ember.Route.extend(DeploymentRouteMixin, UsesOseDefaults, {
         controller.set('model.upstream_consumer_name', results.owner_details.upstreamConsumer.name);
       }
     });
-  },
-
-  loadCloudFormsDefaults(controller, model) {
-    // GET from API v2 CFME settings for Foreman/Sat6 - if CFME is selected
-    if (model.get('deploy_cfme')) {
-      request('/api/v2/settings?search=cloudforms').then(function(settings) {
-        var results = settings['results'];
-        // overwrite values for deployment since Sat6 settings is only place to change CFME VM requirements
-        model.set('cloudforms_vcpu', results.findBy('name', 'cloudforms_vcpu').value);
-        model.set('cloudforms_ram', results.findBy('name', 'cloudforms_ram').value);
-        model.set('cloudforms_vm_disk_size', results.findBy('name', 'cloudforms_vm_disk_size').value);
-        model.set('cloudforms_db_disk_size', results.findBy('name', 'cloudforms_db_disk_size').value);
-      });
-    }
-  },
-
-  loadOpenshiftDefaults(controller, model) {
-    // GET from API v2 OSE settings for Foreman/Sat6
-
-    if (model.get('deploy_openshift')) {
-      request('/api/v2/settings?search=openshift').then(settings => {
-        var results = settings['results'];
-        if (this.shouldUseOseDefault(model.get('openshift_master_vcpu'))) {
-          model.set('openshift_master_vcpu', results.findBy('name', 'openshift_master_vcpu').value);
-        }
-        if (this.shouldUseOseDefault(model.get('openshift_master_ram'))) {
-          model.set('openshift_master_ram', results.findBy('name', 'openshift_master_ram').value);
-        }
-        if (this.shouldUseOseDefault(model.get('openshift_master_disk'))) {
-          model.set('openshift_master_disk', results.findBy('name', 'openshift_master_disk').value);
-        }
-        if (this.shouldUseOseDefault(model.get('openshift_node_vcpu'))) {
-          model.set('openshift_node_vcpu', results.findBy('name', 'openshift_node_vcpu').value);
-        }
-        if (this.shouldUseOseDefault(model.get('openshift_node_ram'))) {
-          model.set('openshift_node_ram', results.findBy('name', 'openshift_node_ram').value);
-        }
-        if (this.shouldUseOseDefault(model.get('openshift_node_disk'))) {
-          model.set('openshift_node_disk', results.findBy('name', 'openshift_node_disk').value);
-        }
-      });
-
-      // set default values 1 Master, 1 Worker, 30GB storage for OSE
-      if (this.shouldUseOseDefault(model.get('openshift_number_master_nodes'))) {
-        model.set('openshift_number_master_nodes', 1);
-      }
-      if (this.shouldUseOseDefault(model.get('openshift_number_worker_nodes'))) {
-        model.set('openshift_number_worker_nodes', 1);
-      }
-      if (this.shouldUseOseDefault(model.get('openshift_storage_size'))) {
-        model.set('openshift_storage_size', 30);
-      }
-
-    }
   },
 
   actions: {

--- a/fusor-ember-cli/app/routes/hypervisor/discovered-host.js
+++ b/fusor-ember-cli/app/routes/hypervisor/discovered-host.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
-import DiscoveredHostRouteMixin from "../../mixins/discovered-host-route-mixin";
-import request from 'ic-ajax';
+import DiscoveredHostRouteMixin from '../../mixins/discovered-host-route-mixin';
+import NeedsDiscoveredHostsAjax from '../../mixins/needs-discovered-hosts-ajax';
 
-export default Ember.Route.extend(DiscoveredHostRouteMixin, {
+export default Ember.Route.extend(DiscoveredHostRouteMixin, NeedsDiscoveredHostsAjax, {
   model() {
     return this.modelFor('deployment').get('discovered_hosts');
   },
@@ -13,29 +13,17 @@ export default Ember.Route.extend(DiscoveredHostRouteMixin, {
 
   actions: {
     saveHyperVisors(redirectPath) {
-      var self = this;
       var deployment = this.modelFor('deployment');
-      var hypervisorModelIds = this.controllerFor('hypervisor/discovered-host').get('hypervisorModelIds');
-      var token = Ember.$('meta[name="csrf-token"]').attr('content');
+      var hypervisorModelIds = this.controllerFor('hypervisor/discovered-host')
+        .get('hypervisorModelIds');
 
-      request({
-        url: '/fusor/api/v21/deployments/' + deployment.get('id'),
-        type: "PUT",
-        data: JSON.stringify({'deployment': { 'discovered_host_ids': hypervisorModelIds } }),
-        headers: {
-          "Accept": "application/json",
-          "Content-Type": "application/json",
-          "X-CSRF-Token": token,
-          "Authorization": "Basic " + self.get('session.basicAuthToken')
-        }
-      }).then(function(response) {
+      this.postDiscoveredHostIds(deployment, hypervisorModelIds).then(() => {
         if (redirectPath) {
-          self.transitionTo('rhev-options');
+          this.transitionTo('rhev-options');
         }
-      }, function(error) {
-        console.log(error);
+      }).catch(err => {
+        console.log(err);
       });
     }
   }
-
 });

--- a/server/app/controllers/fusor/api/v21/deployments_controller.rb
+++ b/server/app/controllers/fusor/api/v21/deployments_controller.rb
@@ -247,7 +247,7 @@ module Fusor
       end
       #############################################################
 
-      params.require(:deployment).permit(allowed)
+      params.require(:deployment).permit(*allowed)
     end
 
     def find_deployment

--- a/server/app/controllers/fusor/api/v21/deployments_controller.rb
+++ b/server/app/controllers/fusor/api/v21/deployments_controller.rb
@@ -206,31 +206,48 @@ module Fusor
     private
 
     def deployment_params
-      params.require(:deployment).permit(:name, :description, :deploy_rhev, :deploy_cfme,
-                                         :deploy_openstack, :deploy_openshift, :is_disconnected, :rhev_is_self_hosted,
-                                         :rhev_engine_admin_password, :rhev_data_center_name,
-                                         :rhev_cluster_name, :rhev_storage_name, :rhev_storage_type,
-                                         :rhev_storage_address, :rhev_cpu_type, :rhev_share_path,
-                                         :hosted_storage_name, :hosted_storage_address, :hosted_storage_path,
-                                         :cfme_install_loc, :rhev_root_password, :cfme_root_password,
-                                         :cfme_admin_password, :cfme_db_password, :foreman_task_uuid,
-                                         :upstream_consumer_uuid, :upstream_consumer_name, :rhev_export_domain_name,
-                                         :rhev_export_domain_address, :rhev_export_domain_path,
-                                         :rhev_local_storage_path, :rhev_gluster_node_name,
-                                         :rhev_gluster_node_address, :rhev_gluster_ssh_port,
-                                         :rhev_gluster_root_password, :host_naming_scheme, :has_content_error,
-                                         :custom_preprend_name, :enable_access_insights, :cfme_address, :cfme_hostname,
-                                         :openshift_install_loc, :openshift_number_master_nodes, :openshift_number_worker_nodes,
-                                         :openshift_storage_size, :openshift_username, :openshift_user_password,
-                                         :openshift_root_password, :openshift_master_vcpu, :openshift_master_ram,
-                                         :openshift_master_disk, :openshift_node_vcpu, :openshift_node_ram, :openshift_node_disk,
-                                         :openshift_available_vcpu, :openshift_available_ram, :openshift_available_disk,
-                                         :openshift_storage_type, :openshift_sample_helloworld, :openshift_storage_host,
-                                         :openshift_export_path, :openshift_subdomain_name, :cloudforms_vcpu,
-                                         :cloudforms_ram, :cloudforms_vm_disk_size, :cloudforms_db_disk_size,
-                                         :cdn_url, :manifest_file, :created_at, :updated_at, :rhev_engine_host_id,
-                                         :organization_id, :lifecycle_environment_id, :discovered_host_id,
-                                         :foreman_task_id, :openstack_deployment_id, :discovered_host_ids => [])
+      allowed = [
+        :name, :description, :deploy_rhev, :deploy_cfme,
+        :deploy_openstack, :deploy_openshift, :is_disconnected, :rhev_is_self_hosted,
+        :rhev_engine_admin_password, :rhev_data_center_name,
+        :rhev_cluster_name, :rhev_storage_name, :rhev_storage_type,
+        :rhev_storage_address, :rhev_cpu_type, :rhev_share_path,
+        :hosted_storage_name, :hosted_storage_address, :hosted_storage_path,
+        :cfme_install_loc, :rhev_root_password, :cfme_root_password,
+        :cfme_admin_password, :cfme_db_password, :foreman_task_uuid,
+        :upstream_consumer_uuid, :upstream_consumer_name, :rhev_export_domain_name,
+        :rhev_export_domain_address, :rhev_export_domain_path,
+        :rhev_local_storage_path, :rhev_gluster_node_name,
+        :rhev_gluster_node_address, :rhev_gluster_ssh_port,
+        :rhev_gluster_root_password, :host_naming_scheme, :has_content_error,
+        :custom_preprend_name, :enable_access_insights, :cfme_address, :cfme_hostname,
+        :openshift_install_loc, :openshift_number_master_nodes, :openshift_number_worker_nodes,
+        :openshift_storage_size, :openshift_username, :openshift_user_password,
+        :openshift_root_password, :openshift_master_vcpu, :openshift_master_ram,
+        :openshift_master_disk, :openshift_node_vcpu, :openshift_node_ram, :openshift_node_disk,
+        :openshift_available_vcpu, :openshift_available_ram, :openshift_available_disk,
+        :openshift_storage_type, :openshift_sample_helloworld, :openshift_storage_host,
+        :openshift_export_path, :openshift_subdomain_name, :cloudforms_vcpu,
+        :cloudforms_ram, :cloudforms_vm_disk_size, :cloudforms_db_disk_size,
+        :cdn_url, :manifest_file, :created_at, :updated_at, :rhev_engine_host_id,
+        :organization_id, :lifecycle_environment_id, :discovered_host_id,
+        :foreman_task_id, :openstack_deployment_id
+      ]
+
+      #############################################################
+      # Workaround for permitting the reset of discovered_hosts via accepting
+      # discovered_host_ids as an empty array. By default, if it's an empty array,
+      # strong params will filter the value so it does not impact an update.
+      # See discussion: https://github.com/rails/rails/issues/13766
+      #############################################################
+      if params[:deployment][:discovered_host_ids].nil?
+        allowed << :discovered_host_ids
+      else
+        allowed << { :discovered_host_ids => [] }
+      end
+      #############################################################
+
+      params.require(:deployment).permit(allowed)
     end
 
     def find_deployment


### PR DESCRIPTION
Bug complaint is, once hosts have been associated as rhev engines or hypervisors, users are unable to return to rhev setup, choose a different option, and then reuse prior hosts (since they've already been associated).

discovered_host(s) associations to a deployment need to be broken between self-hosted and a standard setup. To reset hasMany serverside, we needed to adjust the strong_params routine to accept empty arrays, see discussion in comment for the reasons.

Separately, once we've broken the host associations, that opens the ability for a user to invalidate persisted setup params for openshift and cfme, both of which can depend on the host configuration. Rest of the patch refactors the default setting for these products and let's us reset them so we don't have stale config.