### PR TITLE
1425224 - Filter passwords embedded in commands.

### DIFF
--- a/server/app/lib/actions/fusor/deployment/cloud_forms/run_appliance_console.rb
+++ b/server/app/lib/actions/fusor/deployment/cloud_forms/run_appliance_console.rb
@@ -10,6 +10,8 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
+require 'fusor/password_filter'
+
 module Actions
   module Fusor
     module Deployment
@@ -91,7 +93,7 @@ module Actions
             retries = 0
             status = 1
 
-            ::Fusor.log.info "Running: #{cmd}"
+            ::Fusor.log.info "Running: #{PasswordFilter.filter_passwords(cmd.clone)}"
             while (status != 0) && (retries < max_try)
               status, output = Utils::Fusor::CommandUtils.run_command(cmd)
               retries += 1

--- a/server/app/lib/actions/fusor/deployment/rhev/import_template.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/import_template.rb
@@ -10,6 +10,8 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
+require 'fusor/password_filter'
+
 module Actions
   module Fusor
     module Deployment
@@ -59,7 +61,7 @@ module Actions
           private
 
           def run_command(cmd)
-            ::Fusor.log.info "Running: #{cmd}"
+            ::Fusor.log.info "Running: #{PasswordFilter.filter_passwords(cmd.clone)}"
             status, output = Utils::Fusor::CommandUtils.run_command(cmd)
             ::Fusor.log.debug "Status: #{status}, output: #{output}"
             return status, output

--- a/server/app/lib/actions/fusor/deployment/rhev/trigger_ansible_run.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/trigger_ansible_run.rb
@@ -1,3 +1,5 @@
+require 'fusor/password_filter'
+
 module Actions
   module Fusor
     module Deployment
@@ -172,7 +174,7 @@ module Actions
             status = 1
 
             cmd = "ansible-playbook #{playbook} -i #{config_dir}/inventory -e '#{vars.to_json}' #{extra_args}"
-            ::Fusor.log.info "Running: #{cmd}"
+            ::Fusor.log.info "Running: #{PasswordFilter.filter_passwords(cmd.clone)}"
             while (status != 0) && (retries < max_try)
               status, output = ::Utils::Fusor::CommandUtils.run_command(cmd, true, environment)
               retries += 1

--- a/server/app/lib/actions/fusor/deployment/rhev/upload_image.rb
+++ b/server/app/lib/actions/fusor/deployment/rhev/upload_image.rb
@@ -10,6 +10,8 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
+require 'fusor/password_filter'
+
 module Actions
   module Fusor
     module Deployment
@@ -61,7 +63,7 @@ module Actions
             client = Utils::Fusor::SSHConnection.new(ssh_host, ssh_username, deployment.rhev_root_password)
             client.on_complete(lambda { upload_image_completed })
             client.on_failure(lambda { upload_image_failed })
-            ::Fusor.log.debug "Running command: #{cmd}"
+            ::Fusor.log.debug "Running command: #{PasswordFilter.filter_passwords(cmd.clone)}"
             client.execute(cmd)
 
             output[:template_name] = imported_template_name


### PR DESCRIPTION
Passwords in production.log are normally filtered when logged as named parameters containing keywords (e.g. password), but since we are logging entire commands to be run (including passwords needed to run the commands) it is necessary to manually filter the command strings before logging.

Currently, `production.log` is written to by the default "Rails Logger" which doesn't run `PasswordFilter`, whereas `deployment.log` is written by a `DeploymentLogger`, which has knowledge of the current deploy and all of the sensitive data which needs to be scrubbed from log messages. 

Unfortunately, because we start logging to production.log before we know which deployment object we will be working with, it's currently not possible to automatically filter passwords embedded in commands from production.log.

Future enhancement to the `DeploymentLogger` class could allow for "lazy passwords scanning": instantiation of a `DeploymentLogger` without immediately providing a `Deployment` object to scan for passwords. This would allow for all-round use the the `DeploymentLogger` and prevent the need for manually scrubbing commands.