### PR TITLE
1358316- Override provisioning interface for self-hosted deployments

### DIFF
--- a/server/test/lib/actions/fusor/deployment/rhev/deploy_test.rb
+++ b/server/test/lib/actions/fusor/deployment/rhev/deploy_test.rb
@@ -57,7 +57,8 @@ module Actions::Fusor::Deployment::Rhev
                                   TriggerProvisioning,
                                 @deployment,
                                 'RHEV-Self-hosted',
-                                first_host)
+                                first_host,
+                                {puppetclass_id => {:provisioning_interface => nil}})
       assert_action_planed_with(@deploy,
                                 WaitUntilProvisioned,
                                 first_host.id, true)
@@ -66,7 +67,8 @@ module Actions::Fusor::Deployment::Rhev
         override = {
           puppetclass_id => {
             :additional_host => true,
-            :host_id => index + 2
+            :host_id => index + 2,
+            :provisioning_interface => nil
           }
         }
         assert_action_planed_with(@deploy,


### PR DESCRIPTION
Depends on https://gitlab.sat.lab.tlv.redhat.com/rhci/puppet-ovirt/merge_requests/31 and a rebuild of puppet-ovirt