### PR TITLE
Removed RHV host validation for ensuring hosts are _not_ managed.

### DIFF
--- a/server/app/lib/fusor/validators/deployment_validator.rb
+++ b/server/app/lib/fusor/validators/deployment_validator.rb
@@ -92,16 +92,8 @@ module Fusor
           deployment.errors[:rhev_engine_host_id] << _('RHV deployments must have an RHV Engine Host')
         end
 
-        if deployment.rhev_engine_host.try(:managed?)
-          deployment.errors[:rhev_engine_host_id] << _('RHEV Engine Host is already managed')
-        end
-
         if deployment.rhev_hypervisor_hosts.count < 1
           deployment.errors[:rhev_hypervisor_hosts] << _('RHV deployments must have at least one Hypervisor')
-        end
-
-        if deployment.rhev_hypervisor_hosts.any? { |host| host.managed? }
-          deployment.errors[:rhev_hypervisor_hosts] << _('RHEV hypervisor host is already managed')
         end
 
         validate_hostname(deployment)

--- a/server/test/models/deployment_test.rb
+++ b/server/test/models/deployment_test.rb
@@ -113,25 +113,11 @@ class DeploymentTest < ActiveSupport::TestCase
         assert_not rhev_d.save, "Saved rhev deployment with no rhev engine"
       end
 
-      test "should not validate rhev deployment with a managed rhev engine host" do
-        rhev_d = fusor_deployments(:rhev)
-        rhev_d.rhev_engine_host.update_attribute(:managed, true)
-        assert_not rhev_d.valid?, 'Validated rhev deployment using a managed host as an engine'
-        assert_not_empty rhev_d.errors[:rhev_engine_host_id]
-      end
-
       test "should not save rhev deployment with no rhev hypervisors" do
         rhev_d = fusor_deployments(:rhev)
         rhev_d.rhev_hypervisor_hosts.clear
         assert rhev_d.deploy_rhev, "Is not a rhev deployment"
         assert_not rhev_d.save, "Saved rhev deployment with no rhev hypervisors"
-      end
-
-      test "should not validate rhev deployment with a managed rhev engine host" do
-        rhev_d = fusor_deployments(:rhev)
-        rhev_d.discovered_hosts[0].update_attribute(:managed, true)
-        assert_not rhev_d.valid?, 'Validated rhev deployment using a managed host as a hypervisor'
-        assert_not_empty rhev_d.errors[:rhev_hypervisor_hosts]
       end
 
       test "should not save rhev deployment if hypervisor is used as rhev engine somewhere else" do


### PR DESCRIPTION
Backing out 2 validations from:
  https://github.com/fusor/fusor/commit/b521063bc4485cfebadaa53d34b13d589943d94c

Was breaking deployments of self-hosted/OSE

Issue is that the validation runs on every update of the deployment object.
We expect to update the deployment object throughout lifetime of deployment run
 i.e. when we create OSE hosts we will update the deployment object with info of those new VMs we created, same for creating the rhev engine record in self-hosted.

During those subsequent updates, we expect the rhv hosts to be managed.

