### PR TITLE
rpmdiff: expected ?dist got dist

### DIFF
--- a/server/rubygem-fusor_server.spec
+++ b/server/rubygem-fusor_server.spec
@@ -30,7 +30,7 @@ Summary: Fusor Server Plugin
 Name: %{?scl_prefix}rubygem-%{gem_name}
 
 Version: 1.0.0
-Release: 0%{dist}
+Release: 0%{?dist}
 Group: Development/Ruby
 License: Distributable
 URL: https://github.com/fusor/fusor

--- a/ui/rubygem-fusor_ui.spec
+++ b/ui/rubygem-fusor_ui.spec
@@ -29,7 +29,7 @@ Summary: Fusor Plugin
 Name: %{?scl_prefix}rubygem-%{gem_name}
 
 Version: 1.0.0
-Release: 0%{dist}
+Release: 0%{?dist}
 Group: Development/Ruby
 License: Distributable
 URL: https://github.com/fusor/fusor


### PR DESCRIPTION
The dist tag should be of the form "%{?dist}", but instead found this:
Release: 18%{dist}