### PR TITLE
Added Sat 6.2 Tools repo to Openshift.

### DIFF
--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -207,6 +207,13 @@
         :repository_set_label: "rhel-7-server-beta-kickstart"
         :basearch: "x86_64"
 #        :releasever: "7.3"
+#
+      - :product_name: "Red Hat Enterprise Linux Server"
+        :product_id: "69"
+        :repository_set_id: "4831"
+        :repository_set_name: "Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)"
+        :repository_set_label: "rhel-7-server-satellite-tools-6.2-rpms"
+        :basearch: "x86_64"
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"


### PR DESCRIPTION
Currently, this PR is not needed to have a proper katello-agent installed on OCP hosts. However this is due to a temporary fix that addresses https://bugzilla.redhat.com/show_bug.cgi?id=1331432.

As indicated by the code, this feature is deprecating and might go away in the future. This PR ensures that Satellite Tools repo will be available to OCP hosts in the future should this logic changes in Katello.