### PR TITLE
added rhv cpu family auto-detection

### DIFF
--- a/fusor-ember-cli/app/controllers/rhev-options.js
+++ b/fusor-ember-cli/app/controllers/rhev-options.js
@@ -13,10 +13,12 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
   confirmRhevRootPassword: Ember.computed.alias("deploymentController.confirmRhevRootPassword"),
   confirmRhevEngineAdminPassword: Ember.computed.alias("deploymentController.confirmRhevEngineAdminPassword"),
 
-  cpuTypes: ['Intel Conroe Family', 'Intel Penryn Family', 'Intel Nehalem Family',
-             'Intel Westmere Family', 'Intel SandyBridge Family', 'Intel Haswell Family',
-             'Intel Haswell-noTSX Family', 'AMD Opteron G1', 'AMD Opteron G2',
-             'AMD Opteron G3', 'AMD Opteron G4', 'AMD Opteron G5', 'IBM POWER 8'],
+  cpuTypes: Ember.computed('model.cpu_families', function() {
+    return this.get('model.cpu_families');
+  }),
+  defaultCpuFamily: Ember.computed('model.default_family', function() {
+    return this.get('model.default_family');
+  }),
 
   passwordValidator: RequiredPasswordValidator.create({}),
 

--- a/fusor-ember-cli/app/routes/rhev-options.js
+++ b/fusor-ember-cli/app/routes/rhev-options.js
@@ -1,6 +1,19 @@
 import Ember from 'ember';
