### PR TITLE
1367579 - Fixed stale engine name used on summary.js.

### DIFF
--- a/fusor-ember-cli/app/controllers/review/summary.js
+++ b/fusor-ember-cli/app/controllers/review/summary.js
@@ -23,7 +23,7 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
     return ('http://' + this.get('model.openstack_deployment.overcloud_address') + '/dashboard/admin');
   }),
 
-  selectedRhevEngine: Ember.computed.alias("deploymentController.model.discovered_host"),
+  selectedRhevEngine: Ember.computed.alias('model.discovered_host'),
   deploymentLabel: Ember.computed.alias('deploymentController.model.label'),
 
   exampleAppUrl: Ember.computed('deploymentController.defaultDomainName', function() {
@@ -33,10 +33,10 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
     return `http://hello-openshift.${subdomainName}.${domainName}`;
   }),
 
-  rhevEngineUrl: Ember.computed('selectedRhevEngine', function() {
+  rhevEngineUrl: Ember.computed('selectedRhevEngine.name', function() {
     return ('https://' + this.get('selectedRhevEngine.name') + '/ovirt-engine/');
   }),
-  rhevEngineUrlIP: Ember.computed('selectedRhevEngine', function() {
+  rhevEngineUrlIP: Ember.computed('selectedRhevEngine.ip', function() {
     return ('https://' + this.get('selectedRhevEngine.ip') + '/ovirt-engine/');
   }),
 


### PR DESCRIPTION
After a deployment, the rhev engine URL was still using the name from the engine as a discovered host, not a managed host, resulting in  "https://eng1/ovirt-engine" instead of "https://eng1.example.com/ovirt-engine".  This fix should use the updated model and the computed property now triggers on the name change.