### PR TITLE
Remove rhel-7-server-rh-common-rpms from hypervisor.

### DIFF
--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -91,14 +91,6 @@
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"
-        :repository_set_id: "2472"
-        :repository_set_name: "Red Hat Enterprise Linux 7 Server - RH Common (RPMs)"
-        :repository_set_label: "rhel-7-server-rh-common-rpms"
-        :basearch: "x86_64"
-        :releasever: "7Server"
-
-      - :product_name: "Red Hat Enterprise Linux Server"
-        :product_id: "69"
         :repository_set_id: "4831"
         :repository_set_name: "Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)"
         :repository_set_label: "rhel-7-server-satellite-tools-6.2-rpms"
@@ -144,14 +136,6 @@
         :repository_set_label: "rhel-7-server-kickstart"
         :basearch: "x86_64"
         :releasever: "7.3"
-
-      - :product_name: "Red Hat Enterprise Linux Server"
-        :product_id: "69"
-        :repository_set_id: "2472"
-        :repository_set_name: "Red Hat Enterprise Linux 7 Server - RH Common (RPMs)"
-        :repository_set_label: "rhel-7-server-rh-common-rpms"
-        :basearch: "x86_64"
-        :releasever: "7Server"
 
       - :product_name: "Red Hat Enterprise Linux Server"
         :product_id: "69"


### PR DESCRIPTION
Determined rhel-guest-image-7 is only needed on RHV engine.