### PR TITLE
Enable proper repos for RHV hypervisor & engine (self-hosted)

### DIFF
--- a/server/app/lib/actions/fusor/configure_host_groups.rb
+++ b/server/app/lib/actions/fusor/configure_host_groups.rb
@@ -214,7 +214,7 @@ module Actions
 
       def get_deployment_overrides(deployment, hostgroup, product_type)
         return [
-          get_rhev_hypervisor_deployment_overrides(),
+          get_rhev_hypervisor_deployment_overrides,
           get_rhev_engine_deployment_overrides(deployment, hostgroup, product_type),
           get_rhev_self_hosted_deployment_overrides(deployment, hostgroup, product_type)
         ]
@@ -281,7 +281,7 @@ module Actions
                 { :name => "db_password", :value => deployment.rhev_engine_admin_password },
                 { :name => "engine_fqdn", :value => "#{deployment.rhev_engine_host_name}.#{hostgroup.domain.name}" },
                 # Disable automatic setup of a local nfs share for the ISO domain
-                { :name => "nfs_config_enabled", :value => false },
+                { :name => "nfs_config_enabled", :value => false }
               ]
             },
             {

--- a/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
@@ -41,7 +41,8 @@ module Actions
 
             ks_name = "#{hostgroup.name} Kickstart"
             snippet_name = "rhevm_guest_agent"
-            ct_util = Utils::Fusor::ConfigTemplateUtils.new({:rhevm_guest_agent_snippet_name => snippet_name})
+            repos = SETTINGS[:fusor][:content][:openshift].map { |p| p[:repository_set_label] if p[:repository_set_label] =~ /rpms$/ }.compact
+            ct_util = Utils::Fusor::ConfigTemplateUtils.new({:rhevm_guest_agent_snippet_name => snippet_name, :enabled_repos => repos})
             ret = ct_util.ensure_ks_with_snippet(ks_name, snippet_name)
             fail _("====== Could not ensure '#{ks_name}' with '#{snippet_name}'") unless ret
 

--- a/server/app/lib/utils/fusor/config_template_utils.rb
+++ b/server/app/lib/utils/fusor/config_template_utils.rb
@@ -7,6 +7,7 @@ module Utils
 
         # set custom snippet names
         @rhevm_guest_agent_snippet_name = params[:rhevm_guest_agent_snippet_name] ||= 'rhevm_guest_agent'
+        @enabled_repos = params[:enabled_repos] ||= []
       end
 
       def create_snippet(name)
@@ -119,6 +120,8 @@ module Utils
       def create_rhevm_guest_agent_snippet
         name = @rhevm_guest_agent_snippet_name
         return nil unless create_snippet(name)
+        append(name, "\nsubscription-manager --enable #{@enabled_repos.join ' --enable '}")
+        append(name, "\nsubscription-manager --disable \"*\"")
         append(name, "\nyum install rhevm-guest-agent-common -y")
         append(name, "\nsystemctl start ovirt-guest-agent.service")
         append(name, "\nsystemctl enable ovirt-guest-agent.service\n")

--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -315,15 +315,18 @@
     - :name: "ovirt"
     - :name: "ovirt::engine::config"
     - :name: "ovirt::engine::packages"
+    - :name: "ovirt::engine::subscription"
     - :name: "ovirt::engine::setup"
     - :name: "ovirt::engine::import_template"
     - :name: "ovirt::engine::run_vm"
+    - :name: "ovirt::hypervisor::subscription"
     - :name: "ovirt::hypervisor::packages"
     - :name: "ovirt::self_hosted::setup"
     - :name: "ovirt::self_hosted::config"
     - :name: "ovirt::self_hosted::packages"
     - :name: "ovirt::self_hosted::import_template"
     - :name: "ovirt::self_hosted::run_vm"
+    - :name: "ovirt::self_hosted::subscription"
 
   :docker_repos:
     - :name: "hello-openshift"
@@ -361,6 +364,7 @@
                :override: "RHEV"
            - :name: "ovirt::engine::config"
            - :name: "ovirt::engine::packages"
+           - :name: "ovirt::engine::subscription"
            - :name: "ovirt::engine::setup"
              :parameters:
              - :name: "firewall_manager"
@@ -382,6 +386,7 @@
              - :name: "product"
                :override: "RHEV"
            - :name: "ovirt::hypervisor::packages"
+           - :name: "ovirt::hypervisor::subscription"
          :activation_key:
            :name: "RHV-Hypervisor"
            :content: :rhevh
@@ -402,6 +407,7 @@
            - :name: "ovirt::self_hosted::config"
            - :name: "ovirt::self_hosted::packages"
            - :name: "ovirt::self_hosted::setup"
+           - :name: "ovirt::self_hosted::subscription"
          :activation_key:
            :name: "RHV-Self-hosted"
            :content: :rhevsh

--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -14,6 +14,7 @@
         :product_id: "69"
         :repository_set_id: "2456"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server (RPMs)"
+        :repository_set_label: "rhel-7-server-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -21,6 +22,7 @@
         :product_id: "69"
         :repository_set_id: "2455"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server (Kickstart)"
+        :repository_set_label: "rhel-7-server-kickstart"
         :basearch: "x86_64"
         :releasever: "7.2"
 
@@ -28,12 +30,14 @@
         :product_id: "69"
         :repository_set_id: "4831"
         :repository_set_name: "Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)"
+        :repository_set_label: "rhel-7-server-satellite-tools-6.2-rpms"
         :basearch: "x86_64"
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"
         :repository_set_id: "2476"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server - Supplementary (RPMs)"
+        :repository_set_label: "rhel-7-server-supplementary-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -41,12 +45,14 @@
         :product_id: "150"
         :repository_set_id: "5024"
         :repository_set_name: "Red Hat Virtualization Manager 4.0 (RHEL 7 Server) (RPMs)"
+        :repository_set_label: "rhel-7-server-rhv-4.0-rpms"
         :basearch: "x86_64"
 
       - :product_name: "JBoss Enterprise Application Platform"
         :product_id: "183"
         :repository_set_id: "4474"
         :repository_set_name: "JBoss Enterprise Application Platform 7 (RHEL 7 Server) (RPMs)"
+        :repository_set_label: "jb-eap-7-for-rhel-7-server-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -54,6 +60,7 @@
         :product_id: "69"
         :repository_set_id: "2463"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server - Optional (RPMs)"
+        :repository_set_label: "rhel-7-server-optional-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -62,6 +69,7 @@
         :product_id: "69"
         :repository_set_id: "2456"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server (RPMs)"
+        :repository_set_label: "rhel-7-server-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -69,6 +77,7 @@
         :product_id: "69"
         :repository_set_id: "2455"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server (Kickstart)"
+        :repository_set_label: "rhel-7-server-kickstart"
         :basearch: "x86_64"
         :releasever: "7.2"
 
@@ -76,12 +85,14 @@
         :product_id: "69"
         :repository_set_id: "4831"
         :repository_set_name: "Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)"
+        :repository_set_label: "rhel-7-server-satellite-tools-6.2-rpms"
         :basearch: "x86_64"
 
       - :product_name: "Red Hat Enterprise Virtualization"
         :product_id: "150"
         :repository_set_id: "5132"
         :repository_set_name: "Red Hat Virtualization 4 Management Agents for RHEL 7 (RPMs)"
+        :repository_set_label: "rhel-7-server-rhv-4-mgmt-agent-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -89,6 +100,7 @@
         :product_id: "69"
         :repository_set_id: "2476"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server - Supplementary (RPMs)"
+        :repository_set_label: "rhel-7-server-supplementary-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -96,6 +108,7 @@
         :product_id: "69"
         :repository_set_id: "2463"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server - Optional (RPMs)"
+        :repository_set_label: "rhel-7-server-optional-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -104,6 +117,7 @@
         :product_id: "69"
         :repository_set_id: "2456"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server (RPMs)"
+        :repository_set_label: "rhel-7-server-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -111,6 +125,7 @@
         :product_id: "69"
         :repository_set_id: "2455"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server (Kickstart)"
+        :repository_set_label: "rhel-7-server-kickstart"
         :basearch: "x86_64"
         :releasever: "7.2"
 
@@ -118,12 +133,14 @@
         :product_id: "69"
         :repository_set_id: "4831"
         :repository_set_name: "Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)"
+        :repository_set_label: "rhel-7-server-satellite-tools-6.2-rpms"
         :basearch: "x86_64"
 
       - :product_name: "Red Hat Enterprise Virtualization"
         :product_id: "150"
         :repository_set_id: "5132"
         :repository_set_name: "Red Hat Virtualization 4 Management Agents for RHEL 7 (RPMs)"
+        :repository_set_label: "rhel-7-server-rhv-4-mgmt-agent-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -131,6 +148,7 @@
         :product_id: "69"
         :repository_set_id: "2476"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server - Supplementary (RPMs)"
+        :repository_set_label: "rhel-7-server-supplementary-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -138,6 +156,7 @@
         :product_id: "69"
         :repository_set_id: "2463"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server - Optional (RPMs)"
+        :repository_set_label: "rhel-7-server-optional-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -146,6 +165,7 @@
         :product_id: "167"
         :repository_set_id: "5233"
         :repository_set_name: "Red Hat CloudForms Management Engine 5.6 (Files)"
+        :repository_set_label: "cf-me-5.6-for-rhel-7-files"
         :basearch: "x86_64"
         # Default behavior is to use the latest available image found
         # in the repository if either :rhos_image_file_name or :rhev_image_file_name
@@ -158,6 +178,7 @@
         :product_id: "69"
         :repository_set_id: "2455"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server (Kickstart)"
+        :repository_set_label: "rhel-7-server-kickstart"
         :basearch: "x86_64"
         :releasever: "7.2"
         # Need Red Hat 7.2 Operating System setup including Media,
@@ -168,12 +189,14 @@
         :product_id: "290"
         :repository_set_id: "4889"
         :repository_set_name: "Red Hat OpenShift Enterprise 3.2 (RPMs)"
+        :repository_set_label: "rhel-7-server-ose-3.2-rpms"
         :basearch: "x86_64"
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"
         :repository_set_id: "2456"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server (RPMs)"
+        :repository_set_label: "rhel-7-server-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -181,6 +204,7 @@
         :product_id: "69"
         :repository_set_id: "2455"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server (Kickstart)"
+        :repository_set_label: "rhel-7-server-kickstart"
         :basearch: "x86_64"
         :releasever: "7.2"
 
@@ -188,6 +212,7 @@
         :product_id: "69"
         :repository_set_id: "2472"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server - RH Common (RPMs)"
+        :repository_set_label: "rhel-7-server-rh-common-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -195,12 +220,14 @@
         :product_id: "69"
         :repository_set_id: "3030"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server - Extras (RPMs)"
+        :repository_set_label: "rhel-7-server-extras-rpms"
         :basearch: "x86_64"
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"
         :repository_set_id: "2463"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server - Optional (RPMs)"
+        :repository_set_label: "rhel-7-server-optional-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -210,6 +237,7 @@
         :product_id: "69"
         :repository_set_id: "2456"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server (RPMs)"
+        :repository_set_label: "rhel-7-server-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -217,6 +245,7 @@
         :product_id: "69"
         :repository_set_id: "2455"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server (Kickstart)"
+        :repository_set_label: "rhel-7-server-kickstart"
         :basearch: "x86_64"
         :releasever: "7.2"
 
@@ -224,12 +253,14 @@
         :product_id: "69"
         :repository_set_id: "3030"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server - Extras (RPMs)"
+        :repository_set_label: "rhel-7-server-extras-rpms"
         :basearch: "x86_64"
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"
         :repository_set_id: "2463"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server - Optional (RPMs)"
+        :repository_set_label: "rhel-7-server-optional-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -237,6 +268,7 @@
         :product_id: "69"
         :repository_set_id: "2472"
         :repository_set_name: "Red Hat Enterprise Linux 7 Server - RH Common (RPMs)"
+        :repository_set_label: "rhel-7-server-rh-common-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -244,12 +276,14 @@
         :product_id: "69"
         :repository_set_id: "4831"
         :repository_set_name: "Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)"
+        :repository_set_label: "rhel-7-server-satellite-tools-6.2-rpms"
         :basearch: "x86_64"
 
       - :product_name: "Red Hat OpenStack"
         :product_id: "191"
         :repository_set_id: "4713"
         :repository_set_name: "Red Hat OpenStack Platform 8 for RHEL 7 (RPMs)"
+        :repository_set_label: "rhel-7-server-openstack-8-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -257,6 +291,7 @@
         :product_id: "191"
         :repository_set_id: "4716"
         :repository_set_name: "Red Hat OpenStack Platform 8 director for RHEL 7 (RPMs)"
+        :repository_set_label: "rhel-7-server-openstack-8-director-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -264,6 +299,7 @@
         :product_id: "191"
         :repository_set_id: "4718"
         :repository_set_name: "Red Hat OpenStack Platform 8 for RHEL 7 (Files)"
+        :repository_set_label: "rhel-7-server-openstack-8-files"
         :basearch: "x86_64"
         :releasever: "7Server"
 
@@ -271,6 +307,7 @@
         :product_id: "201"
         :repository_set_id: "2808"
         :repository_set_name: "Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 Server"
+        :repository_set_label: "rhel-server-rhscl-7-rpms"
         :basearch: "x86_64"
         :releasever: "7Server"
 


### PR DESCRIPTION
* added puppet classes to fusor.yaml
* add repositories to fusor.yaml
* add ovirt::engine::subscription
* configure self-hosted hypervisors
* added ovirt::{engine,hypervisor}::subscription

put the disable and enable of repos into a puppet class for both engine and
hypervisor. self-hosted is being done by user-data.erb via cloud-init
