### PR TITLE
consistent hypervisor selection table placement

### DIFF
--- a/fusor-ember-cli/app/templates/hypervisor.hbs
+++ b/fusor-ember-cli/app/templates/hypervisor.hbs
@@ -5,8 +5,6 @@
       Select one or more target machines to be hypervisors.
     </p>
 
-    <br />
-
     {{outlet}}
   </div>
 </div>


### PR DESCRIPTION
Deleted white space to match UX on hypervisor and table selection pages.