### PR TITLE
Revert "[Needs testing] Fix subscription-manager commands for OCP on RHV kickstart snippet"

### DIFF
--- a/server/app/lib/utils/fusor/config_template_utils.rb
+++ b/server/app/lib/utils/fusor/config_template_utils.rb
@@ -120,8 +120,8 @@ module Utils
       def create_rhevm_guest_agent_snippet
         name = @rhevm_guest_agent_snippet_name
         return nil unless create_snippet(name)
-        append(name, "\nsubscription-manager repos --disable \"*\"")
-        append(name, "\nsubscription-manager repos --enable #{@enabled_repos.join ' --enable '}")
+        append(name, "\nsubscription-manager --enable #{@enabled_repos.join ' --enable '}")
+        append(name, "\nsubscription-manager --disable \"*\"")
         append(name, "\nyum install rhevm-guest-agent-common -y")
         append(name, "\nsystemctl start ovirt-guest-agent.service")
         append(name, "\nsystemctl enable ovirt-guest-agent.service\n")


### PR DESCRIPTION
Reverts fusor/fusor#1290 until further testing proves this resolves the issue. 