### PR TITLE
1386305 - Sub saving issues

### DIFF
--- a/fusor-ember-cli/app/mixins/load-updated-subscriptions-mixin.js
+++ b/fusor-ember-cli/app/mixins/load-updated-subscriptions-mixin.js
@@ -1,0 +1,103 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+
+  loadUpdatedSubscriptionInfo(deployment, consumerUUID) {
+    let deploymentId = deployment.get('id');
+
+    if (deployment.get('is_disconnected')) {
+      return Ember.RSVP.hash({
+        entitlements: [],
+        pools: [],
+        subscriptions: this.store.query('subscription', {
+          deployment_id: deploymentId,
+          source: 'added',
+          cachebust: Date.now().toString() // Force a non-cached response
+        })
+      });
+    }
+
+    return Ember.RSVP.hash({
+      entitlements: this.store.query('entitlement', {uuid: consumerUUID}),
+      pools: this.store.query('pool', {uuid: consumerUUID}),
+      subscriptions: this.store.query('subscription', {
+        deployment_id: deploymentId,
+        source: 'added',
+        cachebust: Date.now().toString() // Force a non-cached response
+      })
+    }).then(results => {
+      let subscriptions = [];
+
+      results.subscriptions.forEach(subscription => {
+        // increment as we encounter entitlements
+        subscription.set('quantity_attached', 0);
+        subscriptions.push(subscription);
+      });
+
+      results.entitlements.forEach(entitlement => {
+        let matchingSub = subscriptions.findBy('contract_number', entitlement.get('contractNumber'));
+        if (Ember.isEmpty(matchingSub)) {
+          matchingSub = this.createSubscription(entitlement, deployment);
+          subscriptions.push(matchingSub);
+        }
+
+        matchingSub.incrementProperty('quantity_attached', entitlement.get('quantity'));
+
+        let qtyAvailableToAdd = entitlement.get('poolQuantity') - entitlement.get('consumed');
+        matchingSub.set('quantity_to_add', Math.min(matchingSub.get('quantity_to_add'), qtyAvailableToAdd));
+        matchingSub.set('total_quantity', entitlement.get('poolQuantity'));
+      });
+
+      results.pools.forEach(pool => {
+        let matchingSub = subscriptions.findBy('contract_number', pool.get('contractNumber'));
+        if (Ember.isEmpty(matchingSub)) {
+          matchingSub = this.createSubscription(pool, deployment);
+          subscriptions.push(matchingSub);
+        }
+
+        let qtyAvailableToAdd = pool.get('quantity') - pool.get('consumed');
+        matchingSub.set('quantity_to_add', Math.min(matchingSub.get('quantity_to_add'), qtyAvailableToAdd));
+        matchingSub.set('total_quantity', pool.get('quantity'));
+      });
+
+      let promises = [];
+      subscriptions.forEach(subscription => {
+        let hasEntitlement = results.entitlements.findBy('contractNumber', subscription.get('contract_number'));
+        let hasAvailablePool = results.pools.findBy('contractNumber', subscription.get('contract_number'));
+
+        if (!hasAvailablePool) {
+          subscription.set('quantity_to_add', 0);
+        }
+
+        if (hasEntitlement || hasAvailablePool) {
+          promises.push(subscription.save());
+        } else {
+          promises.push(subscription.destroyRecord());
+        }
+      });
+
+      return Ember.RSVP.hash({
+        entitlements: results.entitlements,
+        pools: results.pools,
+        subscriptions: Ember.RSVP.all(promises)
+      });
+    });
+  },
+
+  createSubscription(subInfo, deployment) {
+    return this.store.createRecord('subscription', {
+      'contract_number': subInfo.get('contractNumber'),
+      'product_name': subInfo.get('productName'),
+      'quantity_to_add': 0,
+      'quantity_attached': 0,
+      'source': 'added',
+      'start_date': subInfo.get('startDate'),
+      'end_date': subInfo.get('endDate'),
+      'deployment': deployment
+    });
+  }
+
+
+
+
+});

