### PR TITLE
Added units to OCP validations. Fix validation message color/symbol combinations.

### DIFF
--- a/fusor-ember-cli/app/templates/components/error-message.hbs
+++ b/fusor-ember-cli/app/templates/components/error-message.hbs
@@ -2,7 +2,7 @@
   <div class="row">
     <div class='col-md-9'>
       <div class='alert alert-danger rhci-alert'>
-          <i class="fa fa-2x fa-exclamation-triangle errorForValidation"></i>
+          <i class="fa fa-2x fa-times-circle-o errorForValidation"></i>
           &nbsp;
           {{errorMsg}}
 

--- a/fusor-ember-cli/app/templates/openshift/openshift-configuration.hbs
+++ b/fusor-ember-cli/app/templates/openshift/openshift-configuration.hbs
@@ -2,7 +2,7 @@
   <div class="row">
     <div class='col-md-9'>
       <div class='alert alert-danger rhci-alert'>
-        <i class="fa fa-2x fa-exclamation-triangle errorForValidation"></i>
+        <i class="fa fa-2x fa-times-circle-o errorForValidation"></i>
         &nbsp;
         {{errorMsg}}
       </div>

--- a/fusor-ember-cli/app/templates/openshift/openshift-nodes.hbs
+++ b/fusor-ember-cli/app/templates/openshift/openshift-nodes.hbs
@@ -14,8 +14,8 @@
 {{#if isError}}
   <div class="row">
     <div class='col-md-9'>
-      <div class='alert alert-warning rhci-alert'>
-        <i class="fa fa-2x fa-exclamation-triangle errorForValidation"></i>
+      <div class='alert alert-danger rhci-alert'>
+        <i class="fa fa-2x fa-times-circle-o errorForValidation"></i>
         &nbsp;
         {{errorTypes}} is overcommitted. Consider lowering node counts or {{errorTypes}} sizes.
       </div>
@@ -25,7 +25,7 @@
   {{#if isOverCapacityVcpu}}
     <div class="row">
       <div class='col-md-9'>
-        <div class='alert alert-warning rhci-alert'>
+        <div class='alert alert-danger rhci-alert'>
           <p>
             Current Configuration Requirements
             {{#if isCloudForms}}
@@ -35,7 +35,7 @@
           <p>Master vCPUs: {{totalMasterCpus}}</p>
           <p>Worker vCPUs: {{totalWorkerCpus}}</p>
           {{#if isHA}}
-            <p>HA Reserved vCPUs: {{totalInfraCpus}}</p>
+            <p>Required HA vCPUs: {{totalInfraCpus}}</p>
           {{/if}}
           <p><strong>Total vCPUs required: {{vcpuNeeded}}</strong></p>
           <p><strong>Total vCPUs available: {{vcpuAvailable}}</strong></p>
@@ -47,7 +47,7 @@
   {{#if isOverCapacityRam}}
     <div class="row">
       <div class='col-md-9'>
-        <div class='alert alert-warning rhci-alert'>
+        <div class='alert alert-danger rhci-alert'>
           <p>
             Current Configuration Requirements
             {{#if isCloudForms}}
@@ -57,7 +57,7 @@
           <p>Master RAM: {{totalMasterRam}} GB</p>
           <p>Worker RAM: {{totalWorkerRam}} GB</p>
           {{#if isHA}}
-            <p>HA Reserved RAM: {{totalInfraRam}}</p>
+            <p>Required HA RAM: {{totalInfraRam}} GB</p>
           {{/if}}
           <p><strong>Total RAM required: {{ramNeeded}} GB</strong></p>
           <p><strong>Total RAM available: {{ramAvailable}} GB</strong></p>
@@ -69,7 +69,7 @@
   {{#if isOverCapacityDisk}}
     <div class="row">
       <div class='col-md-9'>
-        <div class='alert alert-warning rhci-alert'>
+        <div class='alert alert-danger rhci-alert'>
           <p>
             Current Configuration Requirements
             {{#if isCloudForms}}
@@ -79,7 +79,7 @@
           <p>Master Disk: {{totalMasterDisk}} GB</p>
           <p>Worker Disk + Storage: {{totalWorkerDiskPlusStorage}} GB</p>
           {{#if isHA}}
-            <p>HA Reserved Disk: {{totalInfraDisk}}</p>
+            <p>Required HA Disk: {{totalInfraDisk}} GB</p>
           {{/if}}
           <p><strong>Total Disk required: {{diskNeeded}} GB</strong></p>
           <p><strong>Total Disk available: {{diskAvailable}} GB</strong></p>

--- a/fusor-ember-cli/app/templates/openstack/assign-nodes.hbs
+++ b/fusor-ember-cli/app/templates/openstack/assign-nodes.hbs
@@ -2,7 +2,7 @@
   <div class="row">
     <div class='col-md-9'>
       <div class='alert alert-danger rhci-alert'>
-        <i class="fa fa-2x fa-exclamation-triangle errorForValidation"></i>
+        <i class="fa fa-2x fa-times-circle-o errorForValidation"></i>
         &nbsp;
         {{errorMsg}}
       </div>

--- a/fusor-ember-cli/app/templates/openstack/register-nodes.hbs
+++ b/fusor-ember-cli/app/templates/openstack/register-nodes.hbs
@@ -8,7 +8,7 @@
     <div class="row register-nodes-errors">
       <div class="col-md-9 col-lg-6">
         <div class="alert alert-danger rhci-alert">
-          <i class="fa fa-2x fa-exclamation-triangle errorForValidation validation-alert-icon"></i>
+          <i class="fa fa-2x fa-times-circle-o errorForValidation validation-alert-icon"></i>
           <p class="validation-alert-message">{{loadErrorMsg}}</p>
         </div>
       </div>
@@ -19,7 +19,7 @@
     <div class="row register-nodes-errors">
       <div class="col-md-9 col-lg-6">
         <div class="alert alert-danger rhci-alert">
-          <i class="fa fa-2x fa-exclamation-triangle errorForValidation validation-alert-icon"></i>
+          <i class="fa fa-2x fa-times-circle-o errorForValidation validation-alert-icon"></i>
           <p class="validation-alert-message">{{errorMsg}}</p>
         </div>
       </div>
@@ -30,7 +30,7 @@
     <div class="row register-nodes-errors">
       <div class="col-md-9 col-lg-6">
         <div class="alert alert-danger rhci-alert">
-          <i class="fa fa-2x fa-exclamation-triangle errorForValidation validation-alert-icon"></i>
+          <i class="fa fa-2x fa-times-circle-o errorForValidation validation-alert-icon"></i>
           <p class="validation-alert-message">The following nodes have errors:</p>
           <ul class="validation-alert-message">
             {{#each nodeErrors as |nodeError|}}

--- a/fusor-ember-cli/app/templates/review/installation.hbs
+++ b/fusor-ember-cli/app/templates/review/installation.hbs
@@ -16,7 +16,7 @@
     <div class="row">
       <div class='col-md-9'>
         <div class='alert alert-danger rhci-alert'>
-          <i class="fa fa-2x fa-exclamation-triangle errorForValidation validation-alert-icon"></i>
+          <i class="fa fa-2x fa-times-circle-o errorForValidation validation-alert-icon"></i>
           <ul class="validation-alert-message">
             {{#each validationErrors as |errorMsg|}}
               <li>{{errorMsg}}</li>

--- a/fusor-ember-cli/app/templates/storage.hbs
+++ b/fusor-ember-cli/app/templates/storage.hbs
@@ -2,7 +2,7 @@
   <div class="row">
     <div class='col-md-9'>
       <div class='alert alert-danger rhci-alert'>
-        <i class="fa fa-2x fa-exclamation-triangle errorForValidation"></i>
+        <i class="fa fa-2x fa-times-circle-o errorForValidation"></i>
         &nbsp;
         {{errorMsg}}
       </div>
@@ -12,7 +12,7 @@
   <div class="row">
     <div class='col-md-9'>
       <div class='alert alert-danger rhci-alert'>
-        <i class="fa fa-2x fa-exclamation-triangle errorForValidation"></i>
+        <i class="fa fa-2x fa-times-circle-o errorForValidation"></i>
         &nbsp;
         {{storageNotEmptyError}}
       </div>

--- a/fusor-ember-cli/app/templates/subscriptions/credentials.hbs
+++ b/fusor-ember-cli/app/templates/subscriptions/credentials.hbs
@@ -2,7 +2,7 @@
   <div class="row">
     <div class='col-md-9'>
       <div class='alert alert-danger rhci-alert'>
-          <i class="fa fa-2x fa-exclamation-triangle errorForValidation"></i>
+          <i class="fa fa-2x fa-times-circle-o errorForValidation"></i>
           &nbsp;
           {{errorMsg}}
       </div>

--- a/fusor-ember-cli/app/templates/subscriptions/management-application.hbs
+++ b/fusor-ember-cli/app/templates/subscriptions/management-application.hbs
@@ -18,7 +18,7 @@
   <div class="row">
     <div class='col-md-9'>
       <div class='alert alert-danger rhci-alert'>
-          <i class="fa fa-2x fa-exclamation-triangle errorForValidation"></i>
+          <i class="fa fa-2x fa-times-circle-o errorForValidation"></i>
           &nbsp;
           {{errorMsg}}
       </div>
@@ -70,6 +70,3 @@
                    disableCancel=isStarted
                    deploymentName=deploymentName}}
 {{/if}}
-
-
-

--- a/fusor-ember-cli/app/templates/subscriptions/select-subscriptions.hbs
+++ b/fusor-ember-cli/app/templates/subscriptions/select-subscriptions.hbs
@@ -2,7 +2,7 @@
   <div class="row">
     <div class='col-md-9'>
       <div class='alert alert-danger rhci-alert'>
-          <i class="fa fa-2x fa-exclamation-triangle errorForValidation"></i>
+          <i class="fa fa-2x fa-times-circle-o errorForValidation"></i>
           &nbsp;
           {{errorMsg}}
       </div>


### PR DESCRIPTION
 - Added units to OCP HA node resource requirements
 - Reclassified OCP resource overcommitting to error since it will probably break deploy
 - Changed error messages to use the error symbol rather than a red warning symbol