### PR TITLE
1384582 - rhv hosts are readable after deployment has started

### DIFF
--- a/fusor-ember-cli/app/components/tr-engine.js
+++ b/fusor-ember-cli/app/components/tr-engine.js
@@ -9,15 +9,21 @@ export default Ember.Component.extend(TrEngineHypervisorMixin, {
     }
   }),
 
-  isHypervisorOrStarted: Ember.computed('host', 'hypervisorModelIds.[]', 'isStarted', function() {
+  isHypervisor: Ember.computed('host', 'hypervisorModelIds.[]', function() {
     let hypervisorIds = this.get('hypervisorModelIds');
-    let isHypervisor = hypervisorIds && hypervisorIds.contains(this.get('host.id'));
-    let isStarted = this.get('isStarted');
-    return isHypervisor || isStarted;
+    return hypervisorIds && hypervisorIds.contains(this.get('host.id'));
+  }),
+
+  isHypervisorOrStarted: Ember.computed('isHypervisor', 'isStarted', function() {
+    return this.get('isHypervisor') || this.get('isStarted');
   }),
 
   isChecked: Ember.computed('isSelectedAsEngine', function () {
     return this.get('isSelectedAsEngine');
+  }),
+
+  isSelectedAndNotStarted: Ember.computed('isSelectedAsEngine', 'isStarted', function() {
+    return this.get('isSelectedAsEngine') && !this.get('isStarted');
   }),
 
   actions: {

--- a/fusor-ember-cli/app/components/tr-hypervisor.js
+++ b/fusor-ember-cli/app/components/tr-hypervisor.js
@@ -8,14 +8,15 @@ export default Ember.Component.extend(TrEngineHypervisorMixin, {
 
   isChecked: Ember.computed.alias('isSelectedAsHypervisor'),
 
-  isEngineOrStarted: Ember.computed('host', 'selectedRhevEngine', 'disabled', function() {
-    let isStarted = this.get('disabled');
+  isEngine: Ember.computed('host', 'selectedRhevEngine', function() {
     let engineId = this.get('selectedRhevEngine.id');
     let hostId = this.get('host.id');
+    return hostId === engineId;
+  }),
 
-    let isEngine = hostId === engineId;
-
-    return isEngine || isStarted;
+  isEngineOrStarted: Ember.computed('isEngine', 'disabled', function() {
+    let isStarted = this.get('disabled');
+    return this.get('isEngine') || isStarted;
   }),
 
   observeHostName: Ember.observer(

--- a/fusor-ember-cli/app/mixins/filter-sort-hosts-mixin.js
+++ b/fusor-ember-cli/app/mixins/filter-sort-hosts-mixin.js
@@ -8,7 +8,14 @@ export default Ember.Mixin.create({
     var availableHosts = this.get('availableHosts');
 
     if (this.get('isStarted')) {
-      return this.get('model');
+      // hypervisors model will already be packaged as array
+      if (Ember.isArray(this.get('model'))) {
+        return this.get('model');
+      }
+      // convert singular host contained in engine model to array
+      else {
+        return Ember.A([this.get('model')]);
+      }
     } else if (availableHosts.get('length') > 0) {
       return availableHosts.filter(function(record) {
         return record.get('name').match(rx) ||

--- a/fusor-ember-cli/app/mixins/tr-engine-hypervisor-mixin.js
+++ b/fusor-ember-cli/app/mixins/tr-engine-hypervisor-mixin.js
@@ -13,8 +13,8 @@ export default Ember.Mixin.create({
     }
   }),
 
-  disabledTr: Ember.computed('isHypervisorOrStarted', 'isEngineOrStarted', function() {
-    if (this.get('isHypervisorOrStarted') || this.get('isEngineOrStarted')) {
+  disabledTr: Ember.computed('isHypervisor', 'isEngine', function() {
+    if (this.get('isHypervisor') || this.get('isEngine')) {
       return 'disabled';
     }
   }),

--- a/fusor-ember-cli/app/templates/components/tr-engine.hbs
+++ b/fusor-ember-cli/app/templates/components/tr-engine.hbs
@@ -8,8 +8,8 @@
 </td>
 {{/if}}
 
-<td class="{{if isSelectedAsEngine 'white-font' 'not-selected'}} {{if isHypervisorOrStarted 'disabled'}}">
-    {{#if isSelectedAsEngine}}
+<td class="{{if isSelectedAsEngine 'white-font' 'not-selected'}} {{if isHypervisor 'disabled'}}">
+    {{#if isSelectedAndNotStarted }}
       {{partial 'rhev-hostname-input'}}
     {{else}}
       <span class='text-lowercase'>{{host.name}}</span>


### PR DESCRIPTION
_Changes:_

 - Selected RHV engine host no longer disappears after deploy starts
 - Hypervisor/Engine selection table color scheme is readable after deploy starts
 - Engine name is uneditable after deployment has started