### PR TITLE
add releasever for management agent sections

### DIFF
--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -83,6 +83,7 @@
         :repository_set_id: "5132"
         :repository_set_name: "Red Hat Virtualization 4 Management Agents for RHEL 7 (RPMs)"
         :basearch: "x86_64"
+        :releasever: "7Server"
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"
@@ -124,6 +125,7 @@
         :repository_set_id: "5132"
         :repository_set_name: "Red Hat Virtualization 4 Management Agents for RHEL 7 (RPMs)"
         :basearch: "x86_64"
+        :releasever: "7Server"
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"


### PR DESCRIPTION
add releasever to management agents only:

```
.../$releasever/$basearch/rhv-mgmt-agent/4"
```

the other repo only has ```$basearch```