### PR TITLE
Fix for hypervisor selection table in self-hosted deployments.

### DIFF
--- a/fusor-ember-cli/app/components/tr-hypervisor.js
+++ b/fusor-ember-cli/app/components/tr-hypervisor.js
@@ -19,6 +19,18 @@ export default Ember.Component.extend(TrEngineHypervisorMixin, {
     return this.get('isEngine') || isStarted;
   }),
 
+  showTooltipDisableCheckbox: Ember.computed('isEngineOrStarted', 'isSelfHosted', function() {
+    return this.get('isEngineOrStarted') && !this.get('isSelfHosted');
+  }),
+
+  hideTooltipDisableCheckbox: Ember.computed('isEngineOrStarted', 'isSelfHosted', function() {
+    return this.get('isEngineOrStarted') && this.get('isSelfHosted');
+  }),
+
+  hideTooltipEnableCheckbox: Ember.computed('isEngineOrStarted', function() {
+    return !this.get('isEngineOrStarted');
+  }),
+
   observeHostName: Ember.observer(
     'isSelectedAsHypervisor',
     'customPreprendName',

--- a/fusor-ember-cli/app/controllers/hypervisor/discovered-host.js
+++ b/fusor-ember-cli/app/controllers/hypervisor/discovered-host.js
@@ -19,6 +19,7 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, PaginationControlle
   deployments: Ember.computed.alias('applicationController.model'),
   deployment: Ember.computed.alias("deploymentController.model"),
   selectedRhevEngine: Ember.computed.alias("deploymentController.model.discovered_host"),
+  isSelfHosted: Ember.computed.alias("deploymentController.model.rhev_is_self_hosted"),
 
 
   hostNamingScheme: Ember.computed.alias("deploymentController.model.host_naming_scheme"),

--- a/fusor-ember-cli/app/templates/components/tr-hypervisor.hbs
+++ b/fusor-ember-cli/app/templates/components/tr-hypervisor.hbs
@@ -1,10 +1,18 @@
-{{#if isEngineOrStarted}}
+{{#if showTooltipDisableCheckbox}}
 <td class="disabled" data-toggle="tooltip" data-placement="top" data-container="body" title="Selected as Engine">
   {{input type="checkbox" name="isSelectedAsHypervisor" checked=isSelectedAsHypervisor id=cssIdHostId data-qci=cssIdHostId disabled=isEngineOrStarted}}
 </td>
-{{else}}
-<td>
+{{/if}}
+
+{{#if hideTooltipDisableCheckbox}}
+<td class="disabled">
   {{input type="checkbox" name="isSelectedAsHypervisor" checked=isSelectedAsHypervisor id=cssIdHostId data-qci=cssIdHostId disabled=isEngineOrStarted}}
+</td>
+{{/if}}
+
+{{#if hideTooltipEnableCheckbox}}
+<td>
+  {{input type="checkbox" name="isSelectedAsHypervisor" checked=isSelectedAsHypervisor id=cssIdHostId data-qci=cssIdHostId}}
 </td>
 {{/if}}
 

--- a/fusor-ember-cli/app/templates/hypervisor/discovered-host.hbs
+++ b/fusor-ember-cli/app/templates/hypervisor/discovered-host.hbs
@@ -71,6 +71,7 @@
                                isCustomScheme=isCustomScheme
                                isMac=isMac
                                isHypervisorN=isHypervisorN
+                               isSelfHosted=isSelfHosted
                                customPreprendName=customPreprendName
                                isFreeform=isFreeform
                                num=host.id


### PR DESCRIPTION
_Problem:_
In a self-hosted deploy, RHV hypervisor selection table would incorrectly show tooltips stating "Selected as Engine" for every hypervisor included in the deployment after the deployment had begun.

_Fix:_
This commit removes the 'Selected as Engine' tooltip altogether from the self-hosted hypervisor selection page. The purpose of the 'Selected as Engine' is to inform users that they have already selected a host for a different purpose on another page of the wizard. Since there is only one RHV host selection page in a self-hosted deploy, the tooltip isn't needed.