### PR TITLE
1361622 - change RHEV to Red Hat Virtualization in OpenShift requirements

### DIFF
--- a/fusor-ember-cli/app/templates/req-openshift.hbs
+++ b/fusor-ember-cli/app/templates/req-openshift.hbs
@@ -3,7 +3,7 @@
   <p class='req-title'>OpenShift Enterprise by Red Hat</p>
 
   <ul class='req-list'>
-    <li>Requires RHEV to be selected to deploy OpenShift</li>
+    <li>Requires Red Hat Virtualization to be selected to deploy OpenShift Enterprise</li>
     <li>NFS/GlusterFS share for persistent storage to be used with internal OpenShift registry</li>
     <li>All host hardware clocks are synchronized with the hardware clock on the Satellite system</li>
     <li>Hypervisor host minimum requirements: 18 GB RAM, 4 CPU</li>

--- a/fusor-ember-cli/app/templates/rhev-options.hbs
+++ b/fusor-ember-cli/app/templates/rhev-options.hbs
@@ -4,7 +4,7 @@
     <form class="form form-horizontal">
       {{text-f label="Root Password" type="password" value=rhevRootPassword cssId="rhev-root-password"
       isRequired=true disabled=isStarted validator=passwordValidator
-      help-inline="Applies to root user accounts for deployed RHEV hosts"
+      help-inline="Applies to root user accounts for deployed RHV hosts"
       placeholder="Must be 8 or more characters"}}
 
       {{text-f label="Confirm Root Password" type="password" value=confirmRhevRootPassword cssId="confirm-rhev-root-password"
@@ -13,7 +13,7 @@
 
       {{text-f label="Engine Admin Password" type="password" value=rhevEngineAdminPassword cssId="rhev-engine-admin-password"
       isRequired=true disabled=isStarted validator=passwordValidator
-      help-inline="Applies to admin user account for RHEV web UI"
+      help-inline="Applies to admin user account for RHV web UI"
       placeholder="Must be 8 or more characters"}}
 
       {{text-f label="Confirm Engine Admin Password" type="password" value=confirmRhevEngineAdminPassword cssId="confirm-rhev-engine-pdmin-password"

--- a/fusor-ember-cli/app/templates/storage.hbs
+++ b/fusor-ember-cli/app/templates/storage.hbs
@@ -58,7 +58,7 @@
     {{/if}}
 
     {{#if rhevIsSelfHosted}}
-      <h4> Self-hosted RHEV Engine Storage Domain </h4>
+      <h4> Self-hosted RHV Engine Storage Domain </h4>
         {{text-f label="Hosted Engine Storage Domain Name" value=model.hosted_storage_name cssId='hosted_storage_name' isRequired=true disabled=deploymentController.isStarted validator=computerNameValidator}}
         {{text-f label="Storage Address" value=model.hosted_storage_address cssId='hosted_storage_address' isRequired=true disabled=deploymentController.isStarted validator=hostnameValidator}}
         {{text-f label="Share Path" value=model.hosted_storage_path cssId='hosted_storage_path' isRequired=true disabled=deploymentController.isStarted validator=sharePathValidator}}


### PR DESCRIPTION
Change RHEV to Red Hat Virtualization  in OpenShift requirements.
Fixed rhev-options help text to say RHV instead of RHEV.
Fixed storage options for self hosted to say RHV instead of RHEV.