### PR TITLE
Scripts to help test oVirt API

### DIFF
--- a/scripts/rhev/ovirt_list_vms.sh
+++ b/scripts/rhev/ovirt_list_vms.sh
@@ -1,0 +1,10 @@
+USER="admin@internal"
+PASS="dog8code"
+
+# For 3.6 URL is just IP/api
+# For 4.0 URL is IP/ovirt/api/v3
+URL="https://192.168.155.11/api"
+
+curl -k --user ${USER}:${PASS} -i -X GET -H "Accept: application/xml; detail=disks; detail=nics; detail=hosts;" ${URL}/vms
+
+

--- a/scripts/rhev/ovirt_list_volumes.sh
+++ b/scripts/rhev/ovirt_list_volumes.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [ "$#" -lt "1" ]; then
+ echo "Please re-run with VM ID"
+ exit 1
+fi
+
+VM_ID="$1"
+
+USER="admin@internal"
+PASS="dog8code"
+
+# For 3.6 URL is just IP/api
+# For 4.0 URL is IP/ovirt/api/v3
+URL="https://192.168.155.11/api"
+
+curl -k --user ${USER}:${PASS} -i -X GET -H "Accept: application/xml; detail=disks; detail=nics; detail=hosts;" ${URL}/vms/${VM_ID}/disks
+

--- a/scripts/rhev/rbo_virt_list_volumes.rb
+++ b/scripts/rhev/rbo_virt_list_volumes.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+
+require 'rbovirt'
+
+USER="admin@internal"
+PASS="dog8code"
+
+# For 3.6 URL is just IP/api
+# For 4.0 URL is IP/ovirt/api/v3
+URL="https://192.168.155.11/api"
+
+
+client = OVIRT::Client.new(USER, PASS, URL, {:ca_no_verify => true})
+puts "API Version: #{client.api_version}"
+
+vm_ids = client.vms.map {|v| v.id}
+puts "vm_ids = #{vm_ids}"
+
+vm_ids.each do |vid|
+  volume_data = client.vm_volumes vid
+  puts "Volume info for #{vid}:"
+  puts "#{volume_data}"
+end
+
+


### PR DESCRIPTION
These scripts are not intended for release and not included in our RPMs, they are just to help developers diagnose/debug issues with the oVirt API.