### PR TITLE
Updated fusor.yaml to reference Satellite Tools 6.2

### DIFF
--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -26,8 +26,8 @@
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"
-        :repository_set_id: "4362"
-        :repository_set_name: "Red Hat Satellite Tools 6 Beta (for RHEL 6 Server) (RPMs)"
+        :repository_set_id: "4831"
+        :repository_set_name: "Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)"
         :basearch: "x86_64"
 
       - :product_name: "Red Hat Enterprise Linux Server"
@@ -67,8 +67,8 @@
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"
-        :repository_set_id: "4380"
-        :repository_set_name: "Red Hat Satellite Tools 6 Beta (for RHEL 7 Server) (RPMs)"
+        :repository_set_id: "4831"
+        :repository_set_name: "Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)"
         :basearch: "x86_64"
 
       - :product_name: "Red Hat Enterprise Virtualization"
@@ -95,8 +95,8 @@
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"
-        :repository_set_id: "4380"
-        :repository_set_name: "Red Hat Satellite Tools 6 Beta (for RHEL 7 Server) (RPMs)"
+        :repository_set_id: "4831"
+        :repository_set_name: "Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)"
         :basearch: "x86_64"
 
       - :product_name: "Red Hat Enterprise Virtualization"


### PR DESCRIPTION
Tested with a RHEV deploy.
"Synchronize Red Hat Satellite Tools 6.2 for RHEL 7 Server RPMs x86_64" > "success"

You may need to change your subscription management application to Satellite 6.2 for the content sync to work. I created a new sub mgmt application with Satellite 6.2 titled 'dwhatley-sat62', but it only has two subscriptions attached currently. 