### PR TITLE
Always use noTSX when Haswell CPU detected.

### DIFF
--- a/server/app/lib/utils/fusor/cpu_compat_detector.rb
+++ b/server/app/lib/utils/fusor/cpu_compat_detector.rb
@@ -65,7 +65,7 @@ module Utils
         cpu_fams = [
           # Intel processor families
           { brand: 'intel', keywords: ['intel'], position: -1 }, #intel wildcard
-          { brand: 'intel', keywords: ['haswell'], position: 6 },
+          { brand: 'intel', keywords: ['haswell'], position: 5 }, # always select noTSX for haswell
           { brand: 'intel', keywords: ['haswell', 'no', 'tsx'], position: 5 },
           { brand: 'intel', keywords: ['sandy', 'bridge'], position: 4 },
           { brand: 'intel', keywords: ['westmere'], position: 3 },


### PR DESCRIPTION
Updating to the latest microcode_ctl doesn't seem to be 100% reliable. This update makes noTSX the default selected option for any detected Haswell CPU's.