--- a/fusor-ember-cli/app/routes/subscriptions/management-application.js
+++ b/fusor-ember-cli/app/routes/subscriptions/management-application.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
+import LoadUpdatedSubscriptions from '../../mixins/load-updated-subscriptions-mixin';
 
-export default Ember.Route.extend({
+export default Ember.Route.extend(LoadUpdatedSubscriptions, {
 
   model() {
     var self = this;
@@ -116,60 +117,12 @@ export default Ember.Route.extend({
   saveSma() {
     let controller = this.get('controller');
     let deployment = this.modelFor('deployment');
-    let deploymentId = deployment.get('id');
     let consumerUUID = deployment.get('upstream_consumer_uuid');
-    let isDisconnected = this.controllerFor('deployment').get('isDisconnected');
 
     controller.set('showWaitingMessage', true);
     controller.set('msgWaiting', 'Updating subscriptions');
     controller.set('errorMsg', null);
 
-
-    return Ember.RSVP.hash({
-      entitlements: this.store.query('entitlement', {uuid: consumerUUID}),
-      pools: this.store.query('pool', {uuid: consumerUUID}),
-      subscriptions: this.store.query('subscription', {
-        deployment_id: deploymentId,
-        source: 'added',
-        cachebust: Date.now().toString() // Force a non-cached response
-      })
-    }).then(results => {
-
-      let promises = [];
-
-      results.pools.forEach(pool => {
-        pool.set('qtyAttached', 0); //default for loop
-
-        results.entitlements.forEach(entitlement => {
-          if (entitlement.get('poolId') === pool.get('id')) {
-            pool.incrementProperty('qtyAttached', entitlement.get('quantity'));
-          }
-        });
-
-        //create Fusor::Subscription records if they don't exist
-        var matchingSubscription = results.subscriptions.filterBy(
-          'contract_number', pool.get('contractNumber')).get('firstObject');
-        if (Ember.isBlank(matchingSubscription)) {
-          var sub = this.store.createRecord('subscription', {
-            'contract_number': pool.get('contractNumber'),
-            'product_name': pool.get('productName'),
-            'quantity_to_add': 0,
-            'quantity_attached': pool.get('qtyAttached'),
-            'source': 'added',
-            'start_date': pool.get('startDate'),
-            'end_date': pool.get('endDate'),
-            'total_quantity': pool.get('quantity'),
-            'deployment': deployment
-          });
-          promises.push(sub.save());
-        } else {
-          // update quantity_attached is it may have changed since record was created
-          matchingSubscription.set('quantity_attached', pool.get('qtyAttached'));
-          promises.push(matchingSubscription.save());
-        }
-      });
-
-      return Ember.RSVP.all(promises);
-    });
+    return this.loadUpdatedSubscriptionInfo(deployment, consumerUUID);
   }
 });

--- a/fusor-ember-cli/app/templates/subscriptions/select-subscriptions.hbs
+++ b/fusor-ember-cli/app/templates/subscriptions/select-subscriptions.hbs
@@ -27,16 +27,6 @@
 
     {{#unless isStarted}}
 
-        {{#if hasContractNumbersInModelNotInPool}}
-          <div class="row">
-            <div class='col-md-9'>
-              <div class='alert alert-danger rhci-alert'>
-                  You previously selected subscriptions (Contract Number {{contractNumbersInModelNotInPool}}) that are no longer available to be selected in the pool.
-              </div>
-            </div>
-          </div>
-        {{/if}}
-
         {{#if hasSubscriptionPools}}
           <table class="table table-bordered small">
             <thead>


### PR DESCRIPTION
Fixed double POST of subscriptions causing duplicates.  Insured the post was complete before moving on tot he next page which would then PUT the new data instead of POSTing

Update subscriptions tables with combined values from both pools and entitlements.  In the case where a pool was not returned (because there were no available subs to add) the Review Subscriptions page was not showing already attached entitlements.