### PR TITLE
1363766 - Disallow OSP deployment names "admin" and "openstack".

### DIFF
--- a/server/app/lib/fusor/validators/deployment_validator.rb
+++ b/server/app/lib/fusor/validators/deployment_validator.rb
@@ -10,6 +10,8 @@ module Fusor
           deployment.errors[:base] << _('You must deploy something...')
         end
 
+        validate_base_parameters(deployment)
+
         if deployment.deploy_rhev
           validate_rhev_parameters(deployment)
         end
@@ -31,6 +33,12 @@ module Fusor
         unless other_running_deployments.empty?
           other = other_running_deployments.first
           deployment.errors[:foreman_task_uuid] << _("Deployment #{other.id}: #{other.name} is already running")
+        end
+      end
+
+      def validate_base_parameters(deployment)
+        if deployment.deploy_openstack? && %w(admin openstack).any? { |illegal_name| illegal_name == deployment.name.try(:downcase) }
+          deployment.errors[:name] << 'Openstack deployments cannot be named "admin" or "openstack"'
         end
       end
 

--- a/server/test/models/deployment_test.rb
+++ b/server/test/models/deployment_test.rb
@@ -22,6 +22,18 @@ class DeploymentTest < ActiveSupport::TestCase
       assert_not rhev_d2.save, "Saved deployment with a duplicate name"
     end
 
+    test "should not allow name admin if deploying OpenStack" do
+      osp = fusor_deployments(:osp)
+      osp.name = 'Admin'
+      assert_not osp.save, "Saved OpenStack deployment with the name \"admin\""
+    end
+
+    test "should not allow name openstack if deploying OpenStack" do
+      osp = fusor_deployments(:osp)
+      osp.name = 'OpenStack'
+      assert_not osp.save, "Saved OpenStack deployment with the name \"openstack\""
+    end
+
     test "should generate a label on create" do
       new_rhev = fusor_deployments(:rhev).dup
       new_rhev.name = "Name with space"


### PR DESCRIPTION
Disallow OSP deployment names "admin" and "openstack" to prevent naming conflict with the tenant name.  This would fail an OSP deployment with a 409 Conflict error at 90%