### PR TITLE
1374046 - Modified custom naming scheme

### DIFF
--- a/fusor-ember-cli/app/components/text-f.js
+++ b/fusor-ember-cli/app/components/text-f.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ValidatedInput from "../mixins/validated-input-mixin";
+import ValidatedInput from '../mixins/validated-input-mixin';
 
 export default Ember.Component.extend(ValidatedInput, {
 
@@ -17,6 +17,10 @@ export default Ember.Component.extend(ValidatedInput, {
     return (this.get('type') === 'password');
   }),
 
+  inputLength: Ember.computed('maxlength', function() {
+    return this.getWithDefault('maxlength', '250');
+  }),
+
   setOrigValue: Ember.on('didInsertElement', function () {
     this.set('origValue', this.get('value'));
   }),
@@ -29,10 +33,10 @@ export default Ember.Component.extend(ValidatedInput, {
       this.set('isEyeOpen', this.toggleProperty('isEyeOpen'));
       if (this.get('isEyeOpen')) {
         this.set('typeInput', 'password');
-        this.set('eyeIcon', "fa-eye");
+        this.set('eyeIcon', 'fa-eye');
       } else {
         this.set('typeInput', 'text');
-        this.set('eyeIcon', "fa-eye-slash");
+        this.set('eyeIcon', 'fa-eye-slash');
       }
     }
   }

--- a/fusor-ember-cli/app/controllers/hypervisor/discovered-host.js
+++ b/fusor-ember-cli/app/controllers/hypervisor/discovered-host.js
@@ -3,7 +3,8 @@ import NeedsDeploymentMixin from "../../mixins/needs-deployment-mixin";
 import {
   AllValidator,
   PresenceValidator,
-  AlphaNumericDashUnderscoreValidator
+  LengthValidator,
+  RegExpValidator
 } from '../../utils/validators';
 
 export default Ember.Controller.extend(NeedsDeploymentMixin, {
@@ -124,7 +125,11 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
   customPrefixValidator: AllValidator.create({
     validators: [
       PresenceValidator.create({}),
-      AlphaNumericDashUnderscoreValidator.create({})
+      LengthValidator.create({max: 40}),
+      RegExpValidator.create({
+        regExp: new RegExp(/^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*)$/),
+        message: 'Custom prefixes must begin with "a-z" or "0-9" and contain only "a-z", "0-9", "." or "-" characters.'
+      })
     ]
   }),
 

--- a/fusor-ember-cli/app/templates/components/naming-scheme-modal.hbs
+++ b/fusor-ember-cli/app/templates/components/naming-scheme-modal.hbs
@@ -24,6 +24,7 @@
                 </span>
                 {{#if isCustomScheme}}
                     {{text-f label='Prepend host names with'
+                             maxlength="40"
                              value=customPreprendName
                              disabled=isStarted
                              placeholder='Enter custom prefix'

--- a/fusor-ember-cli/app/templates/components/text-f.hbs
+++ b/fusor-ember-cli/app/templates/components/text-f.hbs
@@ -10,7 +10,7 @@
                      data-qci=cssId
                      disabled=disabled
                      autocomplete='off'
-                     maxlength="250"}}{{postText}}
+                     maxlength=inputLength}}{{postText}}
 
   {{#if canShowPassword}}
     <i {{action 'showPassword'}} class="fa {{eyeIcon}} eye-icon"></i>


### PR DESCRIPTION
Modified custom naming scheme so it would result in valid hypervisor names.
Disallow capital letters and underscores.
Limit to 40 characters.
Allow - and . after the first character.