+import request from 'ic-ajax';
 
 export default Ember.Route.extend({
+  model() {
+    var deploymentId = this.modelFor('deployment').get('id');
+    return request({
+      url: `/fusor/api/v21/deployments/${deploymentId}/compatible_cpu_families`,
+      type: 'GET',
+      headers: {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "X-CSRF-Token": Ember.$('meta[name="csrf-token"]').attr('content')
+      }
+    });
+  },
   deactivate() {
     return this.send('saveDeployment', null);
   }

--- a/fusor-ember-cli/app/templates/rhev-options.hbs
+++ b/fusor-ember-cli/app/templates/rhev-options.hbs
@@ -30,7 +30,7 @@
         {{select-simple-f label="CPU Type"
                           content=cpuTypes
                           value=rhevCpuType
-                          prompt="Intel Nehalem Family"
+                          prompt=defaultCpuFamily
                           renderInPlace=true
                           disabled=isStarted
                           action="setSelectValue"
@@ -46,4 +46,3 @@
                    disableNext=disableNextRhevOptions
                    disableCancel=isStarted
                    deploymentName=deploymentName}}
-

--- a/server/app/controllers/fusor/api/v21/deployments_controller.rb
+++ b/server/app/controllers/fusor/api/v21/deployments_controller.rb
@@ -13,6 +13,7 @@
 require "net/http"
 require "sys/filesystem"
 require "uri"
+require "json"
 
 module Fusor
   class Api::V21::DeploymentsController < Api::V2::DeploymentsController
@@ -135,128 +136,11 @@ module Fusor
     end
 
     def compatible_cpu_families
-      # @deployment is provided by pre-filter run of find_deployment
-      rhv_hypervisors_list = @deployment.discovered_hosts
-
-      # find the fact_name_id corresponding to "processors"
-      processors_id = FactName.where(name: 'processors').first.id
-
-      # build string containing all cpu families attached to hypervisors
-      processor_concat = ''
-
-      rhv_hypervisors_list.each do |hypervisor|
-        processor_str = hypervisor.fact_values.where("fact_name_id" => processors_id).first.value
-        processor_hash = eval(processor_str)
-        processor_models = processor_hash["models"]
-        processor_concat << (processor_models.join(' ; ').downcase)
-      end
-
-      cpu_families_and_default = lcd_of_cpus(processor_concat)
-      render json: cpu_families_and_default, status: 200
+      rhv_hypervisors = @deployment.discovered_hosts
+      cpu_families = Utils::Fusor::CpuCompatDetector.rhv_cpu_families(rhv_hypervisors)
+      render json: cpu_families, status: 200
     end
 
-    def lcd_of_cpus(processor_concat)
-      # description: # finds oldest architecture, brand in rhv cluster
-
-      # input:  processor_concat = all processors in cluster as string
-      # output: a compatible list of cpu families will be returned oldest first.
-      # output: a best guess default cpu family to display
-
-      # if intel processors are being used, installed generation and older will be returned
-      # if amd processors are being used, all amd processors will returned
-      # if ibm processors are being used, all ibm processors will be returned
-      # if auto-detection doesn't match any processors, all options will be returned
-      cpu_fam_candidates = {
-        'intel': [
-          'Intel Conroe Family',
-          'Intel Penryn Family',
-          'Intel Nehalem Family',
-          'Intel Westmere Family',
-          'Intel SandyBridge Family',
-          'Intel Haswell-noTSX Family',
-          'Intel Haswell Family',
-        ],
-        'amd': [
-          'AMD Opteron G1',
-          'AMD Opteron G2',
-          'AMD Opteron G3',
-          'AMD Opteron G4',
-          'AMD Opteron G5'
-        ],
-        'ibm': [
-          'IBM POWER 8'
-        ]
-      }
-
-      # cpu family of cluster should match the oldest cpu present
-      # in the cluster, therefore newest processors are checked first
-      # and can be overwritten by older processor later in iteration
-      cpu_fams = [
-        # Intel processor families
-        { brand: 'intel', keywords: ['intel'], position: -1 }, #intel wildcard
-        { brand: 'intel', keywords: ['haswell'], position: 6 },
-        { brand: 'intel', keywords: ['haswell', 'no', 'tsx'], position: 5 },
-        { brand: 'intel', keywords: ['sandy', 'bridge'], position: 4 },
-        { brand: 'intel', keywords: ['westmere'], position: 3 },
-        { brand: 'intel', keywords: ['nehalem'], position: 2 },
-        { brand: 'intel', keywords: ['penryn'], position: 1 },
-        { brand: 'intel', keywords: ['conroe'], position: 0 },
-        # AMD processor families - no generational trimming
-        { brand: 'amd', keywords: ['amd'], position: -1 }, #amd wildcard
-        # IBM processor families
-        { brand: 'ibm', keywords: ['ibm'], position: -1 }, #ibm wildcard
-        { brand: 'ibm', keywords: ['ibm', 'power', '8'], position: 0 },
-      ]
-
-      # placeholder for best compatible cpu family for cluster
-      best_cpu_fam = { brand: 'none', keywords: [], value: -1 }
-
-      # iterate through cpu_fams looking for keyword matches
-      cpu_fams.each do |cpu_fam|
-        # if brand_X cpu found, break once we start checking brand_Z
-        if !(best_cpu_fam[:brand] == (cpu_fam[:brand]) || best_cpu_fam[:brand] == ('none'))
-          break
-        end
-        # ensure that all keywords match before setting new compatible best cpu family
-        if cpu_fam[:keywords].all? { |keyword| processor_concat.include? keyword }
-          best_cpu_fam = cpu_fam
-        end
-      end
-
-      if best_cpu_fam[:brand] == 'none'
-        # return all cpu families if keyword matches failed
-        all_cpu_fams = []
-        cpu_fam_candidates.values.each do |brand_fams| all_cpu_fams << brand_fams end
-        all_cpu_fams.flatten!
-        return {
-          cpu_families: all_cpu_fams,
-          default_family: 'Intel Nehalem Family'
-        }
-      else
-        # we were able to detect a brand
-        if best_cpu_fam[:position] == -1
-          # set default cpu family per brand
-          # this is used if a specific CPU family cannot be detected
-          case best_cpu_fam[:brand]
-          when 'intel'
-            default_fam = 'Intel Nehalem Family'
-          when 'amd'
-            default_fam = 'AMD Opteron G3'
-          when 'ibm'
-            default_fam = 'IBM POWER 8'
-          end
-        else
-          # if a known cpu family is detected in the cluster, set it as the default
-          default_fam = cpu_fam_candidates[best_cpu_fam[:brand].to_sym][best_cpu_fam[:position]]
-        end
-
-        return {
-          # keep all families from best_cpu_fam and older
-          cpu_families: cpu_fam_candidates[best_cpu_fam[:brand].to_sym][0..best_cpu_fam[:position]],
-          default_family: default_fam
-        }
-      end
-    end
 
     def check_mount_point
       mount_address = params['address']

--- a/server/app/controllers/fusor/api/v21/deployments_controller.rb
+++ b/server/app/controllers/fusor/api/v21/deployments_controller.rb
@@ -18,7 +18,8 @@ module Fusor
   class Api::V21::DeploymentsController < Api::V2::DeploymentsController
 
     before_filter :find_deployment, :only => [:destroy, :show, :update, :check_mount_point,
-                                              :deploy, :redeploy, :validate, :log, :openshift_disk_space]
+                                              :deploy, :redeploy, :validate, :log,
+                                              :openshift_disk_space, :compatible_cpu_families]
 
     rescue_from Encoding::UndefinedConversionError, :with => :ignore_it
 
@@ -130,6 +131,130 @@ module Fusor
         message = 'Malformed request'
         message = error.message if error.respond_to?(:message)
         render json: { :error => message }, status: 400
+      end
+    end
+
+    def compatible_cpu_families
+      # @deployment is provided by pre-filter run of find_deployment
+      rhv_hypervisors_list = @deployment.discovered_hosts
+
+      # find the fact_name_id corresponding to "processors"
+      processors_id = FactName.where(name: 'processors').first.id
+
+      # build string containing all cpu families attached to hypervisors
+      processor_concat = ''
+
+      rhv_hypervisors_list.each do |hypervisor|
+        processor_str = hypervisor.fact_values.where("fact_name_id" => processors_id).first.value
+        processor_hash = eval(processor_str)
+        processor_models = processor_hash["models"]
+        processor_concat << (processor_models.join(' ; ').downcase)
+      end
+
+      cpu_families_and_default = lcd_of_cpus(processor_concat)
+      render json: cpu_families_and_default, status: 200
+    end
+
+    def lcd_of_cpus(processor_concat)
+      # description: # finds oldest architecture, brand in rhv cluster
+
+      # input:  processor_concat = all processors in cluster as string
+      # output: a compatible list of cpu families will be returned oldest first.
+      # output: a best guess default cpu family to display
+
+      # if intel processors are being used, installed generation and older will be returned
+      # if amd processors are being used, all amd processors will returned
+      # if ibm processors are being used, all ibm processors will be returned
+      # if auto-detection doesn't match any processors, all options will be returned
+      cpu_fam_candidates = {
+        'intel': [
+          'Intel Conroe Family',
+          'Intel Penryn Family',
+          'Intel Nehalem Family',
+          'Intel Westmere Family',
+          'Intel SandyBridge Family',
+          'Intel Haswell-noTSX Family',
+          'Intel Haswell Family',
+        ],
+        'amd': [
+          'AMD Opteron G1',
+          'AMD Opteron G2',
+          'AMD Opteron G3',
+          'AMD Opteron G4',
+          'AMD Opteron G5'
+        ],
+        'ibm': [
+          'IBM POWER 8'
+        ]
+      }
+
+      # cpu family of cluster should match the oldest cpu present
+      # in the cluster, therefore newest processors are checked first
+      # and can be overwritten by older processor later in iteration
+      cpu_fams = [
+        # Intel processor families
+        { brand: 'intel', keywords: ['intel'], position: -1 }, #intel wildcard
+        { brand: 'intel', keywords: ['haswell'], position: 6 },
+        { brand: 'intel', keywords: ['haswell', 'no', 'tsx'], position: 5 },
+        { brand: 'intel', keywords: ['sandy', 'bridge'], position: 4 },
+        { brand: 'intel', keywords: ['westmere'], position: 3 },
+        { brand: 'intel', keywords: ['nehalem'], position: 2 },
+        { brand: 'intel', keywords: ['penryn'], position: 1 },
+        { brand: 'intel', keywords: ['conroe'], position: 0 },
+        # AMD processor families - no generational trimming
+        { brand: 'amd', keywords: ['amd'], position: -1 }, #amd wildcard
+        # IBM processor families
+        { brand: 'ibm', keywords: ['ibm'], position: -1 }, #ibm wildcard
+        { brand: 'ibm', keywords: ['ibm', 'power', '8'], position: 0 },
+      ]
+
+      # placeholder for best compatible cpu family for cluster
+      best_cpu_fam = { brand: 'none', keywords: [], value: -1 }
+
+      # iterate through cpu_fams looking for keyword matches
+      cpu_fams.each do |cpu_fam|
+        # if brand_X cpu found, break once we start checking brand_Z
+        if !(best_cpu_fam[:brand] == (cpu_fam[:brand]) || best_cpu_fam[:brand] == ('none'))
+          break
+        end
+        # ensure that all keywords match before setting new compatible best cpu family
+        if cpu_fam[:keywords].all? { |keyword| processor_concat.include? keyword }
+          best_cpu_fam = cpu_fam
+        end
+      end
+
+      if best_cpu_fam[:brand] == 'none'
+        # return all cpu families if keyword matches failed
+        all_cpu_fams = []
+        cpu_fam_candidates.values.each do |brand_fams| all_cpu_fams << brand_fams end
+        all_cpu_fams.flatten!
+        return {
+          cpu_families: all_cpu_fams,
+          default_family: 'Intel Nehalem Family'
+        }
+      else
+        # we were able to detect a brand
+        if best_cpu_fam[:position] == -1
+          # set default cpu family per brand
+          # this is used if a specific CPU family cannot be detected
+          case best_cpu_fam[:brand]
+          when 'intel'
+            default_fam = 'Intel Nehalem Family'
+          when 'amd'
+            default_fam = 'AMD Opteron G3'
+          when 'ibm'
+            default_fam = 'IBM POWER 8'
+          end
+        else
+          # if a known cpu family is detected in the cluster, set it as the default
+          default_fam = cpu_fam_candidates[best_cpu_fam[:brand].to_sym][best_cpu_fam[:position]]
+        end
+
+        return {
+          # keep all families from best_cpu_fam and older
+          cpu_families: cpu_fam_candidates[best_cpu_fam[:brand].to_sym][0..best_cpu_fam[:position]],
+          default_family: default_fam
+        }
       end
     end
 

--- a/server/app/lib/utils/fusor/cpu_compat_detector.rb
+++ b/server/app/lib/utils/fusor/cpu_compat_detector.rb
@@ -1,0 +1,133 @@
+##
+# CpuCompatDetector
+# =================
+# Detects compatible CPU families for a RHV cluster
+
+module Utils
+  module Fusor
+    class CpuCompatDetector
+      def self.rhv_cpu_families(discovered_hosts)
+        # gets cpu families that will be compatible with a rhv hypervisor cluster
+        # returns { cpu_families: ['intelX', 'intelZ'], default_family: 'intelX'}
+        # requires @deployment to have hypervisor host(s) attached.
+        processors = processor_concat(discovered_hosts)
+        return resolve_compatible_cpus(processors)
+      end
+
+      def self.processor_concat(discovered_hosts)
+        processor_concat = ''
+        host_ids = discovered_hosts.map { |h| h.id }
+        # snippet by jesusr
+        # get fact_values for the 'processors' fact_name, for all hypervisors (discovered_hosts)
+        FactValue.joins(:fact_name).where(:fact_names => { :name => 'processors' }, :host_id => host_ids).each do |procs|
+          processor_concat << (JSON.parse(procs.value.gsub('=>', ':'))["models"].join(' ; ').downcase)
+        end
+        return processor_concat
+      end
+
+      def self.resolve_compatible_cpus(processor_concat)
+        # description: finds oldest cpu architecture, brand in rhv cluster.
+        #              returns compatible cpus (oldest found + older)
+
+        # input:  processor_concat = all processors in cluster as string
+        # output: a compatible list of cpu families will be returned oldest first.
+        # output: a best guess default cpu family to display
+
+        # if intel processors are being used, installed generation and older will be returned
+        # if amd processors are being used, all amd processors will returned
+        # if ibm processors are being used, all ibm processors will be returned
+        # if auto-detection doesn't match any processors, all options will be returned
+        cpu_fam_candidates = {
+          'intel': [
+            'Intel Conroe Family',
+            'Intel Penryn Family',
+            'Intel Nehalem Family',
+            'Intel Westmere Family',
+            'Intel SandyBridge Family',
+            'Intel Haswell-noTSX Family',
+            'Intel Haswell Family'
+          ],
+          'amd': [
+            'AMD Opteron G1',
+            'AMD Opteron G2',
+            'AMD Opteron G3',
+            'AMD Opteron G4',
+            'AMD Opteron G5'
+          ],
+          'ibm': [
+            'IBM POWER 8'
+          ]
+        }
+
+        # cpu family of cluster should match the oldest cpu present
+        # in the cluster, therefore newest processors are checked first
+        # and can be overwritten by older processor later in iteration
+        cpu_fams = [
+          # Intel processor families
+          { brand: 'intel', keywords: ['intel'], position: -1 }, #intel wildcard
+          { brand: 'intel', keywords: ['haswell'], position: 6 },
+          { brand: 'intel', keywords: ['haswell', 'no', 'tsx'], position: 5 },
+          { brand: 'intel', keywords: ['sandy', 'bridge'], position: 4 },
+          { brand: 'intel', keywords: ['westmere'], position: 3 },
+          { brand: 'intel', keywords: ['nehalem'], position: 2 },
+          { brand: 'intel', keywords: ['penryn'], position: 1 },
+          { brand: 'intel', keywords: ['conroe'], position: 0 },
+          # AMD processor families - no generational trimming
+          { brand: 'amd', keywords: ['amd'], position: -1 }, #amd wildcard
+          # IBM processor families
+          { brand: 'ibm', keywords: ['ibm'], position: -1 }, #ibm wildcard
+          { brand: 'ibm', keywords: ['ibm', 'power', '8'], position: 0 }
+        ]
+
+        # placeholder for best compatible cpu family for cluster
+        best_cpu_fam = { brand: 'none', keywords: [], value: -1 }
+
+        # iterate through cpu_fams looking for keyword matches
+        cpu_fams.each do |cpu_fam|
+          # if brand_X cpu found, break once we start checking brand_Z
+          if !(best_cpu_fam[:brand] == (cpu_fam[:brand]) || best_cpu_fam[:brand] == ('none'))
+            break
+          end
+          # ensure that all keywords match before setting new compatible best cpu family
+          if cpu_fam[:keywords].all? { |keyword| processor_concat.include? keyword }
+            best_cpu_fam = cpu_fam
+          end
+        end
+
+        if best_cpu_fam[:brand] == 'none'
+          # return all cpu families if keyword matches failed
+          all_cpu_fams = []
+          cpu_fam_candidates.values.each do |brand_fams| all_cpu_fams << brand_fams end
+          all_cpu_fams.flatten!
+          return {
+            cpu_families: all_cpu_fams,
+            default_family: 'Intel Nehalem Family'
+          }
+        else
+          # we were able to detect a brand
+          if best_cpu_fam[:position] == -1
+            # set default cpu family per brand
+            # this is used if a specific CPU family cannot be detected
+            case best_cpu_fam[:brand]
+            when 'intel'
+              default_fam = 'Intel Nehalem Family'
+            when 'amd'
+              default_fam = 'AMD Opteron G3'
+            when 'ibm'
+              default_fam = 'IBM POWER 8'
+            end
+          else
+            # if a known cpu family is detected in the cluster, set it as the default
+            default_fam = cpu_fam_candidates[best_cpu_fam[:brand].to_sym][best_cpu_fam[:position]]
+          end
+
+          return {
+            # keep all families from best_cpu_fam and older
+            cpu_families: cpu_fam_candidates[best_cpu_fam[:brand].to_sym][0..best_cpu_fam[:position]],
+            default_family: default_fam
+          }
+        end
+      end
+    end
+  end
+end

--- a/server/config/routes/api/v21.rb
+++ b/server/config/routes/api/v21.rb
@@ -11,6 +11,7 @@ Fusor::Engine.routes.draw do
             get :log
             get :openshift_disk_space
             get :check_mount_point
+            get :compatible_cpu_families
           end
         end
         resources :openstack_deployments do

--- a/server/test/controllers/deployments_controller_test.rb
+++ b/server/test/controllers/deployments_controller_test.rb
@@ -515,59 +515,13 @@ module Fusor
       end
     end
 
-    context 'lcd_of_cpus' do
-      test 'lcd_of_cpus should return all cpus if no known brands found in cluster cpu list' do
-        processor_concat = 'unlisted brand quad core processor ; ' * 4
-        cpu_families_and_default = @controller.lcd_of_cpus(processor_concat)
-        cpu_families = cpu_families_and_default[:cpu_families]
-        default_family = cpu_families_and_default[:default_family]
-        cpu_families_concat = cpu_families.join(" ; ")
-        assert cpu_families_concat.downcase.include?('intel')
-        assert cpu_families_concat.downcase.include?('amd')
-        assert cpu_families_concat.downcase.include?('ibm')
-        assert default_family.downcase.include?('intel nehalem')
-      end
-
-      test 'lcd_of_cpus should return all intel cpus if "intel" found, but known arch not found' do
-        processor_concat = 'intel core processor (baybridge, not_real) ; ' * 4
-        cpu_families_and_default = @controller.lcd_of_cpus(processor_concat)
-        cpu_families = cpu_families_and_default[:cpu_families]
-        cpu_families.each do |cpu_fam| assert cpu_fam.downcase.include?('intel') end
-      end
-
-      test 'lcd_of_cpus should return all amd cpus if "amd" found, but known arch not found' do
-        processor_concat = 'amd opteron(tm) processor 6172 ; ' * 4
-        processor_concat << 'amd opteron(tm) processor 4362 ; ' * 4
-        cpu_families_and_default = @controller.lcd_of_cpus(processor_concat)
-        cpu_families = cpu_families_and_default[:cpu_families]
-        cpu_families.each do |cpu_fam| assert cpu_fam.downcase.include?('amd') end
-      end
-
-      test 'lcd_of_cpus should return all ibm cpus if "ibm" found, but known arch not found' do
-        processor_concat = 'ibm powerpc processor ; ' * 4
-        cpu_families_and_default = @controller.lcd_of_cpus(processor_concat)
-        cpu_families = cpu_families_and_default[:cpu_families]
-        cpu_families.each do |cpu_fam| assert cpu_fam.downcase.include?('ibm') end
-      end
-
-      test 'lcd_of_cpus should return haswell-notsx and older if entire cluster is haswell-notsx' do
-        processor_concat = 'intel core processor (haswell, no tsx) ; ' * 4
-        cpu_families_and_default = @controller.lcd_of_cpus(processor_concat)
-        cpu_families = cpu_families_and_default[:cpu_families]
-        default_family = cpu_families_and_default[:default_family]
-        assert default_family.downcase.include?('notsx')
-        assert cpu_families.count == 6
-        cpu_families.each do |cpu_fam| assert cpu_fam.downcase.include?('intel') end
-      end
-
-      test 'lcd_of_cpus should return nehalem, penryn, and conroe if sandybridge and nehalem cpus in cluster' do
-        processor_concat = 'intel core processor (sandybridge, no tsx) ; ' * 4
-        processor_concat << 'intel core processor (nehalem, no tsx) ; ' * 4
-        cpu_families_and_default = @controller.lcd_of_cpus(processor_concat)
-        cpu_families = cpu_families_and_default[:cpu_families]
-        default_family = cpu_families_and_default[:default_family]
-        assert cpu_families.count == 3
-        assert default_family.downcase.include?('nehalem')
+    context 'cpu_compat_detector' do
+      test 'compatible_cpu_families should return a compatible list of cpus' do
+        @deployment.discovered_hosts = [hosts(:host_haswell)]
+        response = JSON.parse(get(:compatible_cpu_families, :id => @deployment.id).body)
+        assert_response :success
+        assert response['cpu_families'].count == 6
+        assert response['default_family'].include?('Haswell-noTSX')
       end
     end
   end

--- a/server/test/controllers/deployments_controller_test.rb
+++ b/server/test/controllers/deployments_controller_test.rb
@@ -515,5 +515,60 @@ module Fusor
       end
     end
 
+    context 'lcd_of_cpus' do
+      test 'lcd_of_cpus should return all cpus if no known brands found in cluster cpu list' do
+        processor_concat = 'unlisted brand quad core processor ; ' * 4
+        cpu_families_and_default = @controller.lcd_of_cpus(processor_concat)
+        cpu_families = cpu_families_and_default[:cpu_families]
+        default_family = cpu_families_and_default[:default_family]
+        cpu_families_concat = cpu_families.join(" ; ")
+        assert cpu_families_concat.downcase.include?('intel')
+        assert cpu_families_concat.downcase.include?('amd')
+        assert cpu_families_concat.downcase.include?('ibm')
+        assert default_family.downcase.include?('intel nehalem')
+      end
+
+      test 'lcd_of_cpus should return all intel cpus if "intel" found, but known arch not found' do
+        processor_concat = 'intel core processor (baybridge, not_real) ; ' * 4
+        cpu_families_and_default = @controller.lcd_of_cpus(processor_concat)
+        cpu_families = cpu_families_and_default[:cpu_families]
+        cpu_families.each do |cpu_fam| assert cpu_fam.downcase.include?('intel') end
+      end
+
+      test 'lcd_of_cpus should return all amd cpus if "amd" found, but known arch not found' do
+        processor_concat = 'amd opteron(tm) processor 6172 ; ' * 4
+        processor_concat << 'amd opteron(tm) processor 4362 ; ' * 4
+        cpu_families_and_default = @controller.lcd_of_cpus(processor_concat)
+        cpu_families = cpu_families_and_default[:cpu_families]
+        cpu_families.each do |cpu_fam| assert cpu_fam.downcase.include?('amd') end
+      end
+
+      test 'lcd_of_cpus should return all ibm cpus if "ibm" found, but known arch not found' do
+        processor_concat = 'ibm powerpc processor ; ' * 4
+        cpu_families_and_default = @controller.lcd_of_cpus(processor_concat)
+        cpu_families = cpu_families_and_default[:cpu_families]
+        cpu_families.each do |cpu_fam| assert cpu_fam.downcase.include?('ibm') end
+      end
+
+      test 'lcd_of_cpus should return haswell-notsx and older if entire cluster is haswell-notsx' do
+        processor_concat = 'intel core processor (haswell, no tsx) ; ' * 4
+        cpu_families_and_default = @controller.lcd_of_cpus(processor_concat)
+        cpu_families = cpu_families_and_default[:cpu_families]
+        default_family = cpu_families_and_default[:default_family]
+        assert default_family.downcase.include?('notsx')
+        assert cpu_families.count == 6
+        cpu_families.each do |cpu_fam| assert cpu_fam.downcase.include?('intel') end
+      end
+
+      test 'lcd_of_cpus should return nehalem, penryn, and conroe if sandybridge and nehalem cpus in cluster' do
+        processor_concat = 'intel core processor (sandybridge, no tsx) ; ' * 4
+        processor_concat << 'intel core processor (nehalem, no tsx) ; ' * 4
+        cpu_families_and_default = @controller.lcd_of_cpus(processor_concat)
+        cpu_families = cpu_families_and_default[:cpu_families]
+        default_family = cpu_families_and_default[:default_family]
+        assert cpu_families.count == 3
+        assert default_family.downcase.include?('nehalem')
+      end
+    end
   end
 end

--- a/server/test/fixtures/fact_names.yml
+++ b/server/test/fixtures/fact_names.yml
@@ -1,0 +1,11 @@
+fact_name_memory:
+  name: memory
+
+fact_name_processors:
+  name: processors
+
+fact_name_hostname:
+  name: hostname
+
+fact_name_storage:
+  name: storage

--- a/server/test/fixtures/fact_values.yml
+++ b/server/test/fixtures/fact_values.yml
@@ -1,0 +1,19 @@
+fact_storage:
+  host: host_haswell
+  fact_name: fact_name_storage
+  value: 200 GB
+
+fact_hostname:
+  host: host_haswell
+  fact_name: fact_name_hostname
+  value: sat62devg.example.com
+
+fact_memory:
+  host: host_haswell
+  fact_name: fact_name_memory
+  value: 4096 MB
+
+fact_processors:
+  host: host_haswell
+  fact_name: fact_name_processors
+  value: '{ "processorcount" :  16, "models" : [ "Intel Haswell-noTSX", "Intel Haswell-noTSX" ] }'

--- a/server/test/fixtures/hosts.yml
+++ b/server/test/fixtures/hosts.yml
@@ -35,3 +35,6 @@ managed_host1:
 managed_host2:
   name: managed2
   type: 'Host::Managed'
+
+host_haswell:
+  name: haswell1

--- a/server/test/lib/utils/fusor/cpu_compat_detector_test.rb
+++ b/server/test/lib/utils/fusor/cpu_compat_detector_test.rb
@@ -1,0 +1,68 @@
+require 'test_plugin_helper'
+
+module Utils::Fusor
+  class CpuCompatDetectorTest < ActiveSupport::TestCase
+
+    test 'cpu_compat_detector should resolve "processors" facts from discovered hosts' do
+      rhv_hypervisors_list = []
+      rhv_hypervisors_list << hosts(:host_haswell)
+      result = CpuCompatDetector.processor_concat(rhv_hypervisors_list)
+      assert result.scan('haswell-notsx').count == 2
+    end
+
+    test 'cpu_compat_detector should return all cpus if no known brands found in cluster cpu list' do
+      processor_concat = 'unlisted brand quad core processor ; ' * 4
+      cpu_families_and_default = CpuCompatDetector.resolve_compatible_cpus(processor_concat)
+      cpu_families = cpu_families_and_default[:cpu_families]
+      default_family = cpu_families_and_default[:default_family]
+      cpu_families_concat = cpu_families.join(" ; ")
+      assert cpu_families_concat.downcase.include?('intel')
+      assert cpu_families_concat.downcase.include?('amd')
+      assert cpu_families_concat.downcase.include?('ibm')
+      assert default_family.downcase.include?('intel nehalem')
+    end
+
+    test 'cpu_compat_detector should return all intel cpus if "intel" found, but known arch not found' do
+      processor_concat = 'intel core processor (baybridge, not_real) ; ' * 4
+      cpu_families_and_default = CpuCompatDetector.resolve_compatible_cpus(processor_concat)
+      cpu_families = cpu_families_and_default[:cpu_families]
+      cpu_families.each do |cpu_fam| assert cpu_fam.downcase.include?('intel') end
+    end
+
+    test 'cpu_compat_detector should return all amd cpus if "amd" found, but known arch not found' do
+      processor_concat = 'amd opteron(tm) processor 6172 ; ' * 4
+      processor_concat << 'amd opteron(tm) processor 4362 ; ' * 4
+      cpu_families_and_default = CpuCompatDetector.resolve_compatible_cpus(processor_concat)
+      cpu_families = cpu_families_and_default[:cpu_families]
+      cpu_families.each do |cpu_fam| assert cpu_fam.downcase.include?('amd') end
+    end
+
+    test 'cpu_compat_detector should return all ibm cpus if "ibm" found, but known arch not found' do
+      processor_concat = 'ibm powerpc processor ; ' * 4
+      cpu_families_and_default = CpuCompatDetector.resolve_compatible_cpus(processor_concat)
+      cpu_families = cpu_families_and_default[:cpu_families]
+      cpu_families.each do |cpu_fam| assert cpu_fam.downcase.include?('ibm') end
+    end
+
+    test 'cpu_compat_detector should return haswell-notsx and older if entire cluster is haswell-notsx' do
+      processor_concat = 'intel core processor (haswell, no tsx) ; ' * 4
+      cpu_families_and_default = CpuCompatDetector.resolve_compatible_cpus(processor_concat)
+      cpu_families = cpu_families_and_default[:cpu_families]
+      default_family = cpu_families_and_default[:default_family]
+      assert default_family.downcase.include?('notsx')
+      assert cpu_families.count == 6
+      cpu_families.each do |cpu_fam| assert cpu_fam.downcase.include?('intel') end
+    end
+
+    test 'cpu_compat_detector should return nehalem, penryn, and conroe if sandybridge and nehalem cpus in cluster' do
+      processor_concat = 'intel core processor (sandybridge, no tsx) ; ' * 4
+      processor_concat << 'intel core processor (nehalem, no tsx) ; ' * 4
+      cpu_families_and_default = CpuCompatDetector.resolve_compatible_cpus(processor_concat)
+      cpu_families = cpu_families_and_default[:cpu_families]
+      default_family = cpu_families_and_default[:default_family]
+      assert cpu_families.count == 3
+      assert default_family.downcase.include?('nehalem')
+    end
+
+  end
+end


### PR DESCRIPTION
_Change Description:_
Examines discovered host facts and attempts to determine CPU family options for RHV cluster. Attempts to hide incompatible CPU families and auto-select best guess for compatible CPU family.

_Example:_ 
If you have an Intel Haswell-noTSX processor in your system, the "CPU Type" dropdown box should only display "Intel Haswell-noTSX" and older CPU architectures. You should _not_ see "Intel Haswell" since it is a newer architecture and is not compatible with noTSX machines. Additionally, you should notice that "Intel Haswell-noTSX" has been auto-selected since it is the newest compatible CPU family.

_Defaults:_
- Intel Nehalem (no brand detected)
- Intel Nehalem (intel detected)
- AMD Opteron G3 (amd detected)
- IBM Power 8 (ibm detected)
