### PR TITLE
1354470 - Force turbolinks to always run fusor-ember-cli.

### DIFF
--- a/ui/app/views/fusor_ui/placeholders/index.html.erb
+++ b/ui/app/views/fusor_ui/placeholders/index.html.erb
@@ -1,9 +1,9 @@
 <%= stylesheet('fusor_ui/fusor-ember-cli') %>
 
 <%= javascript('fusor_ui/vendor') %>
-<%= javascript('fusor_ui/fusor-ember-cli') %>
+<%= javascript_include_tag 'fusor_ui/fusor-ember-cli', 'data-turbolinks-eval'=>'always' %>
 
 <%= content_for(:title, _("QuickStart Cloud Installer")) %>
 
-<div id='ember-app'>
+<div id='ember-app' data-no-turbolink>
 </div>

--- a/ui/lib/fusor_ui/engine.rb
+++ b/ui/lib/fusor_ui/engine.rb
@@ -21,12 +21,14 @@ module FusorUi
                :url      => '/r/#/deployments',
                :url_hash => { :controller => 'fusor_ui/placeholders', :action => :index },
                :caption  => N_('Deployments'),
-               :engine   => FusorUi::Engine
+               :engine   => FusorUi::Engine,
+               :turbolinks => false
           menu :top_menu, :new_fusor_deployment,
                :url      => '/r/#/deployments/new/start',
                :url_hash => { :controller => 'fusor_ui/placeholders', :action => :new },
                :caption  => N_('New Deployment'),
-               :engine   => FusorUi::Engine
+               :engine   => FusorUi::Engine,
+               :turbolinks => false
         end
 
       end


### PR DESCRIPTION
Back button was replacing the Ember app with an empty page, which I have not been able to prevent.  Turbolinks does not run JavaScript on a page by default if it has already been run initially.  This PR forces Turbolinks to always run fusor-ember-cli.  This ensures it runs after Turbolinks loads a page after a browser back button is pressed so the blanked out portion will be rendered again.  In short:

Back button is pressed.
Ember renders it's page.
Turbolinks blanks it out.
fusor-ember-cli runs and fills it out again.

Not ideal, but better than a permanently blank page until Foreman allows plugins to disable Turbolinks.


