### PR TITLE
1366338 - handle products covered by multiple subs

### DIFF
--- a/server/app/lib/fusor/subscriptions/subscription_info.rb
+++ b/server/app/lib/fusor/subscriptions/subscription_info.rb
@@ -31,11 +31,28 @@ module Fusor
         return @product_ids
       end
 
-      def get_product_key(pids)
+      def get_product_keys(pids)
         ::Fusor.log.debug "SUB-INFO: #{@name}.get_product_key: pids: #{pids}"
+        # if pids - values is empty we found our best match
+        # otherwise if any of the items matched add the key to the list
+        # skip if pids - values == pids
+        #
+        keys = []
         @product_ids.each do |key, values|
-          return key if (pids - values).empty?
+          #return key if (pids - values).empty?
+
+          diff = (pids - values)
+          if diff.empty?
+            return [key] # best match
+          end
+
+          if diff.count < pids.count
+            # found at least one add it to the list
+            keys << key
+          end
         end
+
+        return keys
       end
 
       def get_product_ids_by_name(product)

--- a/server/app/lib/fusor/subscriptions/subscription_validator.rb
+++ b/server/app/lib/fusor/subscriptions/subscription_validator.rb
@@ -73,14 +73,20 @@ module Fusor
             ::Fusor.log.info "SUB-VAL.compare: deployment has product: #{product} with count: #{count}"
             ::Fusor.log.info "SUB-VAL.compare: #{deployment_si.get_product_ids_by_name(product)}"
 
-            key = other_si.get_product_key(deployment_si.get_product_ids_by_name(product))
-            if key.nil?
-              ::Fusor.log.error "SUB-VAL.compare: COULD NOT FIND key #{key} for product [#{product}]. #{deployment_si.get_product_ids_by_name(product)}"
+            # get the set of keys that encompass the counts
+            # for each of the keys, get their count
+            # each count has to be >= to the count we need
+            keys = other_si.get_product_keys(deployment_si.get_product_ids_by_name(product))
+            if keys.empty?
+              ::Fusor.log.error "SUB-VAL.compare: COULD NOT FIND any keys for product [#{product}]. #{deployment_si.get_product_ids_by_name(product)}"
             end
+
             dep_count = deployment_si.get_counts_by_name(product)
-            count = other_si.get_counts_by_name(key)
-            valid &&= (dep_count <= count)  # valid = valid && (dep_count <= count)
-            ::Fusor.log.info "SUB-VAL.compare: deployment needs #{dep_count}. subscriptions supply #{count}. Valid? #{valid}"
+            keys.each do |key|
+              count = other_si.get_counts_by_name(key)
+              valid &&= (dep_count <= count)  # valid = valid && (dep_count <= count)
+              ::Fusor.log.info "SUB-VAL.compare: deployment needs #{dep_count}. subscriptions supply #{count}. Valid? #{valid}"
+            end
           end
         end
 

--- a/server/test/lib/fusor/subscriptions/subscription_info_test.rb
+++ b/server/test/lib/fusor/subscriptions/subscription_info_test.rb
@@ -1,0 +1,76 @@
+require 'test_plugin_helper'
+
+module Utils::Fusor
+  class SubscriptionInfoTest < ActiveSupport::TestCase
+    def setup
+      #@subval = Fusor::Subscriptions::SubscriptionValidator.new
+    end
+
+    test "product key should return multiple keys" do
+      si = Fusor::Subscriptions::SubscriptionInfo.new("satellite-tpapaioa_3")
+      si.update_counts("awesome product", 20)
+      si.update_counts("another awesome product", 10)
+      si.update_counts("should not get returned", 1)
+      si.add_product_ids("awesome product", ["201", "69", "205", "180", "240", "167", "303"])
+      si.add_product_ids("another awesome product", ["183", "307", "150", "328"])
+      si.add_product_ids("should not get returned", ["1", "3", "15", "32"])
+      keys = si.get_product_keys(["69", "183", "150"])
+      assert_equal false, keys.nil?
+      assert_equal false, keys.empty?
+      assert_equal 2, keys.count
+      assert_equal true, (["awesome product", "another awesome product"] - keys).empty?
+    end
+
+    test "product key should return empty" do
+      si = Fusor::Subscriptions::SubscriptionInfo.new("satellite-tpapaioa_3")
+      si.update_counts("awesome product", 20)
+      si.add_product_ids("awesome product", ["201", "69", "205", "180", "240", "167", "303"])
+      keys = si.get_product_keys(["6", "18", "15"])
+      assert_equal false, keys.nil?
+      assert_equal true, keys.empty?
+      assert_equal 0, keys.count
+    end
+
+    test "product ids updated by add" do
+      si = Fusor::Subscriptions::SubscriptionInfo.new("add-products")
+      ids = ["10", "20", "30"]
+      si.add_product_ids(:product, ids)
+      assert_equal false, si.get_product_ids.empty?
+      # ensure the sets are equal
+      assert_equal true, (si.get_product_ids[:product] - ids).empty?
+    end
+
+    test "add products removes duplicates" do
+      si = Fusor::Subscriptions::SubscriptionInfo.new("add-products")
+      ids = ["10", "30", "20", "30", "20"]
+      si.add_product_ids(:product, ids)
+      assert_equal false, si.get_product_ids.empty?
+      assert_equal 3, si.get_product_ids[:product].count
+    end
+
+    test "update counts" do
+      si = Fusor::Subscriptions::SubscriptionInfo.new("update-counts")
+      si.update_counts(:product, 10)
+      assert_equal 10, si.get_counts_by_name(:product)
+      si.update_counts(:product, 20)
+      assert_equal 30, si.get_counts_by_name(:product)
+    end
+
+    test "update counts handles nil" do
+      si = Fusor::Subscriptions::SubscriptionInfo.new("update-counts")
+      si.update_counts(:product, nil)
+      assert_equal 0, si.get_counts_by_name(:product)
+    end
+
+    test "flatten products" do
+      si = Fusor::Subscriptions::SubscriptionInfo.new("flatten")
+      ids1 = ["10", "20", "30"]
+      ids2 = ["30", "40", "50"]
+      si.add_product_ids(:product1, ids1)
+      si.add_product_ids(:product2, ids2)
+      assert_equal 5, si.flatten_product_ids.count
+      combined = ids1 + ids2
+      assert_equal combined.uniq, si.flatten_product_ids
+    end
+  end
+end

