### PR TITLE
1386398- Fix hanging during ansible playbook runs for RHV

### DIFF
--- a/server/app/lib/actions/fusor/deployment/cloud_forms/run_appliance_console.rb
+++ b/server/app/lib/actions/fusor/deployment/cloud_forms/run_appliance_console.rb
@@ -49,7 +49,7 @@ module Actions
                   "--db_password #{db_password}"
 
             status, output = run_command(cmd)
-            fail _("Unable to run appliance console: %{output}") % { :output => output.join('; ') } unless status == 0
+            fail _("Unable to run appliance console: %{output}") % { :output => output } unless status == 0
 
             if secondary_address
               cmd = "#{script_dir}miq_run_appliance_console.py "\
@@ -60,7 +60,7 @@ module Actions
                   "--primary_appliance #{cfme_address}"
 
               status, output = run_command(cmd)
-              fail _("Unable to run appliance console: %{output}") % { :output => output.join('; ') } unless status == 0
+              fail _("Unable to run appliance console: %{output}") % { :output => output } unless status == 0
 
               # TODO: observing issues with running the appliance console using SSHConnection; therefore, temporarily
               # commenting out and using the approach above which will run it from a python script

--- a/server/app/lib/actions/fusor/deployment/rhev/trigger_ansible_run.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/trigger_ansible_run.rb
@@ -171,7 +171,7 @@ module Actions
             status, output = ::Utils::Fusor::CommandUtils.run_command(cmd, true, environment)
 
             if status != 0
-              fail _("ansible-ovirt returned a non-zero return code\n#{output.join.gsub('\n', "\n")}")
+              fail _("ansible-ovirt returned a non-zero return code\n#{output.gsub('\n', "\n")}")
             else
               ::Fusor.log.debug(output)
               status

--- a/server/app/lib/actions/fusor/deployment/rhev/wait_for_data_center.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/wait_for_data_center.rb
@@ -37,19 +37,14 @@ module Actions
           end
 
           def poll_intervals
-            # It takes almost 7 minutes to do the rpm installation via puppet,
-            # so no point in spinning our wheels trying to see if the datacenter
-            # is up yet. Also, another 22 minutes of "other" activitties after
-            # the last rpm is installed before the datacenter can be checked.
-            #
-            # So reversing the polling intervals so that dynflow will wait 6
-            # minutes before doing the second check. After the first interval
+            # So reversing the polling intervals so that dynflow will wait 1
+            # minute before doing the second check. After the first interval
             # checks fail, it will speed them up as it takes longer. This should
             # minimize the number of polling actions we do on the datacenter and
             # reduce the noise in the logs.
             #
-            # 6m, 4m, 1m, 30s, 8s, 4s, 1s, .5s
-            [360, 240, 60, 30, 8, 4, 1, 0.5]
+            # 1m, 30s, 8s, 4s, 1s, .5s
+            [60, 30, 8, 4, 1, 0.5]
           end
 
           def invoke_external_task
@@ -94,13 +89,13 @@ module Actions
                 "--api_pass #{api_password} "\
                 "--data_center #{data_center}"
 
-              status, output = Utils::Fusor::CommandUtils.run_command(cmd)
+              status, output = Utils::Fusor::CommandUtils.run_command(cmd, true)
               { status: status, output: output }
             end
           end
 
           def is_up?(status)
-            !status.nil? && (status[:status] == 0) && ("up" == status[:output].first.rstrip) ? true : false
+            status && (status[:status] == 0) && (status[:output].rstrip == 'up')
           end
         end
       end

--- a/server/app/lib/utils/fusor/command_utils.rb
+++ b/server/app/lib/utils/fusor/command_utils.rb
@@ -16,19 +16,10 @@ module Utils
   module Fusor
     class CommandUtils
       def self.run_command(cmd, log_on_success = false, environment = {})
-        # popen2e merges stdout and stderr, which we have put into
-        # the the output variable
-        stdin, stdout_err, wait_thr = Open3.popen2e(environment, cmd)
-        status = wait_thr.value.exitstatus
-
-        # capture the output into a variable because once we close
-        # it you can no longer read it.
-        #
-        # also need to capture it so that we can log any errors
-        # that may have occurred otherwise we just log the class id
-        # which is useless in a debugging scenario.
-        #
-        output = stdout_err.readlines
+        # capture2e merges stdout and stderr, which we have put into
+        # the output variable
+        output, status_object = Open3.capture2e(environment, cmd)
+        status = status_object.exitstatus
 
         cmd_filtered = cmd
         output_filtered = output
@@ -48,10 +39,6 @@ module Utils
           ::Fusor.log.info "Status code: #{status}"
           ::Fusor.log.info "Command output: #{output_filtered}"
         end
-
-        # need to close these explicitly as per the docs
-        stdin.close unless stdin.closed?
-        stdout_err.close unless stdout_err.closed?
 
         return status, output
       end

--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -431,7 +431,7 @@
   :system:
     :logging:
       :level: ":debug"
-      :ansible_debug: true # Enable verbose debug logging for ansible
+      :ansible_debug: false # Enable verbose debug logging for ansible
       :show_passwords: false # show passwords in logs for non-prod environments
       :watch:
         :production:


### PR DESCRIPTION
Caused by large stdout chunks failing to write, hanging the ansible process. Fixed by using Open3.capture2e instead of Open3.popen2e, which handles reading the stdout in chunks so that we don't have to.
