### PR TITLE
fixed hypervisor table sort redirection to engines

### DIFF
--- a/fusor-ember-cli/app/controllers/engine/discovered-host.js
+++ b/fusor-ember-cli/app/controllers/engine/discovered-host.js
@@ -1,8 +1,12 @@
 import Ember from 'ember';
+
 import NeedsDeploymentMixin from "../../mixins/needs-deployment-mixin";
 import PaginationControllerMixin from "../../mixins/pagination-controller-mixin";
+import FilterSortHostsMixin from "../../mixins/filter-sort-hosts-mixin";
 
-export default Ember.Controller.extend(NeedsDeploymentMixin, PaginationControllerMixin, {
+export default Ember.Controller.extend(NeedsDeploymentMixin, PaginationControllerMixin, FilterSortHostsMixin, {
+
+  sortRoute: "engine.discovered-host",
 
   rhevController: Ember.inject.controller('rhev'),
 
@@ -40,32 +44,6 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, PaginationControlle
       return !isHypervisor && !isDeploying;
     });
   }),
-
-  filteredHosts: Ember.computed('availableHosts.[]', 'searchString', 'isStarted', function(){
-    var searchString = this.get('searchString');
-    var rx = new RegExp(searchString, 'gi');
-    var availableHosts = this.get('availableHosts');
-
-    if (this.get('isStarted')) {
-      return Ember.A([this.get('model')]);
-    } else if (availableHosts.get('length') > 0) {
-      return availableHosts.filter(function(record) {
-        return (record.get('name').match(rx) || record.get('memory_human_size').match(rx) ||
-                record.get('disks_human_size').match(rx) || record.get('subnet_to_s').match(rx) ||
-                record.get('mac').match(rx)
-               );
-      });
-    } else {
-      return availableHosts;
-    }
-  }),
-
-  sortCriteria: Ember.computed('sort_by', 'dir', function () {
-    let sort_by = this.get('sort_by') || 'name';
-    let dir = this.get('dir') || 'asc';
-    return [sort_by+':'+dir];
-  }),
-  sortedHosts: Ember.computed.sort('filteredHosts', 'sortCriteria'),
 
   numSelected: Ember.computed('model.id', function() {
     return (this.get('model.id')) ? 1 : 0;

--- a/fusor-ember-cli/app/controllers/hypervisor/discovered-host.js
+++ b/fusor-ember-cli/app/controllers/hypervisor/discovered-host.js
@@ -1,5 +1,9 @@
 import Ember from 'ember';
+
 import NeedsDeploymentMixin from "../../mixins/needs-deployment-mixin";
+import PaginationControllerMixin from "../../mixins/pagination-controller-mixin";
+import FilterSortHostsMixin from "../../mixins/filter-sort-hosts-mixin";
+
 import {
   AllValidator,
   PresenceValidator,
@@ -7,11 +11,14 @@ import {
   RegExpValidator
 } from '../../utils/validators';
 
-export default Ember.Controller.extend(NeedsDeploymentMixin, {
+export default Ember.Controller.extend(NeedsDeploymentMixin, PaginationControllerMixin,  FilterSortHostsMixin, {
+
+  sortRoute: "hypervisor.discovered-host",
 
   deployments: Ember.computed.alias('applicationController.model'),
   selectedRhevEngine: Ember.computed.alias("deploymentController.model.discovered_host"),
   rhevIsSelfHosted: Ember.computed.alias("deploymentController.model.rhev_is_self_hosted"),
+
 
   hostNamingScheme: Ember.computed.alias("deploymentController.model.host_naming_scheme"),
   customPreprendName: Ember.computed.alias("deploymentController.model.custom_preprend_name"),
@@ -50,27 +57,6 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, {
 
       return !isEngine && !isDeploying;
     });
-  }),
-
-  // same as Engine. TODO. put it mixin
-  filteredHosts: Ember.computed('availableHosts.[]', 'searchString', 'isStarted', function(){
-    var searchString = this.get('searchString');
-    var rx = new RegExp(searchString, 'gi');
-    var availableHosts = this.get('availableHosts');
-
-    if (this.get('isStarted')) {
-      return this.get('model');
-    } else if (availableHosts.get('length') > 0) {
-      return availableHosts.filter(function(record) {
-        return record.get('name').match(rx) ||
-          record.get('memory_human_size').match(rx) ||
-          record.get('disks_human_size').match(rx) ||
-          record.get('subnet_to_s').match(rx) ||
-          record.get('mac').match(rx);
-      });
-    } else {
-      return availableHosts;
-    }
   }),
 
   hypervisorModelIds: Ember.computed('model.[]', 'selectedRhevEngine', function() {

--- a/fusor-ember-cli/app/mixins/filter-sort-hosts-mixin.js
+++ b/fusor-ember-cli/app/mixins/filter-sort-hosts-mixin.js
@@ -1,0 +1,33 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+
+  filteredHosts: Ember.computed('availableHosts.[]', 'searchString', 'isStarted', function(){
+    var searchString = this.get('searchString');
+    var rx = new RegExp(searchString, 'gi');
+    var availableHosts = this.get('availableHosts');
+
+    if (this.get('isStarted')) {
+      return this.get('model');
+    } else if (availableHosts.get('length') > 0) {
+      return availableHosts.filter(function(record) {
+        return record.get('name').match(rx) ||
+          record.get('memory_human_size').match(rx) ||
+          record.get('disks_human_size').match(rx) ||
+          record.get('subnet_to_s').match(rx) ||
+          record.get('mac').match(rx);
+      });
+    } else {
+      return availableHosts;
+    }
+  }),
+
+  sortCriteria: Ember.computed('sort_by', 'dir', function () {
+    let sort_by = this.get('sort_by') || 'name';
+    let dir = this.get('dir') || 'asc';
+    return [sort_by+':'+dir];
+  }),
+
+  sortedHosts: Ember.computed.sort('filteredHosts', 'sortCriteria')
+
+});

--- a/fusor-ember-cli/app/templates/hypervisor/discovered-host.hbs
+++ b/fusor-ember-cli/app/templates/hypervisor/discovered-host.hbs
@@ -52,7 +52,7 @@
       <table class="table table-bordered small fusor-table">
         {{partial 'thead-discovered-hosts'}}
         <tbody>
-        {{#each filteredHosts as |host|}}
+        {{#each sortedHosts as |host|}}
            {{tr-hypervisor host=host
                            model=model
                            isCustomScheme=isCustomScheme

--- a/fusor-ember-cli/app/templates/thead-discovered-hosts.hbs
+++ b/fusor-ember-cli/app/templates/thead-discovered-hosts.hbs
@@ -2,42 +2,42 @@
   <tr>
     <th class='rhev-checkbox'></th>
     <th class='rhev-hostname'>
-      {{#link-to 'engine.discovered-host' (query-params sort_by="name" dir=sortByDirection)}}
+      {{#link-to sortRoute (query-params sort_by="name" dir=sortByDirection)}}
         {{column-name name='Host Name' col_name="name" sort_by=sort_by dir=dir}}
       {{/link-to}}
     </th>
     <th class='rhev-mac-address'>
-      {{#link-to 'engine.discovered-host' (query-params sort_by="mac" dir=sortByDirection)}}
+      {{#link-to sortRoute (query-params sort_by="mac" dir=sortByDirection)}}
         {{column-name name='MAC Address' col_name="mac" sort_by=sort_by dir=dir}}
       {{/link-to}}
     </th>
     <th class='rhev-host-type text-center'>
-      {{#link-to 'engine.discovered-host' (query-params sort_by="is_virtual" dir=sortByDirection)}}
+      {{#link-to sortRoute (query-params sort_by="is_virtual" dir=sortByDirection)}}
         {{column-name name='Host Type' col_name="is_virtual" sort_by=sort_by dir=dir}}
       {{/link-to}}
     </th>
     <th class='rhev-cpu text-center'>
-      {{#link-to 'engine.discovered-host' (query-params sort_by="cpus" dir=sortByDirection)}}
+      {{#link-to sortRoute (query-params sort_by="cpus" dir=sortByDirection)}}
         {{column-name name='CPU' col_name="cpus" sort_by=sort_by dir=dir}}
       {{/link-to}}
     </th>
     <th class='rhev-memory text-center'>
-      {{#link-to 'engine.discovered-host' (query-params sort_by="memory_human_size" dir=sortByDirection)}}
+      {{#link-to sortRoute (query-params sort_by="memory_human_size" dir=sortByDirection)}}
         {{column-name name='Memory' col_name="memory_human_size" sort_by=sort_by dir=dir}}
       {{/link-to}}
     </th>
     <th class='rhev-disks text-center'>
-      {{#link-to 'engine.discovered-host' (query-params sort_by="disk_count" dir=sortByDirection)}}
+      {{#link-to sortRoute (query-params sort_by="disk_count" dir=sortByDirection)}}
         {{column-name name='# Disks' col_name="disk_count" sort_by=sort_by dir=dir}}
       {{/link-to}}
     </th>
     <th class='rhev-diskspace text-center'>
-      {{#link-to 'engine.discovered-host' (query-params sort_by="disks_human_size" dir=sortByDirection)}}
+      {{#link-to sortRoute (query-params sort_by="disks_human_size" dir=sortByDirection)}}
         {{column-name name='Disk Space' col_name="disks_human_size" sort_by=sort_by dir=dir}}
       {{/link-to}}
     </th>
     <th class='rhev-network'>
-      {{#link-to 'engine.discovered-host' (query-params sort_by="subnet_to_s" dir=sortByDirection)}}
+      {{#link-to sortRoute (query-params sort_by="subnet_to_s" dir=sortByDirection)}}
         {{column-name name='Network' col_name="subnet_to_s" sort_by=sort_by dir=dir}}
       {{/link-to}}
     </th>


### PR DESCRIPTION
_Changes:_
 - Fixed faulty sorting on hypervisor selection page.
 - Moved shared sorting and filtering functionality to `filter-sort-hosts-mixin.js`
 - Made `thead-discovered-hosts.hbs `general purpose

_Testing Instructions:_
 - Try out sorting and filtering on RHV engine selection and hypervisor selection pages
 - Ensure sorting on hypervisor selection page does not pull up engine list
