### PR TITLE
Updates for OSE v2 answer file changes

### DIFF
--- a/server/lib/modules/ose_installer/launch.rb
+++ b/server/lib/modules/ose_installer/launch.rb
@@ -137,7 +137,7 @@ module OSEInstaller
           ip = stdout.split("\n").first.split("  ").first
         end
 
-        entry = "- connect_to: #{n}\n  hostname: #{n}\n  ip: #{ip}\n  node: true\n  public_hostname: #{n}\n  public_ip: #{ip}\n"
+        entry = "- connect_to: #{n}\n    hostname: #{n}\n    ip: #{ip}\n    node: true\n    public_hostname: #{n}\n    public_ip: #{ip}"
         if node_entries.nil?
           node_entries = entry
         else
@@ -157,7 +157,7 @@ module OSEInstaller
           ip = stdout.split("\n").first.split("  ").first
         end
 
-        entry = "- connect_to: #{m}\n  hostname: #{m}\n  ip: #{ip}\n  master: true\n  node: true\n  public_hostname: #{m}\n  public_ip: #{ip}\n"
+        entry = "- connect_to: #{m}\n    hostname: #{m}\n    ip: #{ip}\n    master: true\n    node: true\n    public_hostname: #{m}\n    public_ip: #{ip}"
         if master_entries.nil?
           master_entries = entry
         else

--- a/server/lib/modules/ose_installer/templates/atomic-openshift-installer.answers.cfg.yml.template
+++ b/server/lib/modules/ose_installer/templates/atomic-openshift-installer.answers.cfg.yml.template
@@ -1,9 +1,16 @@
 ansible_config: /usr/share/atomic-openshift-utils/ansible.cfg
 ansible_log_path: /tmp/ansible.log
 ansible_ssh_user: root
-hosts:
-<node_entries>
-<master_entries>
+deployment:
+  hosts:
+  <node_entries>
+    roles:
+    - node
+  <master_entries>
+    roles:
+    - master
+    - node
+  roles: {'master', 'node'}
 variant: openshift-enterprise
 variant_version: '3.2'
-version: v1
+version: v2


### PR DESCRIPTION
Still testing, this is required for changes to the format of the OSE answers file.

Without these changes we were seeing:
 changed: [jwm1-ose-master1.example.com] => {"changed": true, "cmd": "atomic-openshift-installer -u -c /tmp/atomic-openshift-installer.answers.cfg.yml install", "delta": "0:00:00.209011", "end": "2016-07-21 04:28:53.888801", "rc": 0, "start": "2016-07-21 04:28:53.679790", "stderr": "", "stdout": "Error loading config, no such key: 'deployment'", "warnings": []}


sdodson helped us learn of the format to the answers file.

We've filed this BZ against OSE, as their change should not have forced us to update the format:
 https://bugzilla.redhat.com/show_bug.cgi?id=1358951

This PR is to update our format to the newer 'v2' format.


Below is a sample answers file I think will work...still testing.

# cat /tmp/atomic-openshift-installer.answers.cfg.yml
ansible_callback_facts_yaml: /tmp/.ansible/callback_facts.yaml
ansible_config: /usr/share/atomic-openshift-utils/ansible.cfg
ansible_inventory_path: /tmp/hosts
ansible_log_path: /tmp/ansible.log
ansible_ssh_user: root
deployment:
  hosts:
  - connect_to: jwm1-ose-node1.example.com
    hostname: jwm1-ose-node1.example.com
    ip: 192.168.155.16
    public_hostname: jwm1-ose-node1.example.com
    public_ip: 192.168.155.16
    roles:
    - node
  - connect_to: jwm1-ose-master1.example.com
    hostname: jwm1-ose-master1.example.com
    ip: 192.168.155.14
    public_hostname: jwm1-ose-master1.example.com
    public_ip: 192.168.155.14
    roles:
    - master
    - node
  roles: {}
variant: openshift-enterprise
variant_version: '3.2'
version: v2