### PR TITLE
1371955 - Added 'force' parameter to installation so that a retry suc…

### DIFF
--- a/server/lib/modules/ose_installer/playbooks/install.yml
+++ b/server/lib/modules/ose_installer/playbooks/install.yml
@@ -10,4 +10,4 @@
       action: copy src="{{output_dir}}/atomic-openshift-installer.answers.cfg.yml" dest="/tmp/atomic-openshift-installer.answers.cfg.yml" owner={{ansible_ssh_user}} mode=0775
 
     - name: execute atomic-openshift-installer
-      shell: atomic-openshift-installer -u -c /tmp/atomic-openshift-installer.answers.cfg.yml install
+      shell: atomic-openshift-installer -u -c /tmp/atomic-openshift-installer.answers.cfg.yml install --force


### PR DESCRIPTION
…ceeds.

This is so that when a user retries a failed installation on the UI, they can click "resume task" and the installer will run from scratch again instead of trying to rerun on top of the previous install.