### PR TITLE
force install of polyglot

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -43,6 +43,8 @@ if [ $1 == "install" ]; then
   echo "gem 'webmock'" >> bundler.d/local.rb
   echo "gem 'vcr', '< 3.0.0'" >> bundler.d/local.rb
   echo "gem 'rake', '< 11'" >> bundler.d/local.rb
+  # fix weird travis weird gem deps
+  echo "gem 'polyglot', '0.3.5'" >> bundler.d/local.rb
 
   # TODO: use the latest version of foreman once this PR is merged
   # https://github.com/theforeman/foreman/pull/3034


### PR DESCRIPTION
broken builds installed deface 1.0.0 which does not bring in polyglot which
apparently docker-api requires but doesn't require it in their gemspec.