### PR TITLE
Removed autodelete of OSP nodes.  

### DIFF
--- a/server/app/lib/actions/fusor/host/introspect_open_stack_node.rb
+++ b/server/app/lib/actions/fusor/host/introspect_open_stack_node.rb
@@ -37,16 +37,7 @@ module Actions::Fusor::Host
     def invoke_external_task
       deployment = ::Fusor::Deployment.find(input[:deployment_id])
       handle = undercloud_handle(deployment)
-      begin
-        handle.introspect_node(input[:node_id])
-      rescue Excon::Errors::BadRequest => e
-        if e.response[:body] =~ /Failed validation of power interface for node/
-          # We gave it bad data for the ipmi server. Delete node so user
-          # can re-try and then re-throw the error.
-          handle.delete_node(input[:node_id])
-        end
-        raise e
-      end
+      handle.introspect_node(input[:node_id])
       false # just starting, return false so we'll start polling
     end
 


### PR DESCRIPTION
This allows users to see the problem nodes and associated information and error before manually deleting
them.  There's no need to auto-delete nodes now that users can do it easily and it was preventing the associated errors from being displayed (if for instance the user entered in bad password info)