### PR TITLE
Keep track of OCP master_lb in database, DRY up OCP deployment parsing

### DIFF
--- a/server/app/lib/actions/fusor/deployment/cloud_forms/add_ose_provider.rb
+++ b/server/app/lib/actions/fusor/deployment/cloud_forms/add_ose_provider.rb
@@ -32,9 +32,9 @@ module Actions
 
             token = File.read("#{Rails.root}/tmp/#{deployment.label}/ocp_master.token")
 
-            if deployment.ose_master_hosts.length > 1
+            if deployment.ose_lb_master_hosts.length > 0
               # point at master load balancer for OCP HA
-              master = deployment.ose_ha_hosts.first
+              master = deployment.ose_lb_master_hosts.first
             else
               # point directly at master for regular OCP
               master = deployment.ose_master_hosts.first

--- a/server/app/lib/actions/fusor/deployment/open_shift/install_ose.rb
+++ b/server/app/lib/actions/fusor/deployment/open_shift/install_ose.rb
@@ -27,12 +27,7 @@ module Actions
           def run
             ::Fusor.log.info "================ OpenShift InstallOSE run method ===================="
             deployment = ::Fusor::Deployment.find(input[:deployment_id])
-            opts = parse_deployment(deployment)
-
-            if opts[:ha_nodes].length > 1
-              deployment.ose_lb_master_hosts = [deployment.ose_ha_hosts.find_by_name(opts[:ha_lb_master])]
-              deployment.save!
-            end
+            opts = Utils::Fusor::OcpUtils.parse_deployment(deployment)
 
             launcher = OSEInstaller::Launch.new("#{Rails.root}/tmp/#{deployment.label}", ::Fusor.log_file_dir(deployment.label, deployment.id), ::Fusor.log)
             inventory = launcher.prepare(opts)
@@ -61,55 +56,6 @@ module Actions
             end
 
             ::Fusor.log.info "================ Leaving OpenShift InstallOSE run method ===================="
-          end
-
-          def parse_deployment(deployment)
-            opts = Hash.new
-
-            masters = Array.new
-            deployment.ose_master_hosts.each do |m|
-              masters << m.name
-            end
-
-            workers = Array.new
-            deployment.ose_worker_hosts.each do |w|
-              workers << w.name
-            end
-
-            ha_nodes = Array.new
-            deployment.ose_ha_hosts.each do |ha|
-              ha_nodes << ha.name
-            end
-
-            opts[:masters] = masters
-            opts[:nodes] = workers
-            opts[:ha_nodes] = ha_nodes
-
-            if opts[:ha_nodes].length > 1
-              opts[:ha_lb_master] = ha_nodes.first
-              opts[:ha_lb_infra] = ha_nodes.last
-            end
-
-            opts[:username] = deployment.openshift_username
-            opts[:ssh_key] = ::Utils::Fusor::SSHKeyUtils.new(deployment).get_ssh_private_key_path
-
-            opts[:docker_registry_host] = deployment.openshift_storage_host
-            opts[:docker_registry_path] = deployment.openshift_export_path
-
-            opts[:docker_storage] = "/dev/vdb"
-            opts[:docker_volume] = "docker-vg"
-            opts[:storage_type] = deployment.openshift_storage_type
-
-            opts[:ose_user] = deployment.openshift_username
-            opts[:ose_password] = deployment.openshift_user_password
-
-            opts[:subdomain_name] = deployment.openshift_subdomain_name + '.' + Domain.find(Hostgroup.find_by_name('Fusor Base').domain_id).name
-            opts[:helloworld_sample_app] = deployment.openshift_sample_helloworld
-
-            opts[:org_label] = Organization.find(deployment.organization_id).label.downcase
-            opts[:satellite_hostname] = `/usr/bin/hostname`.chomp
-
-            opts
           end
         end
       end

--- a/server/app/lib/actions/fusor/deployment/open_shift/post_install_ose.rb
+++ b/server/app/lib/actions/fusor/deployment/open_shift/post_install_ose.rb
@@ -27,7 +27,7 @@ module Actions
           def run
             ::Fusor.log.info "================ OpenShift PostInstallOSE run method ===================="
             deployment = ::Fusor::Deployment.find(input[:deployment_id])
-            opts = parse_deployment(deployment)
+            opts = Utils::Fusor::OcpUtils.parse_deployment(deployment)
             launcher = OSEInstaller::Launch.new("#{Rails.root}/tmp/#{deployment.label}", ::Fusor.log_file_dir(deployment.label, deployment.id), ::Fusor.log)
             inventory = launcher.prepare(opts)
             if deployment.ose_master_hosts.length > 1
@@ -45,49 +45,6 @@ module Actions
             ::Fusor.log.info "================ Finished OpenShift Deployment ===================="
           end
 
