### PR TITLE
rhev_cpu_type default to null fix

### DIFF
--- a/fusor-ember-cli/app/routes/rhev-options.js
+++ b/fusor-ember-cli/app/routes/rhev-options.js
@@ -14,6 +14,16 @@ export default Ember.Route.extend({
       }
     });
   },
+
+  setupController(controller, model) {
+    controller.set('model', model);
+
+    // initialize the deployment cpu family to the default returned family
+    if (this.modelFor('deployment').get('rhev_cpu_type') === null) {
+      this.modelFor('deployment').set('rhev_cpu_type', model.default_family);
+    }
+  },
+
   deactivate() {
     return this.send('saveDeployment', null);
   }


### PR DESCRIPTION
Fixed a bug where rhev_cpu_type was only being set on the deployment object when the CPU family selection box was manually modified.

This could potentially cause a deploy to fail on AMD and IBM machines if the CPU family selection box was left unmodified by the user. On Intel machines, the null value for rhev_cpu_type would result in the
overall default (Intel Nehalem) being selected.
