### PR TITLE
1306823 - revise rhv hypervisor selection table

### DIFF
--- a/fusor-ember-cli/app/components/tr-hypervisor.js
+++ b/fusor-ember-cli/app/components/tr-hypervisor.js
@@ -8,6 +8,16 @@ export default Ember.Component.extend(TrEngineHypervisorMixin, {
 
   isChecked: Ember.computed.alias('isSelectedAsHypervisor'),
 
+  isEngineOrStarted: Ember.computed('host', 'selectedRhevEngine', 'disabled', function() {
+    let isStarted = this.get('disabled');
+    let engineId = this.get('selectedRhevEngine.id');
+    let hostId = this.get('host.id');
+
+    let isEngine = hostId === engineId;
+
+    return isEngine || isStarted;
+  }),
+
   observeHostName: Ember.observer(
     'isSelectedAsHypervisor',
     'customPreprendName',

--- a/fusor-ember-cli/app/controllers/hypervisor/discovered-host.js
+++ b/fusor-ember-cli/app/controllers/hypervisor/discovered-host.js
@@ -45,10 +45,9 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
 
     return allDiscoveredHosts.filter(host => {
       let hostId = host.get('id');
-      let isEngine = hostId === this.get('selectedRhevEngine.id');
       let isDeploying = deployingHosts.any(deployingHost => deployingHost.get('id') === hostId);
 
-      return !isEngine && !isDeploying;
+      return !isDeploying;
     });
   }),
 

--- a/fusor-ember-cli/app/mixins/tr-engine-hypervisor-mixin.js
+++ b/fusor-ember-cli/app/mixins/tr-engine-hypervisor-mixin.js
@@ -13,8 +13,8 @@ export default Ember.Mixin.create({
     }
   }),
 
-  disabledTr: Ember.computed('isHypervisorOrStarted', function() {
-    if (this.get('isHypervisorOrStarted')) {
+  disabledTr: Ember.computed('isHypervisorOrStarted', 'isEngineOrStarted', function() {
+    if (this.get('isHypervisorOrStarted') || this.get('isEngineOrStarted')) {
       return 'disabled';
     }
   }),

--- a/fusor-ember-cli/app/templates/components/tr-hypervisor.hbs
+++ b/fusor-ember-cli/app/templates/components/tr-hypervisor.hbs
@@ -1,6 +1,12 @@
-<td>
-  {{input type="checkbox" name="isSelectedAsHypervisor" checked=isSelectedAsHypervisor id=cssIdHostId data-qci=cssIdHostId disabled=disabled}}
+{{#if isEngineOrStarted}}
+<td class="disabled" data-toggle="tooltip" data-placement="top" data-container="body" title="Selected as Engine">
+  {{input type="checkbox" name="isSelectedAsHypervisor" checked=isSelectedAsHypervisor id=cssIdHostId data-qci=cssIdHostId disabled=isEngineOrStarted}}
 </td>
+{{else}}
+<td>
+  {{input type="checkbox" name="isSelectedAsHypervisor" checked=isSelectedAsHypervisor id=cssIdHostId data-qci=cssIdHostId disabled=isEngineOrStarted}}
+</td>
+{{/if}}
 
 <td class="{{if isSelectedAsHypervisor 'white-font' 'not-selected'}}">
   {{#if isSelectedAsHypervisor}}

--- a/fusor-ember-cli/app/templates/hypervisor/discovered-host.hbs
+++ b/fusor-ember-cli/app/templates/hypervisor/discovered-host.hbs
@@ -65,6 +65,7 @@
                            filteredHosts=filteredHosts
                            setIfHostnameInvalid='setIfHostnameInvalid'
                            customPrefixValidator=customPrefixValidator
+                           selectedRhevEngine=selectedRhevEngine
                            }}
         {{/each}}
         </tbody>


### PR DESCRIPTION
_Change Description:_

This commit mirrors a previous commit in which functionality was added to display all discovered hosts in the engine selection table, but show selected hypervisors as disabled TRs with tooltips explaining. The selected RHV Engine will show up in the table as disabled with a tooltip "Selected as Engine".


_Testing Instructions:_
 - Discover 2+ hosts
 - Select any host as RHV Engine
 - Verify that on RHV Hypervisor selection page, selected Engine shows as disabled
 - Verify that RHV Engine selected appears grayed out on Hypervisor selection page
 - Verify when hovering over selection checkbox, "Selected as Hypervisor" tooltip displays

_Corresponding PR for Engine selection table:_ https://github.com/fusor/fusor/pull/1228