### PR TITLE
[WIP] Override the NIC after host is provisioned

### DIFF
--- a/server/app/lib/actions/fusor/host/trigger_provisioning.rb
+++ b/server/app/lib/actions/fusor/host/trigger_provisioning.rb
@@ -18,9 +18,9 @@ module Actions
           _("Trigger Provisoning of Host")
         end
 
-        def plan(deployment, hostgroup_name, host, puppet_overrides = nil)
+        def plan(deployment, hostgroup_name, host)
           super(deployment)
-          plan_self(deployment_id: deployment.id, hostgroup_name: hostgroup_name, host_id: host.id, puppet_overrides: puppet_overrides)
+          plan_self(deployment_id: deployment.id, hostgroup_name: hostgroup_name, host_id: host.id)
         end
 
         def run
@@ -34,23 +34,7 @@ module Actions
           host = assign_host_to_hostgroup(host, hostgroup)
 
           ::Fusor.log.debug "assign_host_to_hostgroup returned id: #{host.id} type: #{host.type}"
-          unless input[:puppet_overrides].nil?
-            ::Fusor.log.debug "applying host specific puppet overrides"
-            apply_puppet_overrides(host, input[:puppet_overrides])
-          end
-
           ::Fusor.log.debug "========================= TriggerProvisioning.run EXIT ========================="
-        end
-
-        def apply_puppet_overrides(host, puppet_overrides)
-          # Puppet overrides should be in the form:
-          # { puppetclass_id => { key => value }, puppetclass2_id => { key2 => value2}}
-          puppet_overrides.each do |puppetclass_id, overrides|
-            puppetclass = Puppetclass.find puppetclass_id
-            overrides.each do |key, value|
-              host.set_param_value_if_changed(puppetclass, key, value)
-            end
-          end
         end
 
         #
@@ -113,7 +97,8 @@ module Actions
             rc = host.save
             successful_save = rc && host.reload.type == 'Host::Managed'
 
-            fail _("Host with id #{host.id} was not converted to a managed host.") unless successful_save
+
+            fail _("Host with id #{host.id} was not converted to a managed host, failed with errors #{host.errors.full_messages}") unless successful_save
 
             return host
           end

--- a/server/test/lib/actions/fusor/deployment/rhev/deploy_test.rb
+++ b/server/test/lib/actions/fusor/deployment/rhev/deploy_test.rb
@@ -41,6 +41,7 @@ module Actions::Fusor::Deployment::Rhev
                                   hypervisor.id, true)
       end
     end
+
     test "plan call should schedule provision and wait actions for each host for self-hosted" do
       @deployment = fusor_deployments(:rhev_self_hosted)
       plan_action(@deploy, fusor_deployments(:rhev_self_hosted))
@@ -57,12 +58,11 @@ module Actions::Fusor::Deployment::Rhev
                                   TriggerProvisioning,
                                 @deployment,
                                 'RHEV-Self-hosted',
-                                first_host,
-                                {puppetclass_id => {:provisioning_interface => nil}})
+                                first_host)
       assert_action_planed_with(@deploy,
                                 WaitUntilProvisioned,
-                                first_host.id, true)
-
+                                first_host.id, true,
+                                {puppetclass_id => {:provisioning_interface => nil}})
       additional_hosts.each_with_index do |hypervisor, index|
         override = {
           puppetclass_id => {
@@ -75,10 +75,10 @@ module Actions::Fusor::Deployment::Rhev
                                   TriggerProvisioning,
                                   @deployment,
                                   'RHEV-Self-hosted',
-                                  hypervisor, override)
+                                  hypervisor)
         assert_action_planed_with(@deploy,
                                   WaitUntilProvisioned,
-                                  hypervisor.id, true)
+                                  hypervisor.id, true, override)
       end
     end
 


### PR DESCRIPTION
This will prevent NIC identifier changes that happen during the build phase from breaking a RHV self-hosted deployment. Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1358316