### PR TITLE
add no-tsx cpu family options for broadwell, haswell

### DIFF
--- a/fusor-ember-cli/app/controllers/rhev-options.js
+++ b/fusor-ember-cli/app/controllers/rhev-options.js
@@ -14,7 +14,8 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
   confirmRhevEngineAdminPassword: Ember.computed.alias("deploymentController.confirmRhevEngineAdminPassword"),
 
   cpuTypes: ['Intel Conroe Family', 'Intel Penryn Family', 'Intel Nehalem Family',
-             'Intel Westmere Family', 'Intel SandyBridge Family', 'Intel Haswell',
+             'Intel Westmere Family', 'Intel SandyBridge Family', 'Intel Haswell Family',
+             'Intel Haswell-noTSX Family', 'Intel Broadwell Family', 'Intel Broadwell-noTSX Family',
              'AMD Opteron G1', 'AMD Opteron G2', 'AMD Opteron G3', 'AMD Opteron G4',
              'AMD Opteron G5', 'IBM POWER 8'],
 

--- a/server/app/lib/actions/fusor/configure_host_groups.rb
+++ b/server/app/lib/actions/fusor/configure_host_groups.rb
@@ -384,13 +384,15 @@ module Actions
 
       def get_cpu_model(cpu_type)
         self_hosted_cpu_map = {
-          'Intel Broadwell Family' => 'model_Broadwell',
           'Intel Conroe Family' => 'model_Conroe',
           'Intel Penryn Family' => 'model_Penryn',
           'Intel Nehalem Family' => 'model_Nehalem',
           'Intel Westmere Family' => 'model_Westmere',
           'Intel SandyBridge Family' => 'model_SandyBridge',
-          'Intel Haswell' => 'model_Haswell',
+          'Intel Haswell Family' => 'model_Haswell',
+          'Intel Haswell-noTSX Family' => 'model_Haswell-noTSX',
+          'Intel Broadwell Family' => 'model_Broadwell',
+          'Intel Broadwell-noTSX Family' => 'model_Broadwell-noTSX',
           'AMD Opteron G1' => 'model_Opteron_G1',
           'AMD Opteron G2' => 'model_Opteron_G2',
           'AMD Opteron G3' => 'model_Opteron_G3',


### PR DESCRIPTION
Haswell-noTSX and Broadwell-noTSX CPU family options allow RHV clusters to utilize the new instructions provided by the latest architectures without failing to deploy due to the TSX instructions being disabled by Intel.

Tested RHV deploy with Haswell-noTSX family on my Haswell machine. Have not been able to test with Broadwell. Do not have any access to Broadwell hardware.