### PR TITLE
1365992 Fix disabled deploy button and tabs on RHEV self-hosted after reload page.

### DIFF
--- a/fusor-ember-cli/app/controllers/rhev.js
+++ b/fusor-ember-cli/app/controllers/rhev.js
@@ -9,11 +9,7 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
   engineDiscoveredHostController: Ember.inject.controller('engine/discovered-host'),
   hypervisorDiscoveredHostController: Ember.inject.controller('hypervisor/discovered-host'),
 
-  rhevSetup: Ember.computed.alias("rhevSetupController.rhevSetup"),
-
-  isSelfHost: Ember.computed('rhevSetup', function() {
-    return (this.get('rhevSetup') === 'selfhost');
-  }),
+  isSelfHost: Ember.computed.alias("rhevSetupController.rhevIsSelfHosted"),
 
   hypervisorTabName: Ember.computed('isSelfHost', function() {
     if (this.get('isSelfHost')) {


### PR DESCRIPTION
    Use model value to determine if rhev is self hosted.
    Reloading pages not on RHEV tab lost validated tab state on a self
    hosted deployment because the setting was loaded in the RHEV route.
