### PR TITLE
1356721 - Filter/Validate hosts aren't already deploying

### DIFF
--- a/fusor-ember-cli/app/controllers/engine/discovered-host.js
+++ b/fusor-ember-cli/app/controllers/engine/discovered-host.js
@@ -22,17 +22,23 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, PaginationControlle
   }),
 
   // Filter out hosts selected as Hypervisor
-  availableHosts: Ember.computed('allDiscoveredHosts.[]', 'hypervisorModelIds.[]', function() {
-    // TODO: Ember.computed.filter() caused problems. error item.get is not a function
-    var self = this;
-    var allDiscoveredHosts = this.get('allDiscoveredHosts');
-    if (this.get('allDiscoveredHosts')) {
-      return allDiscoveredHosts.filter(function(item) {
-        if (self.get('hypervisorModelIds')) {
-          return !(self.get('hypervisorModelIds').contains(item.get('id')));
-        }
-      });
+  availableHosts: Ember.computed('deployingHosts', 'allDiscoveredHosts.[]', 'hypervisorModelIds.[]', function() {
+    let allDiscoveredHosts = this.get('allDiscoveredHosts');
+
+    if (Ember.isEmpty(allDiscoveredHosts)) {
+      return [];
     }
+
+    let deployingHosts = this.get('deployingHosts');
+    let hypervisorIds = this.get('hypervisorModelIds');
+
+    return allDiscoveredHosts.filter(host => {
+      let hostId = host.get('id');
+      let isHypervisor = hypervisorIds && hypervisorIds.contains(host.get('id'));
+      let isDeploying = deployingHosts.any(deployingHost => deployingHost.get('id') === hostId);
+
+      return !isHypervisor && !isDeploying;
+    });
   }),
 
   filteredHosts: Ember.computed('availableHosts.[]', 'searchString', 'isStarted', function(){

--- a/fusor-ember-cli/app/mixins/discovered-host-route-mixin.js
+++ b/fusor-ember-cli/app/mixins/discovered-host-route-mixin.js
@@ -5,24 +5,69 @@ export default Ember.Mixin.create({
   setupController(controller, model) {
     controller.set('model', model);
     if (this.modelFor('deployment').get('isNotStarted')) {
-      controller.set('isLoadingHosts', true);
-      this.store.query('discovered-host', {per_page: 1000}).then(function(results) {
-        controller.set('allDiscoveredHosts', results.filterBy('is_discovered', true));
-        controller.set('isLoadingHosts', false);
-      });
+      this.loadDiscoveredHosts();
     }
   },
 
   actions: {
     refreshDiscoveredHosts() {
       console.log('refresh allDiscoveredHosts');
-      var controller = this.get('controller');
-      controller.set('isLoadingHosts', true);
-      this.store.query('discovered-host', {per_page: 1000}).then(function(results) {
-        controller.set('allDiscoveredHosts', results.filterBy('is_discovered', true));
-        controller.set('isLoadingHosts', false);
-      });
+      this.loadDiscoveredHosts();
     }
+  },
+
+  loadDiscoveredHosts() {
+    var controller = this.get('controller');
+    controller.set('isLoadingHosts', true);
+    return Ember.RSVP.hash({
+      deployingHosts: this.getDeployingHosts(),
+      discoveredHosts: this.store.query('discovered-host', {per_page: 1000})
+    }).then(hash => {
+      this.set('controller.deployingHosts', hash.deployingHosts);
+      this.set('controller.allDiscoveredHosts', hash.discoveredHosts.filterBy('is_discovered', true));
+    }).finally(() => controller.set('isLoadingHosts', false));
+  },
+
+  getDeployingHosts() {
+    let currentDeployment = this.modelFor('deployment');
+    let discoveredHostRequests = [];
+
+    return this.getRunningDeployments().then(deployments => {
+      deployments.forEach(deployment => {
+        if (deployment.get('id') !== currentDeployment.get('id')) {
+          discoveredHostRequests.push(deployment.get('discovered_host'));
+          discoveredHostRequests.push(deployment.get('discovered_hosts'));
+        }
+      });
+
+      return Ember.RSVP.all(discoveredHostRequests);
+    }).then(results => {
+      let flattenedHosts = [];
+      results.forEach(result => {
+        if (Ember.isArray(result)) {
+          result.forEach(host => flattenedHosts.push(host));
+        } else {
+          flattenedHosts.push(result);
+        }
+      });
+      return flattenedHosts.uniq();
+    });
+  },
+
+  getRunningDeployments() {
+    let deployments = this.modelFor('application');
+    return this.getDeploymentTasks(deployments).then(tasks => {
+      let runningDeploymentTasks = tasks.filterBy('state', 'running');
+      return deployments.filter(deployment => {
+        return runningDeploymentTasks.any(task => task.get('id') === deployment.get('foreman_task_uuid'));
+      });
+    });
+  },
+
+  getDeploymentTasks(deployments) {
+    let deploymentTaskRequests = deployments.mapBy('foreman_task_uuid').compact()
+      .map(foremanTaskUuid => this.get('store').findRecord('foreman-task', foremanTaskUuid));
+    return Ember.RSVP.all(deploymentTaskRequests);
   }
 
 });

--- a/server/test/fixtures/foreman_tasks_tasks.yml
+++ b/server/test/fixtures/foreman_tasks_tasks.yml
@@ -20,3 +20,10 @@ running_deployment_task:
   label: Actions::Fusor::Deploy
   state: running
   result: pending
+
+successful_deployment_task:
+  id: 986c9213-0596-48d3-8383-7543701e5dfc
+  type: ForemanTasks::Task::DynflowTask
+  label: Actions::Fusor::Deploy
+  state: stopped
+  result: success


### PR DESCRIPTION
- Added validation that no other fusor deployment is running.
- Added validation that deployment's hosts are not already managed.
- Added filter for engine/hypervisor discovered hosts to omit hosts associated with a currently running deployment. 