-          def parse_deployment(deployment)
-            opts = Hash.new
-
-            masters = Array.new
-            deployment.ose_master_hosts.each do |m|
-              masters << m.name
-            end
-
-            workers = Array.new
-            deployment.ose_worker_hosts.each do |w|
-              workers << w.name
-            end
-
-            ha_nodes = Array.new
-            deployment.ose_ha_hosts.each do |ha|
-              ha_nodes << ha.name
-            end
-
-            opts[:masters] = masters
-            opts[:nodes] = workers
-            opts[:ha_nodes] = ha_nodes
-
-            opts[:username] = deployment.openshift_username
-            opts[:ssh_key] = ::Utils::Fusor::SSHKeyUtils.new(deployment).get_ssh_private_key_path
-
-            opts[:docker_registry_host] = deployment.openshift_storage_host
-            opts[:docker_registry_path] = deployment.openshift_export_path
-
-            opts[:docker_storage] = "/dev/vdb"
-            opts[:docker_volume] = "docker-vg"
-            opts[:storage_type] = deployment.openshift_storage_type
-
-            opts[:ose_user] = deployment.openshift_username
-            opts[:ose_password] = deployment.openshift_user_password
-
-            opts[:subdomain_name] = deployment.openshift_subdomain_name + '.' + Domain.find(Hostgroup.find_by_name('Fusor Base').domain_id).name
-            opts[:helloworld_sample_app] = deployment.openshift_sample_helloworld
-
-            opts[:org_label] = Organization.find(deployment.organization_id).label.downcase
-            opts[:satellite_hostname] = `/usr/bin/hostname`.chomp
-
-            opts
-          end
         end
       end
     end

--- a/server/app/lib/utils/fusor/ocp_utils.rb
+++ b/server/app/lib/utils/fusor/ocp_utils.rb
@@ -1,0 +1,60 @@
+##
+# OcpUtils
+# =================
+# Shared utility functions for OpenShift deployments
+
+module Utils
+  module Fusor
+    class OcpUtils
+      # Utils::Fusor::OcpUtils.parse_deployment(deployment)
+      def self.parse_deployment(deployment)
+        opts = Hash.new
+
+        masters = Array.new
+        deployment.ose_master_hosts.each do |m|
+          masters << m.name
+        end
+
+        workers = Array.new
+        deployment.ose_worker_hosts.each do |w|
+          workers << w.name
+        end
+
+        ha_nodes = Array.new
+        deployment.ose_ha_hosts.each do |ha|
+          ha_nodes << ha.name
+        end
+
+        opts[:masters] = masters
+        opts[:nodes] = workers
+        opts[:ha_nodes] = ha_nodes
+
+        if opts[:ha_nodes].length > 1
+          opts[:ha_lb_master] = ha_nodes.first
+          opts[:ha_lb_infra] = ha_nodes.last
+        end
+
+        opts[:username] = deployment.openshift_username
+        opts[:ssh_key] = ::Utils::Fusor::SSHKeyUtils.new(deployment).get_ssh_private_key_path
+
+        opts[:docker_registry_host] = deployment.openshift_storage_host
+        opts[:docker_registry_path] = deployment.openshift_export_path
+
+        opts[:docker_storage] = "/dev/vdb"
+        opts[:docker_volume] = "docker-vg"
+        opts[:storage_type] = deployment.openshift_storage_type
+
+        opts[:ose_user] = deployment.openshift_username
+        opts[:ose_password] = deployment.openshift_user_password
+
+        opts[:subdomain_name] = deployment.openshift_subdomain_name + '.' + Domain.find(Hostgroup.find_by_name('Fusor Base').domain_id).name
+        opts[:helloworld_sample_app] = deployment.openshift_sample_helloworld
+
+        opts[:org_label] = Organization.find(deployment.organization_id).label.downcase
+        opts[:satellite_hostname] = `/usr/bin/hostname`.chomp
+
+        opts
+      end
+    end
+  end
+end

--- a/server/app/models/fusor/deployment.rb
+++ b/server/app/models/fusor/deployment.rb
@@ -49,6 +49,9 @@ module Fusor
     has_many :ose_worker_hosts, :through => :ose_deployment_worker_hosts, :class_name => "::Host::Base", :source => :discovered_host
     has_many :ose_deployment_ha_hosts, -> { where(:deployment_host_type => 'ose_ha') }, :class_name => "Fusor::DeploymentHost"
     has_many :ose_ha_hosts, :through => :ose_deployment_ha_hosts, :class_name => "::Host::Base", :source => :discovered_host
+    has_many :ose_deployment_lb_master_hosts, -> { where(:deployment_host_type => 'ose_lb_master') }, :class_name => "Fusor::DeploymentHost"
+    has_many :ose_lb_master_hosts, :through => :ose_deployment_lb_master_hosts, :class_name => "::Host::Base", :source => :discovered_host
+
     alias_attribute :discovered_host_id, :rhev_engine_host_id
     attr_accessor :foreman_task_id
 

--- a/server/lib/modules/ose_installer/launch.rb
+++ b/server/lib/modules/ose_installer/launch.rb
@@ -96,8 +96,8 @@ module OSEInstaller
       if !opts[:ha_nodes].nil? and opts[:ha_nodes].length > 1
         # split it by two groups
         if opts[:ha_nodes].length == 2
-          ha_master_list = "#{opts[:ha_nodes].first}\n"
-          ha_infra_list = "#{opts[:ha_nodes].last}\n"
+          ha_master_list = "#{opts[:ha_lb_master]}\n"
+          ha_infra_list = "#{opts[:ha_lb_infra]}\n"
         else
           ha_list = opts[:ha_nodes].each_slice(2).to_a
           ha_list.first.each do |master_ha_node|


### PR DESCRIPTION
 - Track master load-balancer host ID on Deployment object for use as a CFME provider
 - Move duplicated OCP `parse_deployment` methods into a util class