### PR TITLE
hypervisor naming scheme preview + cancel works

### DIFF
--- a/fusor-ember-cli/app/components/naming-scheme-modal.js
+++ b/fusor-ember-cli/app/components/naming-scheme-modal.js
@@ -40,6 +40,12 @@ export default Ember.Component.extend({
 
   actions: {
     saveNamingScheme() {
+      // field name provided by setSelectValue below
+      let fieldName = this.get('lookupName');
+      let selectionValue = this.get(fieldName);
+
+      // triggers action updating hostNamingScheme on deployment model
+      this.sendAction('setSelectValue', fieldName, selectionValue);
       this.set('openModal', false);
       this.sendAction('saveNamingScheme');
     },
@@ -50,12 +56,12 @@ export default Ember.Component.extend({
       this.set('origCustomPreprendName', null);
       this.sendAction('cancelNamingScheme');
     },
+
     setSelectValue(fieldName, selectionValue) {
+      // sets lookupName so that we know fieldName in 'saveNamingScheme' above
+      this.set('lookupName', fieldName);
       // this just sets hostNamingScheme on the modal component
       this.set(fieldName, selectionValue);
-      // this triggers the action to update hostNamingScheme on the deployment modal
-      this.sendAction('setSelectValue', fieldName, selectionValue);
     }
-
   }
 });


### PR DESCRIPTION
_Change Description:_
 - Canceling a name scheme change works
 - Live preview of name scheme change still works, but reverses upon cancel

_Testing Instructions:_

1.  Go to Hypervisor selection page
2.  Select Hypervisor(s) 
3.  Click 'Edit Naming Scheme'
4.  Select a naming scheme different from current
5.  Verify changes preview in the background
6.  Click cancel
7.  Verify changes are cancelled
8.  Run through 3-5 steps again, Save Changes
9.  Verify changes persist