### PR TITLE
SCP rhel guest image to engine, include image path in fusor.yaml

### DIFF
--- a/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/ose_launch.rb
@@ -358,7 +358,7 @@ module Actions
             hostname = deployment.rhev_engine_host.name
             password = deployment.rhev_root_password
 
-            ::Fusor.log.info "Transfering RHEL guest image from #{image_file} to #{hostname}:#{image_destination_path}."
+            ::Fusor.log.info "Transferring RHEL guest image from #{image_file} to #{hostname}:#{image_destination_path}."
             Net::SCP.start(hostname, "root", :password => password, :paranoid => false) do |scp|
               scp.upload!(image_file, image_destination_path)
             end

--- a/server/config/fusor.yaml
+++ b/server/config/fusor.yaml
@@ -471,4 +471,5 @@
         - "foreman-tasks/dynflow"
         - "foreman-tasks/action"
 
+  :rhel_guest_image: "/usr/share/rhel-guest-image-7/rhel-guest-image-7.3-32.x86_64.qcow2"
   :puppet_module:


### PR DESCRIPTION
- Added guest image path to fusor.yaml
- Remove packages from ansible vars
- Add image path to ansible vars
- SCP RHEL guest image to engine

Related: https://github.com/fusor/ansible-ovirt/pull/35