### PR TITLE
[DO NOT MERGE] 1396267 - added support for a unique mount suffix

### DIFF
--- a/fusor-ember-cli/app/controllers/openshift/openshift-configuration.js
+++ b/fusor-ember-cli/app/controllers/openshift/openshift-configuration.js
@@ -83,7 +83,8 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, ValidatesMounts, {
       const params = {
         path: deployment.get('openshift_export_path'),
         address: deployment.get('openshift_storage_host'),
-        type: deployment.get('openshift_storage_type')
+        type: deployment.get('openshift_storage_type'),
+        unique_suffix: 'ocp'
       };
 
       this.set('showLoadingSpinner', true);

--- a/fusor-ember-cli/app/controllers/storage.js
+++ b/fusor-ember-cli/app/controllers/storage.js
@@ -23,7 +23,8 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, ValidatesMounts, {
       const storageParams = {
         path: this.get('model.rhev_share_path'),
         address: this.get('model.rhev_storage_address'),
-        type: this.get('model.rhev_storage_type')
+        type: this.get('model.rhev_storage_type'),
+        unique_suffix: 'rhv'
       };
 
       const validationPromises = {
@@ -34,7 +35,8 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, ValidatesMounts, {
         const exportParams = {
           path: this.get('model.rhev_export_domain_path'),
           address: this.get('model.rhev_export_domain_address'),
-          type: this.get('model.rhev_storage_type')
+          type: this.get('model.rhev_storage_type'),
+          unique_suffix: 'export'
         };
 
         validationPromises.export = this.fetchMountValidation(
@@ -47,7 +49,8 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, ValidatesMounts, {
         const hostedParams = {
           path: this.get('model.hosted_storage_path'),
           address: this.get('model.hosted_storage_address'),
-          type: this.get('model.rhev_storage_type')
+          type: this.get('model.rhev_storage_type'),
+          unique_suffix: 'selfhosted'
         };
 
         validationPromises.hosted = this.fetchMountValidation(
@@ -252,4 +255,3 @@ export default Ember.Controller.extend(NeedsDeploymentMixin, ValidatesMounts, {
   validRhevStorage: Ember.computed.not('disableNextStorage')
 
 });
-

--- a/server/app/controllers/fusor/api/v21/deployments_controller.rb
+++ b/server/app/controllers/fusor/api/v21/deployments_controller.rb
@@ -364,9 +364,10 @@ module Fusor
       address = @deployment.rhev_storage_address
       path = @deployment.rhev_share_path
       storage_type = @deployment.rhev_storage_type
+      unique_suffix = 'ocp'
 
       begin
-        mount_response = mount_storage(address, path, storage_type)
+        mount_response = mount_storage(address, path, storage_type, unique_suffix)
         render json: { :openshift_disk_space => mount_response[:mb_available]}, status: 200
       rescue Exception => error
         message = 'Unable to retrieve Openshift disk space'

--- a/server/app/controllers/fusor/api/v21/deployments_controller.rb
+++ b/server/app/controllers/fusor/api/v21/deployments_controller.rb
@@ -300,13 +300,15 @@ module Fusor
     param :address, String, required: true, desc: 'Address of the file server'
     param :path, String, required: true, desc: 'Path of the shared file system'
     param :type, String, required: true, desc: 'Type of file share (NFS/glusterfs)'
+    param :unique_suffix, String, required: true, desc: 'Unique suffix allowing async mount validation'
     def check_mount_point
       mount_address = params['address']
       mount_path = params['path']
       mount_type = params['type']
+      mount_unique_suffix = params['unique_suffix']
 
       begin
-        mount_result = mount_storage(mount_address, mount_path, mount_type)
+        mount_result = mount_storage(mount_address, mount_path, mount_type, mount_unique_suffix)
         render json: { :mounted => true, :is_empty => mount_result[:is_empty] }, status: 200
       rescue
         render json: { :mounted => false, :is_empty => false }, status: 200
@@ -314,7 +316,7 @@ module Fusor
     end
 
     # mount_storage will return in megabytes the amount of free space left on the storage mount
-    def mount_storage(address, path, type)
+    def mount_storage(address, path, type, unique_suffix)
       deployment_id = @deployment.id
       if type == "GFS"
         type = "glusterfs"
@@ -322,17 +324,17 @@ module Fusor
         type = "nfs"
       end
 
-      cmd = "sudo safe-mount.sh '#{deployment_id}' '#{address}' '#{path}' '#{type}'"
+      cmd = "sudo safe-mount.sh '#{deployment_id}' '#{unique_suffix}' '#{address}' '#{path}' '#{type}'"
       status, _output = Utils::Fusor::CommandUtils.run_command(cmd)
 
       raise 'Unable to mount NFS share at specified mount point' unless status == 0
 
-      files = Dir["/tmp/fusor-test-mount-#{deployment_id}/*"]
+      files = Dir["/tmp/fusor-test-mount-#{deployment_id}-#{unique_suffix}/*"]
 
-      stats = Sys::Filesystem.stat("/tmp/fusor-test-mount-#{deployment_id}")
+      stats = Sys::Filesystem.stat("/tmp/fusor-test-mount-#{deployment_id}-#{unique_suffix}")
       mb_available = stats.block_size * stats.blocks_available / 1024 / 1024
 
-      Utils::Fusor::CommandUtils.run_command("sudo safe-umount.sh #{deployment_id}")
+      Utils::Fusor::CommandUtils.run_command("sudo safe-umount.sh #{deployment_id} #{unique_suffix}")
       return {
         :mb_available => mb_available,
         :is_empty => files.size == 0

--- a/server/app/lib/fusor/validators/deployment_validator.rb
+++ b/server/app/lib/fusor/validators/deployment_validator.rb
@@ -268,6 +268,7 @@ module Fusor
         return error
       end
 
+      # rubocop:disable Metrics/ParameterLists
       def validate_storage_share(deployment, type, address, path, uid, unique_suffix)
         # validate that the NFS server exists
         # don't proceed if it doesn't
@@ -276,6 +277,7 @@ module Fusor
         # validate that the NFS share exists and is clean
         validate_storage_mount(deployment, type, address, path, uid, unique_suffix)
       end
+      # rubocop:enable Metrics/ParameterLists
 
       def validate_storage_server(deployment, address)
         cmd = "showmount #{address}"
@@ -291,6 +293,7 @@ module Fusor
         return true
       end
 
+      # rubocop:disable Metrics/ParameterLists
       def validate_storage_mount(deployment, storage_type, address, path, uid, unique_suffix)
         if storage_type == "NFS"
           type = "nfs"
@@ -322,6 +325,7 @@ module Fusor
                      )
         end
       end
+      # rubocop:enable Metrics/ParameterLists
 
       def validate_storage_credentials(deployment, uid, gid, unique_suffix)
         if File.stat("/tmp/fusor-test-mount-#{deployment.id}-#{unique_suffix}").uid != uid

--- a/server/app/lib/fusor/validators/deployment_validator.rb
+++ b/server/app/lib/fusor/validators/deployment_validator.rb
@@ -82,7 +82,7 @@ module Fusor
             elsif deployment.rhev_storage_address.empty?
               deployment.errors[:rhev_storage_address] << _('RHV storage specified but missing address to the share')
             else
-              validate_storage_share(deployment, deployment.rhev_storage_type, deployment.rhev_storage_address, deployment.rhev_share_path, 36)
+              validate_storage_share(deployment, deployment.rhev_storage_type, deployment.rhev_storage_address, deployment.rhev_share_path, 36, 'rhv')
             end
           end
         end
@@ -115,7 +115,7 @@ module Fusor
             elsif deployment.hosted_storage_address.empty?
               deployment.errors[:hosted_storage_address] << _('RHV self hosted deployments must specify hosted storage address')
             else
-              validate_storage_share(deployment, deployment.rhev_storage_type, deployment.hosted_storage_address, deployment.hosted_storage_path, 36)
+              validate_storage_share(deployment, deployment.rhev_storage_type, deployment.hosted_storage_address, deployment.hosted_storage_path, 36, 'selfhosted')
             end
           end
         end
@@ -163,7 +163,7 @@ module Fusor
               deployment.errors[:rhev_export_domain_path] << _(error)
             end
 
-            validate_storage_share(deployment, deployment.rhev_storage_type, deployment.rhev_export_domain_address, deployment.rhev_export_domain_path, 36)
+            validate_storage_share(deployment, deployment.rhev_storage_type, deployment.rhev_export_domain_address, deployment.rhev_export_domain_path, 36, 'export')
           end
         end
       end
@@ -230,7 +230,7 @@ module Fusor
           if error
             deployment.errors[:openshift_export_path] << _(error)
           else
-            validate_storage_share(deployment, deployment.openshift_storage_type, deployment.openshift_storage_host, deployment.openshift_export_path, -1)
+            validate_storage_share(deployment, deployment.openshift_storage_type, deployment.openshift_storage_host, deployment.openshift_export_path, -1, 'ocp')
           end
         end
       end
@@ -268,13 +268,13 @@ module Fusor
         return error
       end
 
-      def validate_storage_share(deployment, type, address, path, uid)
+      def validate_storage_share(deployment, type, address, path, uid, unique_suffix)
         # validate that the NFS server exists
         # don't proceed if it doesn't
         return unless validate_storage_server(deployment, address)
 
         # validate that the NFS share exists and is clean
-        validate_storage_mount(deployment, type, address, path, uid)
+        validate_storage_mount(deployment, type, address, path, uid, unique_suffix)
       end
 
       def validate_storage_server(deployment, address)
@@ -291,13 +291,13 @@ module Fusor
         return true
       end
 
-      def validate_storage_mount(deployment, storage_type, address, path, uid)
+      def validate_storage_mount(deployment, storage_type, address, path, uid, unique_suffix)
         if storage_type == "NFS"
           type = "nfs"
         else
           type = "glusterfs"
         end
-        cmd = "sudo safe-mount.sh '#{deployment.id}' '#{address}' '#{path}' '#{type}'"
+        cmd = "sudo safe-mount.sh '#{deployment.id}' '#{unique_suffix}' '#{address}' '#{path}' '#{type}'"
         status, output = Utils::Fusor::CommandUtils.run_command(cmd)
 
         if status != 0
@@ -310,11 +310,11 @@ module Fusor
         # Check if we want to verify NFS mount credentials as well
         # If specified UID is -1, do not check
         if uid != -1
-          validate_storage_credentials(deployment, uid, uid)
+          validate_storage_credentials(deployment, uid, uid, unique_suffix)
         end
 
-        files = Dir["/tmp/fusor-test-mount-#{deployment.id}/*"] # this may return [] if it can't read the share
-        Utils::Fusor::CommandUtils.run_command("sudo safe-umount.sh #{deployment.id}")
+        files = Dir["/tmp/fusor-test-mount-#{deployment.id}-#{unique_suffix}/*"] # this may return [] if it can't read the share
+        Utils::Fusor::CommandUtils.run_command("sudo safe-umount.sh #{deployment.id} #{unique_suffix}")
 
         if files.length > 0
           add_warning(deployment, _("NFS file share '%s' is not empty. This could cause deployment problems.") %
@@ -323,14 +323,14 @@ module Fusor
         end
       end
 
-      def validate_storage_credentials(deployment, uid, gid)
-        if File.stat("/tmp/fusor-test-mount-#{deployment.id}").uid != uid
+      def validate_storage_credentials(deployment, uid, gid, unique_suffix)
+        if File.stat("/tmp/fusor-test-mount-#{deployment.id}-#{unique_suffix}").uid != uid
           add_warning(deployment, _("NFS share has an invalid UID. The expected UID is '%s'. " \
                                     "Please check NFS share permissions.") % "#{uid}")
           return
         end
 
-        if File.stat("/tmp/fusor-test-mount-#{deployment.id}").gid != gid
+        if File.stat("/tmp/fusor-test-mount-#{deployment.id}-#{unique_suffix}").gid != gid
           add_warning(deployment, _("NFS share has an invalid GID. The expected GID is '%s'. " \
                                     "Please check NFS share permissions.") % "#{gid}")
           return


### PR DESCRIPTION
**Note**
This PR should be tested and merged in tandem with https://github.com/fusor/fusor-utils/pull/7 from fusor-utils. 

**Change Description**
The purpose of this change is to give each storage designation (RHV, RHV Self-Hosted, Export, OCP) a unique test mount-point so that mount validations can run in parallel without risk of collision.

I've implemented this by adding a unique suffix to each test mount point (rhv, selfhosted, export, ocp).

**Testing Instructions**

1. Pull this PR and the PR from fusor-utils into your dev env
2. Create a deployment with RHV, CFME, and OCP. 
3. Click back and forth on the "Storage" steps (RHV storage step, OCP storage step) and have the process run without failure, provided that your share info is valid.
4. Run the overall deployment validations by navigating to the "Review" step without errors