--- a/server/test/lib/fusor/subscriptions/subscription_validator_test.rb
+++ b/server/test/lib/fusor/subscriptions/subscription_validator_test.rb
@@ -61,5 +61,86 @@ module Utils::Fusor
         @subval.validate(deployment, session, manifest_imported, disconnected)
       end
     end
+
+    # BZ 1366338
+    test "compare passes if multiple subs have enough to cover the deployment" do
+      deployment_si = Fusor::Subscriptions::SubscriptionInfo.new("tpapaioa_3")
+      deployment_si.update_counts(:rhev, 1)
+      deployment_si.add_product_ids(:rhev, ["69", "150", "183"])
+      satellite_si = Fusor::Subscriptions::SubscriptionInfo.new("satellite-tpapaioa_3")
+      satellite_si.update_counts("CloudForms Employee Subscription", 20)
+      satellite_si.update_counts("RHEV Employee Subscription", 10)
+      satellite_si.add_product_ids("CloudForms Employee Subscription", ["201", "69", "205", "180", "240", "167", "303"])
+      satellite_si.add_product_ids("RHEV Employee Subscription", ["183", "307", "150", "328"])
+
+      assert_equal true, @subval.send(:compare, deployment_si, satellite_si)
+    end
+
+    test "compare fails when not enough entitlements" do
+      deployment_si = Fusor::Subscriptions::SubscriptionInfo.new("tpapaioa_3")
+      deployment_si.update_counts(:rhev, 2)
+      deployment_si.add_product_ids(:rhev, ["69", "150", "183"])
+      satellite_si = Fusor::Subscriptions::SubscriptionInfo.new("satellite-tpapaioa_3")
+      satellite_si.update_counts("CloudForms Employee Subscription", 1)
+      satellite_si.update_counts("RHEV Employee Subscription", 1)
+      satellite_si.add_product_ids("CloudForms Employee Subscription", ["201", "69", "205", "180", "240", "167", "303"])
+      satellite_si.add_product_ids("RHEV Employee Subscription", ["183", "307", "150", "328"])
+
+      assert_equal false, @subval.send(:compare, deployment_si, satellite_si)
+    end
+
+    test "compare fails when at least one not enough entitlements" do
+      deployment_si = Fusor::Subscriptions::SubscriptionInfo.new("tpapaioa_3")
+      deployment_si.update_counts(:rhev, 2)
+      deployment_si.add_product_ids(:rhev, ["69", "150", "183"])
+      satellite_si = Fusor::Subscriptions::SubscriptionInfo.new("satellite-tpapaioa_3")
+      satellite_si.update_counts("CloudForms Employee Subscription", 1)
+      satellite_si.update_counts("RHEV Employee Subscription", 10)
+      satellite_si.add_product_ids("CloudForms Employee Subscription", ["201", "69", "205", "180", "240", "167", "303"])
+      satellite_si.add_product_ids("RHEV Employee Subscription", ["183", "307", "150", "328"])
+
+      assert_equal false, @subval.send(:compare, deployment_si, satellite_si)
+    end
+
+    test "compare passes if subs have enough to cover the deployment" do
+      deployment_si = Fusor::Subscriptions::SubscriptionInfo.new("tpapaioa_3")
+      deployment_si.update_counts(:rhev, 1)
+      deployment_si.add_product_ids(:rhev, ["69", "150", "183"])
+      satellite_si = Fusor::Subscriptions::SubscriptionInfo.new("satellite-tpapaioa_3")
+      satellite_si.update_counts("RHEV Subscription", 1)
+      satellite_si.add_product_ids("RHEV Subscription", ["69", "150", "183"])
+
+      assert_equal true, @subval.send(:compare, deployment_si, satellite_si)
+    end
+
+    test "products covered returns false if not enough" do
+      dep = ["69", "150", "183"]
+      other = ["201", "69", "205", "180", "240", "167", "303"]
+
+      assert_equal false, @subval.send(:products_covered?, dep, other)
+    end
+
+    test "products covered returns true if products are a subset" do
+      dep = ["69", "150", "183"]
+      other = ["69", "183", "307", "150", "328"]
+
+      assert_equal true, @subval.send(:products_covered?, dep, other)
+    end
+
+    test "products covered returns true if products are equal" do
+      dep = ["69", "150", "183"]
+      other = ["69", "183", "150"]
+
+      assert_equal true, @subval.send(:products_covered?, dep, other)
+    end
+
+    test "get product ids from config nil key" do
+      assert_equal true, @subval.send(:get_product_ids_from_config, nil).empty?
+    end
+
+    test "get product ids from config " do
+      assert_equal false, @subval.send(:get_product_ids_from_config, /rhev/).empty?
+    end
+
   end
 end


### PR DESCRIPTION
The validation assumed wrongly that a product would be covered by a single
subscription, but there are cases where a product is covered by multiple
subscriptions. For example, Awesome Virtualization could require Virtualization
subscription, Awesome OS subscription, and Awesome Middleware subscription to
cover a single Awesome Virtualization product.