### PR TITLE
1306823 - revise rhv engine selection table

### DIFF
--- a/fusor-ember-cli/app/components/tr-engine.js
+++ b/fusor-ember-cli/app/components/tr-engine.js
@@ -9,6 +9,13 @@ export default Ember.Component.extend(TrEngineHypervisorMixin, {
     }
   }),
 
+  isHypervisorOrStarted: Ember.computed('host', 'hypervisorModelIds.[]', 'isStarted', function() {
+    let hypervisorIds = this.get('hypervisorModelIds');
+    let isHypervisor = hypervisorIds && hypervisorIds.contains(this.get('host.id'));
+    let isStarted = this.get('isStarted');
+    return isHypervisor || isStarted;
+  }),
+
   isChecked: Ember.computed('isSelectedAsEngine', function () {
     return this.get('isSelectedAsEngine');
   }),

--- a/fusor-ember-cli/app/controllers/engine/discovered-host.js
+++ b/fusor-ember-cli/app/controllers/engine/discovered-host.js
@@ -30,14 +30,12 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, PaginationControlle
     }
 
     let deployingHosts = this.get('deployingHosts');
-    let hypervisorIds = this.get('hypervisorModelIds');
 
     return allDiscoveredHosts.filter(host => {
       let hostId = host.get('id');
-      let isHypervisor = hypervisorIds && hypervisorIds.contains(host.get('id'));
       let isDeploying = deployingHosts.any(deployingHost => deployingHost.get('id') === hostId);
 
-      return !isHypervisor && !isDeploying;
+      return !isDeploying;
     });
   }),
 

--- a/fusor-ember-cli/app/mixins/tr-engine-hypervisor-mixin.js
+++ b/fusor-ember-cli/app/mixins/tr-engine-hypervisor-mixin.js
@@ -5,11 +5,17 @@ export default Ember.Mixin.create({
 
   tagName: 'tr',
 
-  classNameBindings: ['bgColor'],
+  classNameBindings: ['bgColor', 'disabledTr'],
 
   bgColor: Ember.computed('isChecked', function () {
     if (this.get('isChecked')) {
       return 'white-on-blue';
+    }
+  }),
+
+  disabledTr: Ember.computed('isHypervisorOrStarted', function() {
+    if (this.get('isHypervisorOrStarted')) {
+      return 'disabled';
     }
   }),
 

--- a/fusor-ember-cli/app/styles/custom.scss
+++ b/fusor-ember-cli/app/styles/custom.scss
@@ -420,6 +420,10 @@ th {
   color:#fff !important;
 }
 
+tr.disabled td {
+  color: #999 !important;
+}
+
 li.disabled a {
   color: #999 !important;
 }

--- a/fusor-ember-cli/app/templates/components/tr-engine.hbs
+++ b/fusor-ember-cli/app/templates/components/tr-engine.hbs
@@ -1,7 +1,14 @@
-<td>
-  {{radio-button value=host groupValue=selectedRhevEngineHost changed="engineHostChanged" id=cssIdHostId dataQci=cssIdHostId disabled=disabled}}
+{{#if isHypervisorOrStarted}}
+<td class="disabled" data-toggle="tooltip" data-placement="top" data-container="body" title="Selected as Hypervisor">
+  {{radio-button value=host groupValue=selectedRhevEngineHost changed="engineHostChanged" id=cssIdHostId dataQci=cssIdHostId disabled=isHypervisorOrStarted}}
 </td>
-<td class="{{if isSelectedAsEngine 'white-font' 'not-selected'}}">
+{{else}}
+<td>
+  {{radio-button value=host groupValue=selectedRhevEngineHost changed="engineHostChanged" id=cssIdHostId dataQci=cssIdHostId disabled=isHypervisorOrStarted}}
+</td>
+{{/if}}
+
+<td class="{{if isSelectedAsEngine 'white-font' 'not-selected'}} {{if isHypervisorOrStarted 'disabled'}}">
     {{#if isSelectedAsEngine}}
       {{partial 'rhev-hostname-input'}}
     {{else}}

--- a/fusor-ember-cli/app/templates/engine/discovered-host.hbs
+++ b/fusor-ember-cli/app/templates/engine/discovered-host.hbs
@@ -40,8 +40,9 @@
         <tbody>
           {{#each sortedHosts as |host|}}
              {{tr-engine host=host
+                         hypervisorModelIds=hypervisorModelIds
                          selectedRhevEngineHost=selectedRhevEngineHost
-                         disabled=isStarted
+                         isStarted=isStarted
                          action="onEngineChanged"
                          setIfHostnameInvalid='setIfHostnameInvalid'}}
           {{/each}}


### PR DESCRIPTION
_Change Description:_

Show users a complete list of available discovered hosts. Disable
selection of hosts which have been selected as RHV Hypervisors, and
notify users why they can't select a Hypervisor as an Engine with a
tooltip.


_Testing Instructions:_
- Discover 2+ hosts
- Select any host as RHV Engine
- Select any host(s) as RHV Hypervisors
- Go back to RHV Engine selection
- Verify that hosts selected as RHV Hypervisors appear grayed out on engine selection page
- Verify when hovering over selection radio button, "Selected as Hypervisor" tooltip displays
- Verify that after deployment has started, all Engine/Hypervisor option TR's/radio buttons become disabled