### PR TITLE
1373636 - removed broadwell from cpu family options

### DIFF
--- a/fusor-ember-cli/app/controllers/rhev-options.js
+++ b/fusor-ember-cli/app/controllers/rhev-options.js
@@ -15,9 +15,8 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
 
   cpuTypes: ['Intel Conroe Family', 'Intel Penryn Family', 'Intel Nehalem Family',
              'Intel Westmere Family', 'Intel SandyBridge Family', 'Intel Haswell Family',
-             'Intel Haswell-noTSX Family', 'Intel Broadwell Family', 'Intel Broadwell-noTSX Family',
-             'AMD Opteron G1', 'AMD Opteron G2', 'AMD Opteron G3', 'AMD Opteron G4',
-             'AMD Opteron G5', 'IBM POWER 8'],
+             'Intel Haswell-noTSX Family', 'AMD Opteron G1', 'AMD Opteron G2',
+             'AMD Opteron G3', 'AMD Opteron G4', 'AMD Opteron G5', 'IBM POWER 8'],
 
   passwordValidator: RequiredPasswordValidator.create({}),
 


### PR DESCRIPTION
Removed Broadwell, which is not supported by RHV 4.0, from front-end RHV CPU family options (Step D in RHV configuration).

[https://access.redhat.com/documentation/en/red-hat-virtualization/4.0/single/technical-reference#Hypervisor_Requirements](url) 