### PR TITLE
1360455 - Use browser history instead of #urls

### DIFF
--- a/fusor-ember-cli/app/router.js
+++ b/fusor-ember-cli/app/router.js
@@ -3,6 +3,7 @@ import config from './config/environment';
 
 var Router = Ember.Router.extend({
   location: config.locationType,
+  rootURL: config.rootURL,
   // log when Ember generates a controller or a route from a generic class
   LOG_ACTIVE_GENERATION: true,
   // log when Ember looks up a template or a view

--- a/fusor-ember-cli/config/environment.js
+++ b/fusor-ember-cli/config/environment.js
@@ -5,7 +5,8 @@ module.exports = function(environment) {
     modulePrefix: 'fusor-ember-cli',
     environment: environment,
     baseURL: '/',
-    locationType: 'hash',
+    rootURL: '/r/',
+    locationType: 'history',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/ui/app/controllers/fusor_ui/placeholders_controller.rb
+++ b/ui/app/controllers/fusor_ui/placeholders_controller.rb
@@ -2,25 +2,6 @@ module FusorUi
 
   class PlaceholdersController < ApplicationController
 
-    # redirect /r/deployments to /r/#/deployments
-    # since Sat6 would strip after # if referral link is a Katello/AngularJS page
-    # redirect from "no hash" /r/ to "with hash" /r/# fixes this bug
-    def index
-      redirect_to "/r/#/deployments"
-    end
-
-    def new
-      redirect_to "/r/#/deployments/new/start"
-    end
-
-    def index_with_hash
-      render :index
-    end
-
-    def new_with_hash
-      render :index
-    end
-
     def r
       render :index
     end

--- a/ui/config/routes.rb
+++ b/ui/config/routes.rb
@@ -1,9 +1,4 @@
 Rails.application.routes.draw do
-
-  get 'r/deployments', :to => 'fusor_ui/placeholders#index'
-  get 'r/deployments/new/start', :to => 'fusor_ui/placeholders#new', :as => :new_fusor_deployment
-  get 'r/#/deployments', :to => 'fusor_ui/placeholders#index_with_hash', :as => :index_with_hash_fusor_deployment
-  get 'r/#/deployments/new/start', :to => 'fusor_ui/placeholders#new_with_hash', :as => :new_with_hash_fusor_deployment
+  get 'r/*ember_route', :to => 'fusor_ui/placeholders#r'
   get 'r', :to => 'fusor_ui/placeholders#r'
-
 end

--- a/ui/lib/fusor_ui/engine.rb
+++ b/ui/lib/fusor_ui/engine.rb
@@ -18,13 +18,13 @@ module FusorUi
 
         sub_menu :top_menu, :fusor_menu, :caption => N_('QuickStart Cloud Installer'), :after => :infrastructure_menu do
           menu :top_menu, :fusor_deployments,
-               :url      => '/r/#/deployments',
+               :url      => '/r/deployments',
                :url_hash => { :controller => 'fusor_ui/placeholders', :action => :index },
                :caption  => N_('Deployments'),
                :engine   => FusorUi::Engine,
                :turbolinks => false
           menu :top_menu, :new_fusor_deployment,
-               :url      => '/r/#/deployments/new/start',
+               :url      => '/r/deployments/new/start',
                :url_hash => { :controller => 'fusor_ui/placeholders', :action => :new },
                :caption  => N_('New Deployment'),
                :engine   => FusorUi::Engine,


### PR DESCRIPTION
Use browser history instead of #/ hash urls so Katello stops stripping our URLs.