### PR TITLE
Remove rhev local storage option from UI

### DIFF
--- a/fusor-ember-cli/app/templates/storage.hbs
+++ b/fusor-ember-cli/app/templates/storage.hbs
@@ -30,12 +30,6 @@
       </span>
     {{/radio-button}}
     &nbsp;&nbsp;&nbsp;&nbsp;
-    {{#radio-button value="Local" groupValue=model.rhev_storage_type id='local' disabled=true}}
-      <span class="disabled">
-        Local
-      </span>
-    {{/radio-button}}
-    &nbsp;&nbsp;&nbsp;&nbsp;
     {{#radio-button value="glusterfs" groupValue=model.rhev_storage_type id='gluster' disabled=deploymentController.isStarted}}
       <span class="{{if deploymentController.isStarted 'disabled'}}">
         Gluster


### PR DESCRIPTION
Pulling the option from the UI for now, back end left in place for future support.