### PR TITLE
Disable local nfs configuration for the RHEV ISO domain

### DIFF
--- a/server/app/lib/actions/fusor/configure_host_groups.rb
+++ b/server/app/lib/actions/fusor/configure_host_groups.rb
@@ -260,7 +260,9 @@ module Actions
                 { :name => "storage_type", :value => deployment.rhev_storage_type },
                 { :name => "admin_password", :value => deployment.rhev_engine_admin_password },
                 { :name => "db_password", :value => deployment.rhev_engine_admin_password },
-                { :name => "engine_fqdn", :value => "#{deployment.rhev_engine_host_name}.#{hostgroup.domain.name}" }
+                { :name => "engine_fqdn", :value => "#{deployment.rhev_engine_host_name}.#{hostgroup.domain.name}" },
+                # Disable automatic setup of a local nfs share for the ISO domain
+                { :name => "nfs_config_enabled", :value => false }
               ]
             }
           ]


### PR DESCRIPTION
We will add the option to configure an NFS share at some point in the future, but for now we are leaving it to the user to manually configure an ISO domain if they want one. Still running a test deployment, which is why it's still WIP.

https://bugzilla.redhat.com/show_bug.cgi?id=1256547