### PR TITLE
fixed the text prompt on RHV engine selection page

### DIFF
--- a/fusor-ember-cli/app/templates/engine/discovered-host.hbs
+++ b/fusor-ember-cli/app/templates/engine/discovered-host.hbs
@@ -1,7 +1,7 @@
 <div class="row">
   <div class='col-md-12'>
     <p>
-      Select a target machine for the {{engineTabNameLowercase}}:
+      Select a target machine for the engine:
     </p>
     <div class='row'>
       <div class='col-lg-9'>
@@ -67,4 +67,3 @@
                        deploymentName=deploymentName}}
   </div>
 </div>
-


### PR DESCRIPTION
"Select a target machine for the :" is now "Select a target machine for the engine:"