### PR TITLE
1366026 - fix losing hypervisor selection when click on Review/OpenShift Tab.

### DIFF
--- a/fusor-ember-cli/app/templates/hypervisor/discovered-host.hbs
+++ b/fusor-ember-cli/app/templates/hypervisor/discovered-host.hbs
@@ -75,12 +75,12 @@
   </div>
 </div>
 
-{{#cancel-back-next backRouteName=hypervisorBackRouteName
+{{cancel-back-next backRouteName=hypervisorBackRouteName
                     disableBack=false
+                    nextRouteName='rhev-options'
+                    disableNext=disableNextOnHypervisor
                     disableCancel=isStarted
                     deploymentName=deploymentName}}
-  <button {{action 'saveHyperVisors' 'rhev-options'}} class='btn btn-primary next-button' disabled={{disableNextOnHypervisor}} data-qci='next-button'>Next <i class="fa fa-angle-right"></i></button>
-{{/cancel-back-next}}
 
 {{naming-scheme-modal openModal=openModalNamingScheme
                       namingOptions=namingOptions


### PR DESCRIPTION
Updated hypervisor selection on transition instead of deactivate.  This change was getting trampled when navigating to OpenShift/Review pages which save as part of the beforeModel hook.