### PR TITLE
Workaround for issues addressed by openshift PR2224 and PR2222.

### DIFF
--- a/server/lib/modules/ose_installer/playbooks/post_install.yml
+++ b/server/lib/modules/ose_installer/playbooks/post_install.yml
@@ -1,6 +1,24 @@
 ---
 # This playbook configures post-installation steps for OSE
 
+- name: Applying temporary fix until https://github.com/openshift/openshift-ansible/pull/2224 is merged in
+  hosts: masters
+  user: ansible_ssh_user
+  tasks:
+    - name: Delete router pod
+      command: oc delete pods router-1-deploy
+    - name: Delete registry pod
+      command: oc delete pods docker-registry-1-deploy
+    - name: Delete registry svc
+      command: oc delete svc docker-registry
+    - name: Delete router svc
+      command: oc delete svc router
+    - name: Delete router dc
+      command: oc delete dc router
+    - name: Delete registry dc
+      command: oc delete dc docker-registry
+ 
+
 - name: Apply common configuration to all nodes
   hosts: nodes
   user: ansible_ssh_user


### PR DESCRIPTION
We need this workaround until the following PRs are merged and built into RPMs we consume during OSE deployment.

https://github.com/openshift/openshift-ansible/pull/2224
https://github.com/openshift/openshift-ansible/pull/2222

Core issue is that default router and registry are incorrectly created during atomic-openshift-installer. The router that's created contains empty endpoint which result in user not being able to access hello_openshift (or any other containers) using hostname that's assigned.