### PR TITLE
1362676 - Fix hovering over navbar dropdown-toggles

### DIFF
--- a/ui/app/views/fusor_ui/placeholders/index.html.erb
+++ b/ui/app/views/fusor_ui/placeholders/index.html.erb
@@ -1,6 +1,10 @@
 <%= stylesheet('fusor_ui/fusor-ember-cli') %>
 
 <%= javascript('fusor_ui/vendor') %>
+<script type="text/javascript">
+  $.noConflict();
+</script>
+
 <%= javascript_include_tag 'fusor_ui/fusor-ember-cli', 'data-turbolinks-eval'=>'always' %>
 
 <%= content_for(:title, _("QuickStart Cloud Installer")) %>


### PR DESCRIPTION
BZ 1362676 - When hovering over navbar dropdown-toggles, they were not expanding properly. 

Restored $ to reference Foreman jQuery using noConflict.  Fusor's version of jQuery was overwriting the $ and causing Foreman calls to not execute correctly.  This also allows us to use whatever version of jQuery we want to as Ember.$.  Also fixes the console errors "Uncaught TypeError: $(...).flot_bar is not a function"