### PR TITLE
1413926 - Pass deployment private key path to ansible-ovirt

### DIFF
--- a/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
@@ -108,6 +108,7 @@ module Actions
               :packages => ['http://download.eng.bos.redhat.com/brewroot/packages/rhel-guest-image/7.3/32.el7/noarch/rhel-guest-image-7-7.3-32.el7.noarch.rpm'],
               :repositories => SETTINGS[:fusor][:content][:openshift].map { |p| p[:repository_set_label] if p[:repository_set_label] =~ /rpms$/ }.compact,
               :username => deployment.openshift_username,
+              :private_key_path => ::Utils::Fusor::SSHKeyUtils.new(deployment).get_ssh_private_key_path,
               :root_password => deployment.openshift_user_password,
               :ssh_key => deployment.ssh_public_key,
               :vms => get_ocp_vms(deployment),


### PR DESCRIPTION
Modified ansible-ovirt vars to include path to the deployment's private key. 

Using this to manually check if SSH is completely up and running on OCP nodes before attempting to SSH into them, as it seems `wait_for port 22` isn't a guaranteed indicator. 

Merge with corresponding PR in https://github.com/fusor/ansible-ovirt/pull/26