### PR TITLE
1358316- Override mac address instead of provisioning interface name

### DIFF
--- a/server/app/lib/actions/fusor/deployment/rhev/deploy.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/deploy.rb
@@ -35,7 +35,7 @@ module Actions
 
                 first_host_overrides = {
                   puppetclass_id => {
-                    :provisioning_interface => first_host.interfaces.where(:provision => true).try(:first).try(:identifier)
+                    :mac_address => first_host.interfaces.where(:provision => true).try(:first).try(:mac)
                   }
                 }
                 plan_action(::Actions::Fusor::Host::TriggerProvisioning,
@@ -51,7 +51,7 @@ module Actions
                     puppetclass_id => {
                      :host_id => (index + 2),
                      :additional_host => true,
-                     :provisioning_interface => host.interfaces.where(:provision => true).try(:first).try(:identifier)
+                     :mac_address => host.interfaces.where(:provision => true).try(:first).try(:mac)
                     }
                   }
                   plan_action(::Actions::Fusor::Host::TriggerProvisioning,

--- a/server/test/lib/actions/fusor/deployment/rhev/deploy_test.rb
+++ b/server/test/lib/actions/fusor/deployment/rhev/deploy_test.rb
@@ -58,7 +58,7 @@ module Actions::Fusor::Deployment::Rhev
                                 @deployment,
                                 'RHEV-Self-hosted',
                                 first_host,
-                                {puppetclass_id => {:provisioning_interface => nil}})
+                                {puppetclass_id => {:mac_address => nil}})
       assert_action_planed_with(@deploy,
                                 WaitUntilProvisioned,
                                 first_host.id, true)
@@ -68,7 +68,7 @@ module Actions::Fusor::Deployment::Rhev
           puppetclass_id => {
             :additional_host => true,
             :host_id => index + 2,
-            :provisioning_interface => nil
+            :mac_address => nil
           }
         }
         assert_action_planed_with(@deploy,


### PR DESCRIPTION
The puppet module will find the name of the interface using the mac address. This way we won't get bitten if the names change.

https://gitlab.sat.lab.tlv.redhat.com/rhci/puppet-ovirt/merge_requests/34

https://bugzilla.redhat.com/show_bug.cgi?id=1358316