### PR TITLE
force RHV engine/hypervisor hostnames to lowercase

### DIFF
--- a/fusor-ember-cli/app/mixins/tr-engine-hypervisor-mixin.js
+++ b/fusor-ember-cli/app/mixins/tr-engine-hypervisor-mixin.js
@@ -53,6 +53,10 @@ export default Ember.Mixin.create({
       var host = this.get('host');
       var self = this;
       var token = Ember.$('meta[name="csrf-token"]').attr('content');
+
+      // hostname to lowercase to match what user sees (css styled lowercase)
+      this.set('host.name', this.get('host.name').toLowerCase());
+
       if (this.get('isValidHostname')) {
         request({
           url: '/api/v21/discovered_hosts/' + host.get('id') + '/rename',

--- a/fusor-ember-cli/app/templates/components/tr-engine.hbs
+++ b/fusor-ember-cli/app/templates/components/tr-engine.hbs
@@ -12,7 +12,7 @@
     {{#if isSelectedAsEngine}}
       {{partial 'rhev-hostname-input'}}
     {{else}}
-      {{host.name}}
+      <span class='text-lowercase'>{{host.name}}</span>
     {{/if}}
 </td>
 <td> {{host.mac}} </td>

--- a/fusor-ember-cli/app/templates/components/tr-hypervisor.hbs
+++ b/fusor-ember-cli/app/templates/components/tr-hypervisor.hbs
@@ -13,10 +13,10 @@
     {{#if isFreeform}}
       {{partial 'rhev-hostname-input'}}
     {{else}}
-      {{host.name}}
+      <span class='text-lowercase'>{{host.name}}</span>
     {{/if}}
   {{else}}
-    {{host.name}}
+    <span class='text-lowercase'>{{host.name}}</span>
   {{/if}}
 </td>
 <td> {{host.mac}} </td>

--- a/fusor-ember-cli/app/templates/rhev-hostname-input.hbs
+++ b/fusor-ember-cli/app/templates/rhev-hostname-input.hbs
@@ -1,8 +1,8 @@
 {{#if disabled}}
-  {{host.name}}
+  <span class="text-lowercase">{{host.name}}</span>
 {{else}}
    <div class="{{if isInvalidHostname 'has-error'}}">
-      {{input type="text" maxlength="45" value=host.name class='form-control' key-up='saveHostname' id=cssHostHostId data-qci=cssHostHostId}}
+      {{input type="text" maxlength="45" value=host.name class='form-control text-lowercase' key-up='saveHostname' id=cssHostHostId data-qci=cssHostHostId}}
       {{#if isInvalidHostname}}
         <span class="error errorForValidation invalid-rhev-hostname">
           <i class="fa fa-warning"></i> Hostname is invalid.


### PR DESCRIPTION
Change Description:
- Hostname inputs appear in lowercase on the client side-using CSS styling.
- Actual conversion to lowercase occurs on server-side.
- Keeps Ember Data in sync with back-end.