### PR TITLE
1294534 - Clear subscriptions table for deployment on new manifest uploads

### DIFF
--- a/server/app/controllers/fusor/api/v21/subscriptions_controller.rb
+++ b/server/app/controllers/fusor/api/v21/subscriptions_controller.rb
@@ -67,6 +67,8 @@ module Fusor
       fail ::Katello::HttpErrors::BadRequest, _("No deployment specified") if params[:manifest_file][:deployment_id].blank?
 
       deployment = Deployment.find(params[:manifest_file][:deployment_id])
+      deployment.subscriptions = []
+      deployment.save(:validate => false)
 
       begin
         # candlepin requires that the file has a zip file extension


### PR DESCRIPTION
Subscriptions are not being cleared from the table on subsequent manifest uploads. Results in all subscriptions ever loaded into the table to be in any subscriptions query. (Could produce bad data in the subscriptions review page).

This patch cleans all subscriptions written to the table for a given deployment before writing the new uploaded manifest.